### PR TITLE
Support more table object types

### DIFF
--- a/HtmlForgeX.Tests/TestTableObjectDetection.cs
+++ b/HtmlForgeX.Tests/TestTableObjectDetection.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTableObjectDetection {
+    private class CustomType {
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+
+    private class FakePsProperty {
+        public string Name { get; set; } = string.Empty;
+        public object? Value { get; set; }
+    }
+
+    private class FakePsObject : DynamicObject {
+        public List<FakePsProperty> Properties { get; } = new();
+        public List<FakePsProperty> Members => Properties;
+
+        public void Add(string name, object? value) {
+            Properties.Add(new FakePsProperty { Name = name, Value = value });
+        }
+    }
+
+    [TestMethod]
+    public void CreateTableFromListPassedAsObject() {
+        var list = new List<CustomType> {
+            new CustomType { Name = "Alice", Age = 30 },
+            new CustomType { Name = "Bob", Age = 40 }
+        };
+
+        var table = HtmlForgeX.Table.Create((object)list, TableType.BootstrapTable);
+
+        Assert.AreEqual(2, table.TableHeaders.Count);
+        Assert.AreEqual(2, table.TableRows.Count);
+    }
+
+    [TestMethod]
+    public void CreateTableFromFakePsObject() {
+        var obj = new FakePsObject();
+        obj.Add("Name", "Alice");
+        obj.Add("Age", 30);
+
+        var table = HtmlForgeX.Table.Create(obj, TableType.BootstrapTable);
+
+        Assert.AreEqual(2, table.TableHeaders.Count);
+        Assert.AreEqual(1, table.TableRows.Count);
+        Assert.AreEqual("Alice", table.TableRows[0][0]);
+        Assert.AreEqual("30", table.TableRows[0][1]);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Collections.Concurrent;
+using System.Collections;
 using System.Text;
 
 namespace HtmlForgeX;
@@ -70,6 +71,20 @@ public class Table : Element {
         if (firstObject == null) {
             // Handle the case where the first object is null
             return this;
+        }
+
+        if (firstObject is IEnumerable enumerable && firstObject is not string && firstObject is not IDictionary) {
+            var flattened = new List<object>();
+            foreach (var obj in objects) {
+                if (obj is IEnumerable inner && obj is not string && obj is not IDictionary) {
+                    foreach (var innerItem in inner) {
+                        flattened.Add(innerItem!);
+                    }
+                } else {
+                    flattened.Add(obj);
+                }
+            }
+            return AddObjects(flattened, addFooter);
         }
 
         if (firstObject is IDictionary<string, object>) {
@@ -281,6 +296,10 @@ public class Table : Element {
     }
 
     public static Table Create(object obj, TableType tableType) {
+        if (obj is IEnumerable enumerable && obj is not string && obj is not IDictionary) {
+            return Create(enumerable.Cast<object>(), tableType);
+        }
+
         return Create(new[] { obj }, tableType);
     }
 


### PR DESCRIPTION
## Summary
- handle nested `IEnumerable` when adding objects to tables
- convert lists passed via `Create(object, TableType)`
- test detection using custom classes and dynamic objects

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686145c3e3f8832ea04e2dab13cd0b45