### PR TITLE
Add stream overload for font loader

### DIFF
--- a/HtmlForgeX.Tests/TestFontLoader.cs
+++ b/HtmlForgeX.Tests/TestFontLoader.cs
@@ -1,0 +1,20 @@
+using HtmlForgeX.Resources;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestFontLoader {
+    [TestMethod]
+    public void LoadFontFromStreamMatchesFile() {
+        var fontFamily = "Test Font";
+        var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.ttf");
+        File.WriteAllBytes(path, bytes);
+        var expected = FontLoader.LoadFontAsStyle(fontFamily, path);
+        using var stream = new MemoryStream(bytes);
+        var actual = FontLoader.LoadFontAsStyle(fontFamily, stream, ".ttf");
+        File.Delete(path);
+        Assert.AreEqual(expected.Properties["font-family"], actual.Properties["font-family"]);
+        Assert.AreEqual(expected.Properties["src"], actual.Properties["src"]);
+    }
+}

--- a/HtmlForgeX/Resources/FontLoader.cs
+++ b/HtmlForgeX/Resources/FontLoader.cs
@@ -43,7 +43,7 @@ public static class FontLoader {
             throw new ArgumentNullException(nameof(fontStream));
         }
 
-        extension = extension.StartsWith('.') ? extension.ToLowerInvariant() : $".{extension.ToLowerInvariant()}";
+        extension = extension.StartsWith(".") ? extension.ToLowerInvariant() : $".{extension.ToLowerInvariant()}";
         var mime = extension switch {
             ".woff2" => "font/woff2",
             ".woff" => "font/woff",

--- a/HtmlForgeX/Resources/FontLoader.cs
+++ b/HtmlForgeX/Resources/FontLoader.cs
@@ -37,4 +37,37 @@ public static class FontLoader {
         };
         return new Style("@font-face", properties);
     }
+
+    public static Style LoadFontAsStyle(string fontFamily, Stream fontStream, string extension) {
+        if (fontStream is null) {
+            throw new ArgumentNullException(nameof(fontStream));
+        }
+
+        extension = extension.StartsWith('.') ? extension.ToLowerInvariant() : $".{extension.ToLowerInvariant()}";
+        var mime = extension switch {
+            ".woff2" => "font/woff2",
+            ".woff" => "font/woff",
+            ".ttf" => "font/ttf",
+            ".otf" => "font/otf",
+            _ => "application/octet-stream"
+        };
+        var format = extension switch {
+            ".woff2" => "woff2",
+            ".woff" => "woff",
+            ".ttf" => "truetype",
+            ".otf" => "opentype",
+            _ => "truetype"
+        };
+
+        fontStream.Position = 0;
+        using var memoryStream = new MemoryStream();
+        fontStream.CopyTo(memoryStream);
+        var fontData = Convert.ToBase64String(memoryStream.ToArray());
+        var escapedFontFamily = fontFamily.Replace("\"", "\\\"");
+        var properties = new Dictionary<string, string> {
+            { "font-family", $"\"{escapedFontFamily}\"" },
+            { "src", $"url(data:{mime};base64,{fontData}) format('{format}')" }
+        };
+        return new Style("@font-face", properties);
+    }
 }

--- a/HtmlForgeX/Resources/Main.cs
+++ b/HtmlForgeX/Resources/Main.cs
@@ -39,4 +39,14 @@ internal class Primary : Library {
     public void LoadFont(string fontFamily, string fontFilePath) {
         Header.CssStyle.Add(FontLoader.LoadFontAsStyle(fontFamily, fontFilePath));
     }
+
+    /// <summary>
+    /// Loads a custom font stream and adds it to the library styles.
+    /// </summary>
+    /// <param name="fontFamily">Font family name.</param>
+    /// <param name="fontStream">Stream containing the font.</param>
+    /// <param name="extension">Font file extension.</param>
+    public void LoadFont(string fontFamily, Stream fontStream, string extension) {
+        Header.CssStyle.Add(FontLoader.LoadFontAsStyle(fontFamily, fontStream, extension));
+    }
 }


### PR DESCRIPTION
## Summary
- extend `FontLoader.LoadFontAsStyle` to accept a `Stream`
- expose matching overload in `Main` for convenience
- test loading font data from a stream

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6861162e6c44832ea0c2aca00a6654b9