### PR TITLE
Add range validation for TablerProgressBarItem

### DIFF
--- a/HtmlForgeX.Tests/TestTablerProgressBarItem.cs
+++ b/HtmlForgeX.Tests/TestTablerProgressBarItem.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerProgressBarItem {
+    [TestMethod]
+    public void ConstructorThrowsWhenProgressBelowZero() {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new TablerProgressBarItem(TablerColor.Primary, -1));
+    }
+
+    [TestMethod]
+    public void ConstructorThrowsWhenProgressAboveHundred() {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new TablerProgressBarItem(TablerColor.Primary, 101));
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
@@ -17,6 +17,10 @@ public class TablerProgressBarItem : Element {
     /// <param name="background">Background color for the progress bar segment.</param>
     /// <param name="progress">Progress percentage.</param>
     public TablerProgressBarItem(TablerColor background, int progress) {
+        if (progress is < 0 or > 100) {
+            throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
+        }
+
         Background = background;
         Progress = progress;
     }
@@ -31,6 +35,10 @@ public class TablerProgressBarItem : Element {
     /// <param name="valueMin">Optional minimum value.</param>
     /// <param name="valueMax">Optional maximum value.</param>
     public TablerProgressBarItem(TablerColor background, int progress, string label, int? valueNow = null, int? valueMin = null, int? valueMax = null) {
+        if (progress is < 0 or > 100) {
+            throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
+        }
+
         Background = background;
         Progress = progress;
         PrivateLabel = label;


### PR DESCRIPTION
## Summary
- validate progress value in `TablerProgressBarItem`
- add tests for out-of-range values

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6861161cfb78832e9ef791561ae631d5