### PR TITLE
Fix TablerProgressBar class output

### DIFF
--- a/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
@@ -129,8 +129,11 @@ public class TablerProgressBar : Element {
         string typeClass = string.Join(" ", Types.Select(t => t.ToClassString()));
 
         HtmlTag progressBarTag = new HtmlTag("div")
-            .Class("progress")
-            .Class(typeClass);
+            .Class("progress");
+
+        if (!string.IsNullOrEmpty(typeClass)) {
+            progressBarTag.Class(typeClass);
+        }
         // TODO: We need to add handling for mb-3 and similar for margins and padding
 
         foreach (var item in Items) {


### PR DESCRIPTION
## Summary
- prevent empty classes in `TablerProgressBar.ToString`
- rebuild

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686115abe47c832e967ec1e86ccd0da1