### PR TITLE
Make GlobalStorage thread-safe

### DIFF
--- a/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
@@ -16,7 +16,7 @@ public class ApexCharts : Element {
     public ApexChartSubtitle Subtitle { get; set; } = new ApexChartSubtitle();
 
     public ApexCharts() {
-        GlobalStorage.Libraries.Add(Libraries.ApexCharts);
+        GlobalStorage.Libraries.TryAdd(Libraries.ApexCharts, 0);
         Id = GlobalStorage.GenerateRandomId("apexChart");
     }
 

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -100,7 +100,7 @@ public class Document : Element {
     /// </summary>
     /// <param name="library">Library identifier.</param>
     public void AddLibrary(Libraries library) {
-        GlobalStorage.Libraries.Add(library);
+        GlobalStorage.Libraries.TryAdd(library, 0);
     }
 
     /// <summary>

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -176,7 +176,7 @@ public class Head {
     /// </summary>
     /// <returns>A string that represents the head section of an HTML document.</returns>
     public override string ToString() {
-        foreach (var libraryEnum in GlobalStorage.Libraries) {
+        foreach (var libraryEnum in GlobalStorage.Libraries.Keys) {
             var library = LibrariesConverter.MapLibraryEnumToLibraryObject(libraryEnum);
             ProcessLibrary(library);
         }

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -278,16 +278,16 @@ public class Table : Element {
         if (Library.HasValue) {
             switch (Library.Value) {
                 case TableType.BootstrapTable:
-                    GlobalStorage.Libraries.Add(Libraries.Bootstrap);
+                    GlobalStorage.Libraries.TryAdd(Libraries.Bootstrap, 0);
                     break;
                 case TableType.DataTables:
-                    GlobalStorage.Libraries.Add(Libraries.Bootstrap);
-                    GlobalStorage.Libraries.Add(Libraries.JQuery);
-                    GlobalStorage.Libraries.Add(Libraries.DataTables);
+                    GlobalStorage.Libraries.TryAdd(Libraries.Bootstrap, 0);
+                    GlobalStorage.Libraries.TryAdd(Libraries.JQuery, 0);
+                    GlobalStorage.Libraries.TryAdd(Libraries.DataTables, 0);
                     break;
                 case TableType.Tabler:
-                    GlobalStorage.Libraries.Add(Libraries.Bootstrap);
-                    GlobalStorage.Libraries.Add(Libraries.Tabler);
+                    GlobalStorage.Libraries.TryAdd(Libraries.Bootstrap, 0);
+                    GlobalStorage.Libraries.TryAdd(Libraries.Tabler, 0);
                     break;
                 default:
                     throw new Exception("Library not supported");

--- a/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
+++ b/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
@@ -5,7 +5,7 @@ public class EasyQRCodeElement : Element {
     private string PrivateText { get; set; }
 
     public EasyQRCodeElement(string text) {
-        GlobalStorage.Libraries.Add(Libraries.EasyQRCode);
+        GlobalStorage.Libraries.TryAdd(Libraries.EasyQRCode, 0);
         Id = GlobalStorage.GenerateRandomId("QrCode");
         PrivateText = text;
     }

--- a/HtmlForgeX/Containers/FancyTree/FancyTree.cs
+++ b/HtmlForgeX/Containers/FancyTree/FancyTree.cs
@@ -21,8 +21,8 @@ public class FancyTree : Element {
 
     public FancyTree() {
         // add library to the global storage, for HTML processing
-        GlobalStorage.Libraries.Add(Libraries.JQuery);
-        GlobalStorage.Libraries.Add(Libraries.FancyTree);
+        GlobalStorage.Libraries.TryAdd(Libraries.JQuery, 0);
+        GlobalStorage.Libraries.TryAdd(Libraries.FancyTree, 0);
         Id = GlobalStorage.GenerateRandomId("fancyTree");
     }
 

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
@@ -67,8 +67,8 @@ public class FullCalendar : Element {
 
     public FullCalendar() {
         // add library to the global storage, for HTML processing
-        GlobalStorage.Libraries.Add(Libraries.FullCalendar);
-        GlobalStorage.Libraries.Add(Libraries.Popper);
+        GlobalStorage.Libraries.TryAdd(Libraries.FullCalendar, 0);
+        GlobalStorage.Libraries.TryAdd(Libraries.Popper, 0);
         Id = GlobalStorage.GenerateRandomId("fullCalendar");
     }
 

--- a/HtmlForgeX/Containers/ScrollingText/ScrollingText.cs
+++ b/HtmlForgeX/Containers/ScrollingText/ScrollingText.cs
@@ -6,7 +6,7 @@ public class ScrollingText : Element {
 
     public ScrollingText() {
         // Add library to the global storage, for HTML processing
-        GlobalStorage.Libraries.Add(Libraries.ScrollingText);
+        GlobalStorage.Libraries.TryAdd(Libraries.ScrollingText, 0);
         Id = GlobalStorage.GenerateRandomId("scrollingText");
     }
 

--- a/HtmlForgeX/Containers/Tabler/TablerIcon.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerIcon.cs
@@ -7,7 +7,7 @@ public class TablerIconElement : Element {
     public Dictionary<string, string> IconStyle { get; set; } = new Dictionary<string, string>();
 
     public TablerIconElement(TablerIcon icon) {
-        GlobalStorage.Libraries.Add(Libraries.TablerIcon);
+        GlobalStorage.Libraries.TryAdd(Libraries.TablerIcon, 0);
         Icon = icon;
     }
 

--- a/HtmlForgeX/Containers/Tabler/TablerPage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerPage.cs
@@ -2,8 +2,8 @@ namespace HtmlForgeX;
 
 public class TablerPage : Element {
     public TablerPage() {
-        GlobalStorage.Libraries.Add(Libraries.Bootstrap);
-        GlobalStorage.Libraries.Add(Libraries.Tabler);
+        GlobalStorage.Libraries.TryAdd(Libraries.Bootstrap, 0);
+        GlobalStorage.Libraries.TryAdd(Libraries.Tabler, 0);
     }
 
     public new TablerRow Row(Action<TablerRow> config) {

--- a/HtmlForgeX/Containers/VisNetwork/VisNetwork.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetwork.cs
@@ -11,8 +11,8 @@ public class VisNetwork : Element {
     public bool EnableLoadingBar { get; set; }
 
     public VisNetwork() {
-        GlobalStorage.Libraries.Add(Libraries.VisNetwork);
-        GlobalStorage.Libraries.Add(Libraries.VisNetworkLoadingBar);
+        GlobalStorage.Libraries.TryAdd(Libraries.VisNetwork, 0);
+        GlobalStorage.Libraries.TryAdd(Libraries.VisNetworkLoadingBar, 0);
         Id = GlobalStorage.GenerateRandomId("Diagram");
     }
 

--- a/HtmlForgeX/GlobalStorage.cs
+++ b/HtmlForgeX/GlobalStorage.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -9,9 +11,9 @@ internal static class GlobalStorage {
     /// <summary>Gets or sets the library mode.</summary>
     internal static LibraryMode LibraryMode { get; set; } = LibraryMode.Online;
     /// <summary>Collection of libraries used by the document.</summary>
-    internal static HashSet<Libraries> Libraries { get; } = new HashSet<Libraries>();
+    internal static ConcurrentDictionary<Libraries, byte> Libraries { get; } = new();
     /// <summary>Collection of processing errors.</summary>
-    internal static List<string> Errors { get; } = new List<string>();
+    internal static ConcurrentBag<string> Errors { get; } = new();
     /// <summary>Output path for generated files.</summary>
     internal static string Path { get; set; } = "";
     /// <summary>Location for CSS resources.</summary>


### PR DESCRIPTION
## Summary
- use `ConcurrentDictionary` and `ConcurrentBag` in `GlobalStorage`
- update all library additions to use `TryAdd`
- iterate over `Libraries.Keys` when generating document headers
- build the solution

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860fc185a14832e948fdad8a15421da