### PR TITLE
Improve ToString performance with cached builders

### DIFF
--- a/HtmlForgeX/Containers/Core/Body.cs
+++ b/HtmlForgeX/Containers/Core/Body.cs
@@ -50,7 +50,7 @@ public class Body : Element {
 
     /// <inheritdoc/>
     public override string ToString() {
-        StringBuilder bodyBuilder = new StringBuilder();
+        var bodyBuilder = StringBuilderCache.Acquire();
         if (GlobalStorage.ThemeMode == ThemeMode.Dark) {
             bodyBuilder.AppendLine("<body data-bs-theme=\"dark\">");
         } else if (GlobalStorage.ThemeMode == ThemeMode.Light) {
@@ -68,6 +68,6 @@ public class Body : Element {
 
         bodyBuilder.AppendLine("</body>");
 
-        return bodyBuilder.ToString();
+        return StringBuilderCache.GetStringAndRelease(bodyBuilder);
     }
 }

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -128,7 +128,7 @@ public class Document : Element {
 
     /// <inheritdoc/>
     public override string ToString() {
-        StringBuilder html = new StringBuilder();
+        var html = StringBuilderCache.Acquire();
 
         html.AppendLine("<!DOCTYPE html>");
         html.AppendLine("<html>");
@@ -136,7 +136,7 @@ public class Document : Element {
         html.AppendLine(this.Body.ToString());
         html.AppendLine("</html>");
 
-        return html.ToString();
+        return StringBuilderCache.GetStringAndRelease(html);
     }
 
     /// <summary>

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -181,7 +181,7 @@ public class Head {
             ProcessLibrary(library);
         }
 
-        StringBuilder head = new StringBuilder();
+        var head = StringBuilderCache.Acquire();
         head.AppendLine("<head>");
 
         if (!string.IsNullOrEmpty(Title)) {
@@ -245,7 +245,7 @@ public class Head {
         }
 
         head.AppendLine("</head>");
-        return head.ToString();
+        return StringBuilderCache.GetStringAndRelease(head);
     }
 
     public Head AddDefaultStyles() {

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -227,7 +227,7 @@ public class Table : Element {
     }
 
     public virtual string BuildTable() {
-        StringBuilder html = new StringBuilder();
+        var html = StringBuilderCache.Acquire();
         // Add table headers
         if (TableHeaders.Count > 0) {
             html.Append("<thead><tr>");
@@ -259,7 +259,7 @@ public class Table : Element {
             html.Append("</tr></tfoot>");
         }
 
-        return html.ToString();
+        return StringBuilderCache.GetStringAndRelease(html);
     }
 
     public static Table Create(IEnumerable<object> objects, TableType tableType) {

--- a/HtmlForgeX/Containers/Tabler/TablerDataGrid.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerDataGrid.cs
@@ -27,7 +27,8 @@ public class TablerDataGrid : Element {
     }
 
     public override string ToString() {
-        StringBuilder html = new StringBuilder("<div class=\"datagrid\">");
+        var html = StringBuilderCache.Acquire();
+        html.Append("<div class=\"datagrid\">");
 
         foreach (var item in Items) {
             html.Append(item.ToString());
@@ -35,6 +36,6 @@ public class TablerDataGrid : Element {
 
         html.Append("</div>");
 
-        return html.ToString();
+        return StringBuilderCache.GetStringAndRelease(html);
     }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerDataGridItem.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerDataGridItem.cs
@@ -23,7 +23,8 @@ public class TablerDataGridItem : Element {
     }
 
     public override string ToString() {
-        StringBuilder html = new StringBuilder("<div class=\"datagrid-item\">");
+        var html = StringBuilderCache.Acquire();
+        html.Append("<div class=\"datagrid-item\">");
 
         if (TitleElement != null) {
             html.Append(TitleElement.ToString());
@@ -35,6 +36,6 @@ public class TablerDataGridItem : Element {
 
         html.Append("</div>");
 
-        return html.ToString();
+        return StringBuilderCache.GetStringAndRelease(html);
     }
 }

--- a/HtmlForgeX/Utilities/StringBuilderCache.cs
+++ b/HtmlForgeX/Utilities/StringBuilderCache.cs
@@ -1,0 +1,28 @@
+namespace HtmlForgeX;
+
+internal static class StringBuilderCache {
+    [ThreadStatic]
+    private static StringBuilder? _cachedInstance;
+
+    public static StringBuilder Acquire() {
+        var sb = _cachedInstance;
+        if (sb == null) {
+            return new StringBuilder();
+        }
+        _cachedInstance = null;
+        sb.Clear();
+        return sb;
+    }
+
+    public static string GetStringAndRelease(StringBuilder sb) {
+        var result = sb.ToString();
+        Release(sb);
+        return result;
+    }
+
+    public static void Release(StringBuilder sb) {
+        if (sb.Capacity <= 360) {
+            _cachedInstance = sb;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `StringBuilderCache` helper
- refactor heavy `ToString` methods to use the cache

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68614544e6a4832e8d3e2177d1ef9a2b