### PR TITLE
Add HTML escaping and tests for special characters

### DIFF
--- a/HtmlForgeX.Tests/TestHtmlSpecialCharacters.cs
+++ b/HtmlForgeX.Tests/TestHtmlSpecialCharacters.cs
@@ -1,0 +1,19 @@
+using HtmlForgeX.Tags;
+using System.Collections.Generic;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestHtmlSpecialCharacters {
+    [TestMethod]
+    public void HtmlTagEscapesContentWithSpecialCharacters() {
+        var tag = new HtmlTag("p", "5 > 3 & \"quote\" 'single' <tag>");
+        Assert.AreEqual("<p>5 &gt; 3 &amp; &quot;quote&quot; &#39;single&#39; &lt;tag&gt;</p>", tag.ToString());
+    }
+
+    [TestMethod]
+    public void HtmlTagEscapesAttributeValuesWithSpecialCharacters() {
+        var tag = new HtmlTag("input", string.Empty, new Dictionary<string, object> { { "value", "He said \"Hello\" & <welcome>" } }, TagMode.SelfClosing);
+        Assert.AreEqual("<input value=\"He said &quot;Hello&quot; &amp; &lt;welcome&gt;\"/>", tag.ToString());
+    }
+}

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -185,15 +185,15 @@ public class Head {
         head.AppendLine("<head>");
 
         if (!string.IsNullOrEmpty(Title)) {
-            head.AppendLine($"\t<title>{Title}</title>");
+            head.AppendLine($"\t<title>{Helpers.HtmlEncode(Title)}</title>");
         }
 
         if (!string.IsNullOrEmpty(Charset)) {
-            head.AppendLine($"\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Charset}\">");
+            head.AppendLine($"\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Helpers.HtmlEncode(Charset)}\">");
         }
 
         if (!string.IsNullOrEmpty(HttpEquiv) && !string.IsNullOrEmpty(Content)) {
-            head.AppendLine($"\t<meta http-equiv=\"{HttpEquiv}\" content=\"{Content}\">");
+            head.AppendLine($"\t<meta http-equiv=\"{Helpers.HtmlEncode(HttpEquiv)}\" content=\"{Helpers.HtmlEncode(Content)}\">");
         }
 
         if (AutoRefresh.HasValue) {
@@ -288,7 +288,11 @@ public class Head {
     }
 
     private string MetaTagString(string name, string? content) {
-        return string.IsNullOrEmpty(content) ? string.Empty : $"\t<meta name=\"{name}\" content=\"{content}\">\n";
+        if (string.IsNullOrEmpty(content)) {
+            return string.Empty;
+        }
+        var encoded = Helpers.HtmlEncode(content);
+        return $"\t<meta name=\"{name}\" content=\"{encoded}\">\n";
     }
 
     private void ProcessLibrary(Library library) {

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -154,9 +154,11 @@ public class HtmlTag : Element {
                     foreach (var style in styleDict) {
                         styleValue.Append($"{style.Key}: {style.Value}; ");
                     }
-                    html.Append($" style=\"{styleValue.ToString().TrimEnd(' ', ';')}\"");
+                    var styleString = styleValue.ToString().TrimEnd(' ', ';');
+                    html.Append($" style=\"{Helpers.HtmlEncode(styleString)}\"");
                 } else {
-                    html.Append($" {attribute.Key}=\"{attribute.Value.ToString()?.Trim()}\"");
+                    var value = Helpers.HtmlEncode(attribute.Value.ToString()?.Trim() ?? string.Empty);
+                    html.Append($" {attribute.Key}=\"{value}\"");
                 }
             }
         }
@@ -171,7 +173,11 @@ public class HtmlTag : Element {
             // if the tag is normal we add the children
             html.Append(">");
             foreach (var child in Children) {
-                html.Append(child);
+                if (child is string str) {
+                    html.Append(Helpers.HtmlEncode(str));
+                } else {
+                    html.Append(child.ToString());
+                }
             }
             html.Append($"</{PrivateTag}>");
         }

--- a/HtmlForgeX/Tags/Span.cs
+++ b/HtmlForgeX/Tags/Span.cs
@@ -141,16 +141,18 @@ public class Span : Element {
 
     public override string ToString() {
         var styleString = GenerateStyle();
-        styleString = !string.IsNullOrEmpty(styleString) ? $" style=\"{styleString}\"" : "";
+        styleString = !string.IsNullOrEmpty(styleString) ? $" style=\"{Helpers.HtmlEncode(styleString)}\"" : "";
 
         var childrenHtml = string.Join("", Children.Select(child => child.ToString()));
 
         var childrenParentHtml = string.Join("", this.Parent.HtmlSpans.Select(child => {
             var childStyle = child.GenerateStyle();
-            childStyle = !string.IsNullOrEmpty(childStyle) ? $" style=\"{childStyle}\"" : "";
-            return $"<span{childStyle}>{child.Content}</span>";
+            childStyle = !string.IsNullOrEmpty(childStyle) ? $" style=\"{Helpers.HtmlEncode(childStyle)}\"" : "";
+            var content = Helpers.HtmlEncode(child.Content ?? string.Empty);
+            return $"<span{childStyle}>{content}</span>";
         }));
 
-        return $"<span{styleString}>{Content}{childrenHtml}</span>{childrenParentHtml}";
+        var mainContent = Helpers.HtmlEncode(Content ?? string.Empty);
+        return $"<span{styleString}>{mainContent}{childrenHtml}</span>{childrenParentHtml}";
     }
 }

--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Net;
 
 namespace HtmlForgeX;
 
@@ -71,6 +72,10 @@ internal static class Helpers {
 
         //file is not locked
         return false;
+    }
+
+    public static string HtmlEncode(string value) {
+        return WebUtility.HtmlEncode(value);
     }
 
 }


### PR DESCRIPTION
## Summary
- escape attribute values and text content when generating HTML
- encode special characters in head meta tags and spans
- add helper for HTML encoding
- add tests covering quotes and special characters

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68610931c314832eb0162c0d23c255c7