### PR TITLE
Implement OS-aware open logic

### DIFF
--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace HtmlForgeX;
@@ -12,11 +13,18 @@ internal static class Helpers {
     /// <param name="filePath"></param>
     /// <param name="open"></param>
     public static void Open(string filePath, bool open) {
-        if (open) {
-            ProcessStartInfo startInfo = new ProcessStartInfo(filePath) {
-                UseShellExecute = true
-            };
-            Process.Start(startInfo);
+        if (!open) {
+            return;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{filePath}\"") {
+                CreateNoWindow = true
+            });
+        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            Process.Start("open", filePath);
+        } else {
+            Process.Start("xdg-open", filePath);
         }
     }
 


### PR DESCRIPTION
## Summary
- open file in default browser using OS-specific commands

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6856ad6f5880832eabb0fb6dc5f6f73c