### PR TITLE
Fix font-family quoting in FontLoader

### DIFF
--- a/HtmlForgeX/Resources/FontLoader.cs
+++ b/HtmlForgeX/Resources/FontLoader.cs
@@ -30,8 +30,9 @@ public static class FontLoader {
         };
 
         var fontData = Convert.ToBase64String(File.ReadAllBytes(fontFilePath));
+        var escapedFontFamily = fontFamily.Replace("\"", "\\\"");
         var properties = new Dictionary<string, string> {
-            { "font-family", $"'{fontFamily}'" },
+            { "font-family", $"\"{escapedFontFamily}\"" },
             { "src", $"url(data:{mime};base64,{fontData}) format('{format}')" }
         };
         return new Style("@font-face", properties);


### PR DESCRIPTION
## Summary
- escape font family name in `LoadFontAsStyle`
- rebuild solution

## Testing
- `dotnet test HtmlForgeX.sln`
- `dotnet build HtmlForgeX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686109548b3c832e92473d397828ee29