### PR TITLE
Fix URL validation in TablerBadgeLink

### DIFF
--- a/HtmlForgeX/Containers/Tabler/TablerBadgeLink.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerBadgeLink.cs
@@ -1,8 +1,17 @@
-using HtmlForgeX;
+namespace HtmlForgeX;
 
 public class TablerBadgeLink : Element {
     private new string Text { get; set; }
-    private string Href { get; set; }
+    private string Href {
+        get => _href;
+        set {
+            if (!Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out _)) {
+                throw new ArgumentException($"Invalid href value: {value}", nameof(value));
+            }
+            _href = value;
+        }
+    }
+    private string _href = string.Empty;
     private TablerColor? Color { get; set; }
 
     private TablerBadgeStyle Style { get; set; }


### PR DESCRIPTION
## Summary
- update namespace style in `TablerBadgeLink`
- validate `Href` using `Uri.TryCreate`

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6861459848ec832e9196a16750a414c4