### PR TITLE
Implement SaveAsync in Document

### DIFF
--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using HtmlForgeX.Logging;
 
 namespace HtmlForgeX;
@@ -109,7 +110,12 @@ public class Document : Element {
             System.IO.Directory.CreateDirectory(directory);
         }
         try {
+#if NET5_0_OR_GREATER
             await File.WriteAllTextAsync(path, ToString(), Encoding.UTF8).ConfigureAwait(false);
+#else
+            using var writer = new StreamWriter(path, false, Encoding.UTF8);
+            await writer.WriteAsync(ToString()).ConfigureAwait(false);
+#endif
         } catch (Exception ex) {
             _logger.WriteError($"Failed to write file '{path}'. {ex.Message}");
         }

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -82,6 +82,40 @@ public class Document : Element {
         Helpers.Open(path, openInBrowser);
     }
 
+    /// <summary>
+    /// Saves the document to disk asynchronously.
+    /// </summary>
+    /// <param name="path">File path.</param>
+    /// <param name="openInBrowser">Whether to open the file after saving.</param>
+    /// <param name="scriptPath">Optional scripts path.</param>
+    /// <param name="stylePath">Optional styles path.</param>
+    public async Task SaveAsync(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "") {
+        GlobalStorage.Path = path;
+        if (!string.IsNullOrEmpty(scriptPath)) {
+            GlobalStorage.ScriptPath = scriptPath;
+        }
+
+        if (!string.IsNullOrEmpty(stylePath)) {
+            GlobalStorage.StylePath = stylePath;
+        }
+
+        var countErrors = GlobalStorage.Errors.Count;
+        if (countErrors > 0) {
+            Console.WriteLine($"There were {countErrors} found during generation of HTML.");
+        }
+
+        var directory = System.IO.Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory)) {
+            System.IO.Directory.CreateDirectory(directory);
+        }
+        try {
+            await File.WriteAllTextAsync(path, ToString(), Encoding.UTF8).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.WriteError($"Failed to write file '{path}'. {ex.Message}");
+        }
+        Helpers.Open(path, openInBrowser);
+    }
+
     /// <inheritdoc/>
     public override string ToString() {
         StringBuilder html = new StringBuilder();


### PR DESCRIPTION
## Summary
- add async SaveAsync method using `File.WriteAllTextAsync`
- keep existing synchronous `Save`

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68611608fcc4832ea45b4eeee6535321