### PR TITLE
Fix progress logging percentCompleted argument

### DIFF
--- a/HtmlForgeX/Logging/InternalLogger.cs
+++ b/HtmlForgeX/Logging/InternalLogger.cs
@@ -84,7 +84,7 @@ public class InternalLogger {
     /// <param name="totalSteps">The total steps of the operation (optional).</param>
     public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
         lock (_lock) {
-            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, totalSteps));
+            OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
             if (IsProgress) {
                 if (currentSteps.HasValue && totalSteps.HasValue) {
                     Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);


### PR DESCRIPTION
## Summary
- fix `WriteProgress` invocation to pass the correct percent completed

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6856ad91fab8832e8625ef65dd5eae9f