### PR TITLE
Add complete tests for Tabler spacing enums

### DIFF
--- a/HtmlForgeX.Tests/TestTablerEnums.cs
+++ b/HtmlForgeX.Tests/TestTablerEnums.cs
@@ -58,4 +58,106 @@ public class TestTablerEnums {
         Assert.AreEqual("py-3", TablerPadding.VerticalNormal.EnumToString());
         Assert.AreEqual("p-5", TablerPadding.AllTriple.EnumToString());
     }
+
+    [TestMethod]
+    public void TablerMarginEnumToStringAllValues() {
+        foreach (TablerMargin margin in Enum.GetValues(typeof(TablerMargin))) {
+            var marginStr = margin.ToString();
+            var property = "m";
+
+            string side;
+            string size;
+
+            if (marginStr.StartsWith("Top")) {
+                side = "t";
+                size = marginStr.Substring(3);
+            } else if (marginStr.StartsWith("Bottom")) {
+                side = "b";
+                size = marginStr.Substring(6);
+            } else if (marginStr.StartsWith("Start")) {
+                side = "s";
+                size = marginStr.Substring(5);
+            } else if (marginStr.StartsWith("End")) {
+                side = "e";
+                size = marginStr.Substring(3);
+            } else if (marginStr.StartsWith("Horizontal")) {
+                side = "x";
+                size = marginStr.Substring(10);
+            } else if (marginStr.StartsWith("Vertical")) {
+                side = "y";
+                size = marginStr.Substring(8);
+            } else if (marginStr.StartsWith("All")) {
+                side = string.Empty;
+                size = marginStr.Substring(3);
+            } else {
+                side = string.Empty;
+                size = marginStr;
+            }
+
+            size = size switch {
+                "Auto" => "auto",
+                "Zero" => "0",
+                "Quarter" => "1",
+                "Half" => "2",
+                "Normal" => "3",
+                "OneAndHalf" => "4",
+                "Triple" => "5",
+                _ => size.ToLower()
+            };
+
+            var expected = $"{property}{side}-{size}";
+            Assert.AreEqual(expected, margin.EnumToString(), $"Mismatch for {marginStr}");
+        }
+    }
+
+    [TestMethod]
+    public void TablerPaddingEnumToStringAllValues() {
+        foreach (TablerPadding padding in Enum.GetValues(typeof(TablerPadding))) {
+            var paddingStr = padding.ToString();
+            var property = "p";
+
+            string side;
+            string size;
+
+            if (paddingStr.StartsWith("Top")) {
+                side = "t";
+                size = paddingStr.Substring(3);
+            } else if (paddingStr.StartsWith("Bottom")) {
+                side = "b";
+                size = paddingStr.Substring(6);
+            } else if (paddingStr.StartsWith("Start")) {
+                side = "s";
+                size = paddingStr.Substring(5);
+            } else if (paddingStr.StartsWith("End")) {
+                side = "e";
+                size = paddingStr.Substring(3);
+            } else if (paddingStr.StartsWith("Horizontal")) {
+                side = "x";
+                size = paddingStr.Substring(10);
+            } else if (paddingStr.StartsWith("Vertical")) {
+                side = "y";
+                size = paddingStr.Substring(8);
+            } else if (paddingStr.StartsWith("All")) {
+                side = string.Empty;
+                size = paddingStr.Substring(3);
+            } else {
+                side = string.Empty;
+                size = paddingStr;
+            }
+
+            size = size switch {
+                "Auto" => "auto",
+                "Zero" => "0",
+                "Quarter" => "1",
+                "Half" => "2",
+                "Normal" => "3",
+                "OneAndHalf" => "4",
+                "Triple" => "5",
+                _ => size.ToLower()
+            };
+
+            var expected = $"{property}{side}-{size}";
+            Assert.AreEqual(expected, padding.EnumToString(), $"Mismatch for {paddingStr}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand spacing conversion tests
- add exhaustive tests for `TablerMarginExtensions.EnumToString`
- add exhaustive tests for `TablerPaddingExtensions.EnumToString`

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685914d58ec8832e93f2315a1e7aea72