### PR TITLE
Add extra unit tests for utilities

### DIFF
--- a/HtmlForgeX.Tests/TestHtmlAdditional.cs
+++ b/HtmlForgeX.Tests/TestHtmlAdditional.cs
@@ -1,0 +1,35 @@
+using HtmlForgeX.Tags;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestHtmlAdditional {
+    [TestMethod]
+    public void BuildTableStylesReturnsExpectedClasses() {
+        var styles = new[] { BootStrapTableStyle.Responsive, BootStrapTableStyle.Striped, BootStrapTableStyle.Hover };
+        var result = styles.BuildTableStyles();
+        Assert.AreEqual("table table-responsive table-striped table-hover", result);
+    }
+
+    [TestMethod]
+    public void BuildTableStylesWithoutExtrasReturnsTable() {
+        var styles = Array.Empty<BootStrapTableStyle>();
+        var result = styles.BuildTableStyles();
+        Assert.AreEqual("table", result);
+    }
+
+    [TestMethod]
+    public void HtmlTagClassAndStyleChainingProducesCorrectOutput() {
+        var tag = new HtmlTag("p").Style("color", "red").Style("font-size", "12px")
+            .Class(null).Class(string.Empty).Class("first").Class("second");
+        Assert.AreEqual("<p style=\"color: red; font-size: 12px;\" class=\"first second\"></p>", tag.ToString());
+    }
+
+    [TestMethod]
+    public void MapLibraryEnumToLibraryObjectWorksAndThrows() {
+        var bootstrap = LibrariesConverter.MapLibraryEnumToLibraryObject(Libraries.Bootstrap);
+        Assert.IsInstanceOfType(bootstrap, typeof(HtmlForgeX.Resources.Bootstrap));
+
+        Assert.ThrowsException<ArgumentException>(() => LibrariesConverter.MapLibraryEnumToLibraryObject(Libraries.None));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for bootstrap table style building
- cover HtmlTag `Class` and `Style` methods
- verify library enum conversion

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685836b15374832e8cbfa74de1df0460