### PR TITLE
Fix directory creation before writing files

### DIFF
--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -52,7 +52,10 @@ public class Document : Element {
             Console.WriteLine($"There were {countErrors} found during generation of HTML.");
         }
 
-        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
+        var directory = System.IO.Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            System.IO.Directory.CreateDirectory(directory);
+        }
         File.WriteAllText(path, this.ToString());
         Helpers.Open(path, openInBrowser);
     }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -315,6 +315,10 @@ public class Head {
                 var jsContent = ReadEmbeddedResource("HtmlForgeX.Resources.Scripts." + js);
                 // we need to save the js file to disk
                 var jsFileName = Path.Combine(GlobalStorage.Path, Path.GetFileName(js));
+                var jsDirectory = Path.GetDirectoryName(jsFileName);
+                if (!string.IsNullOrEmpty(jsDirectory)) {
+                    Directory.CreateDirectory(jsDirectory);
+                }
                 File.WriteAllText(jsFileName, jsContent);
             }
         }


### PR DESCRIPTION
## Summary
- ensure the target directory exists before saving document
- create output directories when exporting library scripts

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6857f799dcc0832eb42ff6f3e826d200