### PR TITLE
Add thread-safe access to logger

### DIFF
--- a/HtmlForgeX/Logging/Settings.cs
+++ b/HtmlForgeX/Logging/Settings.cs
@@ -11,47 +11,88 @@ public class Settings {
     protected static InternalLogger _logger = new InternalLogger();
 
     /// <summary>
+    /// Lock object used to synchronize access to <see cref="_logger" />.
+    /// </summary>
+    private static readonly object LoggerLock = new();
+
+    /// <summary>
     /// Gets or sets a value indicating whether error logging is enabled.
     /// </summary>
     public bool Error {
-        get => _logger.IsError;
-        set => _logger.IsError = value;
+        get {
+            lock (LoggerLock) {
+                return _logger.IsError;
+            }
+        }
+        set {
+            lock (LoggerLock) {
+                _logger.IsError = value;
+            }
+        }
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether verbose logging is enabled.
     /// </summary>
     public bool Verbose {
-        get => _logger.IsVerbose;
-        set => _logger.IsVerbose = value;
+        get {
+            lock (LoggerLock) {
+                return _logger.IsVerbose;
+            }
+        }
+        set {
+            lock (LoggerLock) {
+                _logger.IsVerbose = value;
+            }
+        }
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether warning logging is enabled.
     /// </summary>
     public bool Warning {
-        get => _logger.IsWarning;
-        set => _logger.IsWarning = value;
+        get {
+            lock (LoggerLock) {
+                return _logger.IsWarning;
+            }
+        }
+        set {
+            lock (LoggerLock) {
+                _logger.IsWarning = value;
+            }
+        }
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether progress logging is enabled.
     /// </summary>
     public bool Progress {
-        get => _logger.IsProgress;
-        set => _logger.IsProgress = value;
+        get {
+            lock (LoggerLock) {
+                return _logger.IsProgress;
+            }
+        }
+        set {
+            lock (LoggerLock) {
+                _logger.IsProgress = value;
+            }
+        }
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether debug logging is enabled.
     /// </summary>
     public bool Debug {
-        get => _logger.IsDebug;
-        set => _logger.IsDebug = value;
+        get {
+            lock (LoggerLock) {
+                return _logger.IsDebug;
+            }
+        }
+        set {
+            lock (LoggerLock) {
+                _logger.IsDebug = value;
+            }
+        }
     }
 
-    /// <summary>
-    /// The lock object
-    /// </summary>
-    protected readonly object _LockObject = new object();
 }


### PR DESCRIPTION
## Summary
- add a static lock object for `Settings._logger`
- guard all `_logger` property accesses with `lock`

## Testing
- `dotnet test HtmlForgeX.sln`

------
https://chatgpt.com/codex/tasks/task_e_6857f7885d8c832eb89a4d803b7ca790