### PR TITLE
Fix margin/padding enum parsing

### DIFF
--- a/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
@@ -53,12 +53,37 @@ public enum TablerMargin {
 }
 
 public static class TablerMarginExtensions {
+    private static readonly Dictionary<string, string> _sideMap = new() {
+        { "Top", "t" },
+        { "Bottom", "b" },
+        { "Start", "s" },
+        { "End", "e" },
+        { "Horizontal", "x" },
+        { "Vertical", "y" },
+        { "All", string.Empty }
+    };
+
+    private static readonly Dictionary<string, string> _sizeMap = new() {
+        { "Auto", "auto" },
+        { "Zero", "0" },
+        { "Quarter", "1" },
+        { "Half", "2" },
+        { "Normal", "3" },
+        { "OneAndHalf", "4" },
+        { "Triple", "5" }
+    };
+
     public static string EnumToString(this TablerMargin margin) {
         var marginStr = margin.ToString();
-        var property = "m";
-        var side = marginStr.Substring(0, marginStr.IndexOfAny("0123456789".ToCharArray()));
-        var size = marginStr.Substring(side.Length);
+        foreach (var side in _sideMap.Keys) {
+            if (!marginStr.StartsWith(side, StringComparison.Ordinal)) {
+                continue;
+            }
 
-        return $"{property}{side}-{size}";
+            var size = marginStr[side.Length..];
+            return $"m{_sideMap[side]}-{_sizeMap[size]}";
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(margin), margin, null);
     }
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
@@ -80,7 +80,7 @@ public static class TablerMarginExtensions {
                 continue;
             }
 
-            var size = marginStr[side.Length..];
+            var size = marginStr.Substring(side.Length);
             return $"m{_sideMap[side]}-{_sizeMap[size]}";
         }
 

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
@@ -82,7 +82,7 @@ public static class TablerPaddingExtensions {
                 continue;
             }
 
-            var size = paddingStr[side.Length..];
+            var size = paddingStr.Substring(side.Length);
             return $"p{_sideMap[side]}-{_sizeMap[size]}";
         }
 

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
@@ -55,12 +55,37 @@ public enum TablerPadding {
 
 
 public static class TablerPaddingExtensions {
+    private static readonly Dictionary<string, string> _sideMap = new() {
+        { "Top", "t" },
+        { "Bottom", "b" },
+        { "Start", "s" },
+        { "End", "e" },
+        { "Horizontal", "x" },
+        { "Vertical", "y" },
+        { "All", string.Empty }
+    };
+
+    private static readonly Dictionary<string, string> _sizeMap = new() {
+        { "Auto", "auto" },
+        { "Zero", "0" },
+        { "Quarter", "1" },
+        { "Half", "2" },
+        { "Normal", "3" },
+        { "OneAndHalf", "4" },
+        { "Triple", "5" }
+    };
+
     public static string EnumToString(this TablerPadding padding) {
         var paddingStr = padding.ToString();
-        var property = "p";
-        var side = paddingStr.Substring(0, paddingStr.IndexOfAny("0123456789".ToCharArray()));
-        var size = paddingStr.Substring(side.Length);
+        foreach (var side in _sideMap.Keys) {
+            if (!paddingStr.StartsWith(side, StringComparison.Ordinal)) {
+                continue;
+            }
 
-        return $"{property}{side}-{size}";
+            var size = paddingStr[side.Length..];
+            return $"p{_sideMap[side]}-{_sizeMap[size]}";
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(padding), padding, null);
     }
 }


### PR DESCRIPTION
## Summary
- fix enum parsing for margins
- apply the same parsing logic for paddings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6856b1b27a04832eb30803b7ac8209b5