### PR TITLE
Make Random ID length configurable

### DIFF
--- a/HtmlForgeX.Tests/TestIdGeneration.cs
+++ b/HtmlForgeX.Tests/TestIdGeneration.cs
@@ -10,6 +10,15 @@ public class TestIdGeneration {
         for (var i = 0; i < iterations; i++) {
             var table = new DataTablesTable();
             Assert.IsTrue(ids.Add(table.Id), $"Duplicate id generated: {table.Id}");
+            Assert.AreEqual("table-".Length + 8, table.Id.Length);
         }
+    }
+
+    [TestMethod]
+    public void GenerateRandomIdCustomLength() {
+        var globalStorage = typeof(DataTablesTable).Assembly.GetType("HtmlForgeX.GlobalStorage")!;
+        var method = globalStorage.GetMethod("GenerateRandomId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var id = (string)method.Invoke(null, new object?[] { "test", 5 })!;
+        Assert.AreEqual("test-".Length + 5, id.Length);
     }
 }

--- a/HtmlForgeX/GlobalStorage.cs
+++ b/HtmlForgeX/GlobalStorage.cs
@@ -6,6 +6,7 @@ namespace HtmlForgeX;
 /// Provides application wide storage for configuration and state.
 /// </summary>
 internal static class GlobalStorage {
+    internal const int DefaultRandomIdLength = 8;
     /// <summary>Gets or sets the current theme mode.</summary>
     internal static ThemeMode ThemeMode { get; set; } = ThemeMode.Light;
     /// <summary>Gets or sets the library mode.</summary>
@@ -27,10 +28,10 @@ internal static class GlobalStorage {
     /// </summary>
     /// <param name="preText">Prefix for the identifier.</param>
     /// <returns>Generated identifier.</returns>
-    internal static string GenerateRandomId(string preText) {
+    internal static string GenerateRandomId(string preText, int length = DefaultRandomIdLength) {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         lock (RandomGenerator) {
-            var randomId = new string(Enumerable.Repeat(chars, 5)
+            var randomId = new string(Enumerable.Repeat(chars, length)
                 .Select(s => s[RandomGenerator.Next(s.Length)]).ToArray());
             return $"{preText}-{randomId}";
         }


### PR DESCRIPTION
## Summary
- add `DefaultRandomIdLength` constant
- allow custom length when generating random IDs
- check ID length in tests and verify optional parameter

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686105a96400832e95e661c2c4c14c01