### PR TITLE
Improve library download error handling

### DIFF
--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -85,7 +85,13 @@ public class LibraryDownloader {
 
         Directory.CreateDirectory(Path.GetDirectoryName(localPath));
         using (FileStream fileStream = new(localPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
-            using Stream httpStream = await _client.GetStreamAsync(url).ConfigureAwait(false);
+            using HttpResponseMessage response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                _logger.WriteError($"Failed to download '{url}' - Status code: {(int)response.StatusCode}");
+                throw new HttpRequestException($"Request for '{url}' failed with status code {response.StatusCode}");
+            }
+
+            using Stream httpStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             await httpStream.CopyToAsync(fileStream).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
## Summary
- improve `LibraryDownloader` to use `HttpResponseMessage`
- log and throw when a download fails

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860fc2c0260832ea60802e59315db0e