### PR TITLE
Fix directory creation when null

### DIFF
--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -83,7 +83,11 @@ public class LibraryDownloader {
 
         _logger.WriteVerbose($"Saving '{url}' to '{localPath}'");
 
-        Directory.CreateDirectory(Path.GetDirectoryName(localPath));
+        var directory = Path.GetDirectoryName(localPath);
+        if (string.IsNullOrEmpty(directory)) {
+            directory = rootPath;
+        }
+        Directory.CreateDirectory(directory);
         using (FileStream fileStream = new(localPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
             using Stream httpStream = await _client.GetStreamAsync(url).ConfigureAwait(false);
             await httpStream.CopyToAsync(fileStream).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- handle missing path directory when downloading libraries

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860fc355b30832e81198a9ed93da89f