### PR TITLE
Add GitHub Actions workflow with coverage

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -1,0 +1,124 @@
+name: Test .NET Libraries
+
+on:
+    push:
+        branches:
+            - master
+        paths-ignore:
+            - '*.md'
+            - 'Docs/**'
+            - 'Examples/**'
+            - '.gitignore'
+    pull_request:
+        branches:
+            - master
+
+env:
+    DOTNET_VERSION: |
+        8.x
+        9.0.x
+    BUILD_CONFIGURATION: 'Release'
+
+jobs:
+    test-windows:
+        name: 'Windows'
+        runs-on: windows-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore HtmlForgeX.sln
+
+            - name: Build solution
+              run: dotnet build HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-windows
+                  path: '**/*.trx'
+
+            - name: Upload coverage reports
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: coverage-reports-windows
+                  path: '**/coverage.cobertura.xml'
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  files: '**/coverage.cobertura.xml'
+
+    test-ubuntu:
+        name: 'Ubuntu'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore HtmlForgeX.sln
+
+            - name: Build solution
+              run: dotnet build HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-ubuntu
+                  path: '**/*.trx'
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  files: '**/coverage.cobertura.xml'
+
+    test-macos:
+        name: 'macOS'
+        runs-on: macos-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Restore dependencies
+              run: dotnet restore HtmlForgeX.sln
+
+            - name: Build solution
+              run: dotnet build HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
+
+            - name: Run tests
+              run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Upload test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-results-macos
+                  path: '**/*.trx'
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  files: '**/coverage.cobertura.xml'

--- a/README.MD
+++ b/README.MD
@@ -3,6 +3,8 @@
 [![nuget downloads](https://img.shields.io/nuget/dt/HtmlForgeX?label=nuget%20downloads)](https://www.nuget.org/packages/HtmlForgeX)
 [![nuget version](https://img.shields.io/nuget/v/HtmlForgeX)](https://www.nuget.org/packages/HtmlForgeX)
 [![license](https://img.shields.io/github/license/EvotecIT/HtmlForgeX.svg)](#)
+[![Test .NET Libraries](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml/badge.svg?branch=master)](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml)
+[![codecov](https://codecov.io/gh/EvotecIT/HtmlForgeX/branch/master/graph/badge.svg)](https://codecov.io/gh/EvotecIT/HtmlForgeX)
 [![wakatime](https://wakatime.com/badge/user/f1abc372-39bb-4b06-ad2b-3a24cf161f13/project/018e489c-bcef-4e14-a689-5180aa570f74.svg)](https://wakatime.com/badge/user/f1abc372-39bb-4b06-ad2b-3a24cf161f13/project/018e489c-bcef-4e14-a689-5180aa570f74)
 
 If you would like to contact me you can do so via Twitter or LinkedIn.

--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,6 @@
 [![license](https://img.shields.io/github/license/EvotecIT/HtmlForgeX.svg)](#)
 [![Test .NET Libraries](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml/badge.svg?branch=master)](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml)
 [![codecov](https://codecov.io/gh/EvotecIT/HtmlForgeX/branch/master/graph/badge.svg)](https://codecov.io/gh/EvotecIT/HtmlForgeX)
-[![wakatime](https://wakatime.com/badge/user/f1abc372-39bb-4b06-ad2b-3a24cf161f13/project/018e489c-bcef-4e14-a689-5180aa570f74.svg)](https://wakatime.com/badge/user/f1abc372-39bb-4b06-ad2b-3a24cf161f13/project/018e489c-bcef-4e14-a689-5180aa570f74)
 
 If you would like to contact me you can do so via Twitter or LinkedIn.
 

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -2,33 +2,9 @@
 # Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
-trigger:
-  batch: true
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
+trigger: none
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - '*'
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
+pr: none
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -2,33 +2,9 @@
 # Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
-trigger:
-  batch: true
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
+trigger: none
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - '*'
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
+pr: none
 
 pool:
   vmImage: 'macos-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,33 +2,10 @@
 # Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
-trigger:
-  batch: true
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - '*'
-  paths:
-    exclude:
-      - docs
-      - .github
-      - .vs
-      - Assets
-      - README.md
-      - CHANGELOG.MD
+trigger: none
+
+pr: none
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to test .NET libraries on Windows, Ubuntu and macOS
- upload coverage data to Codecov
- disable all Azure Pipelines by setting `trigger: none`
- add build and coverage badges to the README

## Testing
- `dotnet build HtmlForgeX.sln` *(fails: Project HtmlForgeX is not compatible with net6.0)*

------
https://chatgpt.com/codex/tasks/task_e_685652c15a9c832ea784e90d62963b58