### PR TITLE
Add UTF8 encoding to File.WriteAllText calls

### DIFF
--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -75,7 +75,7 @@ public class Document : Element {
             System.IO.Directory.CreateDirectory(directory);
         }
         try {
-            File.WriteAllText(path, ToString());
+            File.WriteAllText(path, ToString(), Encoding.UTF8);
         } catch (Exception ex) {
             _logger.WriteError($"Failed to write file '{path}'. {ex.Message}");
         }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -324,7 +324,7 @@ public class Head {
                     Directory.CreateDirectory(jsDirectory);
                 }
                 try {
-                    File.WriteAllText(jsFileName, jsContent);
+                    File.WriteAllText(jsFileName, jsContent, Encoding.UTF8);
                 } catch (Exception ex) {
                     _logger.WriteError($"Failed to write file '{jsFileName}'. {ex.Message}");
                 }


### PR DESCRIPTION
## Summary
- ensure `File.WriteAllText` uses `Encoding.UTF8`
- build the solution to verify

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68610585dac0832ebe847ee0833d3108