### PR TITLE
Add validation checks for Anchor

### DIFF
--- a/HtmlForgeX.Tests/TestAnchorValidation.cs
+++ b/HtmlForgeX.Tests/TestAnchorValidation.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HtmlForgeX.Tags;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestAnchorValidation {
+    [TestMethod]
+    public void AnchorThrowsOnInvalidHref() {
+        Assert.ThrowsException<ArgumentException>(() => new Anchor(""));
+    }
+
+    [TestMethod]
+    public void AnchorThrowsOnInvalidHrefMethod() {
+        var anchor = new Anchor("https://example.com");
+        Assert.ThrowsException<ArgumentException>(() => anchor.HrefLink(" "));
+    }
+
+    [TestMethod]
+    public void AnchorThrowsOnInvalidTarget() {
+        var anchor = new Anchor("https://example.com");
+        Assert.ThrowsException<ArgumentException>(() => anchor.Target(""));
+    }
+}

--- a/HtmlForgeX/Tags/Anchor.cs
+++ b/HtmlForgeX/Tags/Anchor.cs
@@ -15,6 +15,13 @@ public class Anchor : HtmlTag {
     /// <param name="hrefLink">URL for the <c>href</c> attribute.</param>
     /// <param name="text">Optional inner text.</param>
     public Anchor(string hrefLink, string text = "") : base("a") {
+        if (string.IsNullOrWhiteSpace(hrefLink)) {
+            throw new ArgumentException("hrefLink cannot be null or empty");
+        }
+        if (!Uri.IsWellFormedUriString(hrefLink, UriKind.RelativeOrAbsolute)) {
+            throw new ArgumentException($"Invalid href value: {hrefLink}");
+        }
+
         Attributes["href"] = hrefLink;
         Value(text);
     }
@@ -25,6 +32,9 @@ public class Anchor : HtmlTag {
     /// <param name="target">Target value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Target(string target) {
+        if (string.IsNullOrWhiteSpace(target)) {
+            throw new ArgumentException("target cannot be null or empty");
+        }
         Attributes["target"] = target;
         return this;
     }
@@ -35,6 +45,9 @@ public class Anchor : HtmlTag {
     /// <param name="name">Name value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Name(string name) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            throw new ArgumentException("name cannot be null or empty");
+        }
         Attributes["name"] = name;
         return this;
     }
@@ -45,6 +58,9 @@ public class Anchor : HtmlTag {
     /// <param name="rel">Relationship value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Rel(string rel) {
+        if (string.IsNullOrWhiteSpace(rel)) {
+            throw new ArgumentException("rel cannot be null or empty");
+        }
         Attributes["rel"] = rel;
         return this;
     }
@@ -55,6 +71,9 @@ public class Anchor : HtmlTag {
     /// <param name="download">Download value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Download(string download) {
+        if (string.IsNullOrWhiteSpace(download)) {
+            throw new ArgumentException("download cannot be null or empty");
+        }
         Attributes["download"] = download;
         return this;
     }
@@ -65,6 +84,12 @@ public class Anchor : HtmlTag {
     /// <param name="hrefLink">URL for the <c>href</c> attribute.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor HrefLink(string hrefLink) {
+        if (string.IsNullOrWhiteSpace(hrefLink)) {
+            throw new ArgumentException("hrefLink cannot be null or empty");
+        }
+        if (!Uri.IsWellFormedUriString(hrefLink, UriKind.RelativeOrAbsolute)) {
+            throw new ArgumentException($"Invalid href value: {hrefLink}");
+        }
         Attributes["href"] = hrefLink;
         return this;
     }
@@ -75,6 +100,9 @@ public class Anchor : HtmlTag {
     /// <param name="hreflang">Language code.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor HrefLang(string hreflang) {
+        if (string.IsNullOrWhiteSpace(hreflang)) {
+            throw new ArgumentException("hreflang cannot be null or empty");
+        }
         Attributes["hreflang"] = hreflang;
         return this;
     }
@@ -85,6 +113,9 @@ public class Anchor : HtmlTag {
     /// <param name="onClick">JavaScript code to execute.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor OnClick(string onClick) {
+        if (string.IsNullOrWhiteSpace(onClick)) {
+            throw new ArgumentException("onClick cannot be null or empty");
+        }
         Attributes["onclick"] = onClick;
         return this;
     }
@@ -95,6 +126,9 @@ public class Anchor : HtmlTag {
     /// <param name="media">Media attribute value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Media(string media) {
+        if (string.IsNullOrWhiteSpace(media)) {
+            throw new ArgumentException("media cannot be null or empty");
+        }
         Attributes["media"] = media;
         return this;
     }
@@ -105,6 +139,12 @@ public class Anchor : HtmlTag {
     /// <param name="ping">Ping URL.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor Ping(string ping) {
+        if (string.IsNullOrWhiteSpace(ping)) {
+            throw new ArgumentException("ping cannot be null or empty");
+        }
+        if (!Uri.IsWellFormedUriString(ping, UriKind.RelativeOrAbsolute)) {
+            throw new ArgumentException($"Invalid ping value: {ping}");
+        }
         Attributes["ping"] = ping;
         return this;
     }
@@ -115,6 +155,9 @@ public class Anchor : HtmlTag {
     /// <param name="referrerPolicy">Referrer policy value.</param>
     /// <returns>The current <see cref="Anchor"/> instance.</returns>
     public Anchor ReferrerPolicy(string referrerPolicy) {
+        if (string.IsNullOrWhiteSpace(referrerPolicy)) {
+            throw new ArgumentException("referrerPolicy cannot be null or empty");
+        }
         Attributes["referrerpolicy"] = referrerPolicy;
         return this;
     }


### PR DESCRIPTION
## Summary
- add basic validation for Anchor attributes
- test that invalid href and target throw

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68586ff5eedc832ea603e6dc501d24df