### PR TITLE
Add Document.Save error logging tests

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using HtmlForgeX.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -38,11 +37,12 @@ public class TestDocumentSaveErrors {
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
         var doc = new Document();
-        string path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), $"file_{Guid.NewGuid()}.html")
-            : Path.Combine("/proc", $"file_{Guid.NewGuid()}.html");
-        doc.Save(path);
+        var path = Path.Combine(Path.GetTempPath(), $"file_{Guid.NewGuid()}.html");
+        using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
+            doc.Save(path);
+        }
         logger.OnErrorMessage -= handler;
+        File.Delete(path);
         Assert.IsNotNull(received);
         StringAssert.Contains(received!, path);
     }

--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using HtmlForgeX.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDocumentSaveErrors {
+    private static InternalLogger GetLogger() {
+        var field = typeof(Document).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field);
+        return (InternalLogger)field!.GetValue(null)!;
+    }
+
+    [TestMethod]
+    public void Save_PathIsDirectory_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+        var doc = new Document();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        doc.Save(dir);
+        logger.OnErrorMessage -= handler;
+        Directory.Delete(dir, true);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, dir);
+    }
+
+    [TestMethod]
+    public void Save_UnwritableLocation_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+        var doc = new Document();
+        string path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), $"file_{Guid.NewGuid()}.html")
+            : Path.Combine("/proc", $"file_{Guid.NewGuid()}.html");
+        doc.Save(path);
+        logger.OnErrorMessage -= handler;
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, path);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -72,7 +72,11 @@ public class Document : Element {
 
         var directory = System.IO.Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory)) {
-            System.IO.Directory.CreateDirectory(directory);
+            try {
+                System.IO.Directory.CreateDirectory(directory);
+            } catch (Exception ex) {
+                _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
+            }
         }
         try {
             File.WriteAllText(path, ToString(), Encoding.UTF8);


### PR DESCRIPTION
## Summary
- add failing path tests to Document.Save

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686116380a70832ea1ec1144c4daccfc