### PR TITLE
Add TablerTag in context

### DIFF
--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
@@ -117,6 +117,8 @@ internal class BasicHtmlContainer03 {
                                 TablerBadgeStyle.Normal, TablerColor.Green));
                             dataGrid.Title("Normal").Content(new TablerBadgeSpan("Testing", TablerColor.AzureLight,
                                 TablerBadgeStyle.Normal));
+                            dataGrid.Title("Tag").Content(new TablerTag("New", TablerColor.Lime).Dismissable());
+                            dataGrid.Title("Large Tag").Content(new TablerTag("Download", TablerColor.Green).TagSize(TablerTagSize.Large).Dismissable());
 
                         });
                     });

--- a/HtmlForgeX.Examples/Containers/DomainHealthCheck.cs
+++ b/HtmlForgeX.Examples/Containers/DomainHealthCheck.cs
@@ -82,6 +82,7 @@ internal class DomainHealthCheck {
                                     dataGrid.AddItem("Name", "evotec.xyz");
                                     dataGrid.AddItem("DNSSEC", new TablerBadgeSpan("yes", TablerColor.GreenLight));
                                     dataGrid.AddItem("Monitoring", new TablerBadgeSpan("yes", TablerColor.GreenLight));
+                                    dataGrid.AddItem("Status", new TablerTag("Active", TablerColor.Lime).Dismissable());
 
                                 });
                             });

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -18,6 +18,7 @@ using HtmlForgeX.Examples.Tags;
 //BasicHtmlTagBuilding02.Demo1();
 
 //ExampleTablerIcon.Demo();
+ExampleTablerTag.Demo();
 
 //BasicHtmlBuilding.Demo1(true);
 //BasicHtmlBuilding.Demo2(true);

--- a/HtmlForgeX.Examples/Tags/ExampleTablerTag.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerTag.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace HtmlForgeX.Examples.Tags;
+
+internal static class ExampleTablerTag {
+    public static void Demo() {
+        var document = new Document { Head = { Title = "Tag Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Card(card => {
+                        card.DataGrid(dataGrid => {
+                            dataGrid.Title("Tag").Content(new TablerTag("Example", TablerColor.Green).Dismissable());
+                            dataGrid.Title("Large Tag").Content(new TablerTag("Download", TablerColor.Lime).TagSize(TablerTagSize.Large).Dismissable());
+                        });
+                    });
+                });
+            });
+        });
+
+        Console.WriteLine(document);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerTag.cs
+++ b/HtmlForgeX.Tests/TestTablerTag.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerTag {
+    [TestMethod]
+    public void TagGeneratesCorrectHtml() {
+        var tag = new TablerTag("New", TablerColor.Blue);
+        Assert.AreEqual("<span class=\"tag bg-blue\">New</span>", tag.ToString());
+    }
+
+    [TestMethod]
+    public void TagDismissAndSize() {
+        var tag = new TablerTag("Close", TablerColor.Red).Dismissable().TagSize(TablerTagSize.Small);
+        var expected = "<span class=\"tag tag-sm bg-red\">Close<a class=\"tag-remove\" href=\"#\"><i class=\"ti ti-x\"></i></a></span>";
+        Assert.AreEqual(expected, tag.ToString());
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerTagSize.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerTagSize.cs
@@ -1,0 +1,33 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Specifies available tag sizes.
+/// </summary>
+public enum TablerTagSize {
+    /// <summary>Default tag size.</summary>
+    Normal,
+
+    /// <summary>Small tag size.</summary>
+    Small,
+
+    /// <summary>Large tag size.</summary>
+    Large
+}
+
+/// <summary>
+/// Extension helpers for <see cref="TablerTagSize"/>.
+/// </summary>
+public static class TablerTagSizeExtensions {
+    /// <summary>
+    /// Converts a size value to the corresponding CSS class.
+    /// </summary>
+    /// <param name="size">Value to convert.</param>
+    /// <returns>CSS class name or empty string.</returns>
+    public static string EnumToString(this TablerTagSize size) {
+        return size switch {
+            TablerTagSize.Small => "tag-sm",
+            TablerTagSize.Large => "tag-lg",
+            _ => string.Empty
+        };
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerTag.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTag.cs
@@ -1,0 +1,74 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Represents a <c>span</c> element styled as a Tabler tag.
+/// </summary>
+public class TablerTag : Element {
+    private string Text { get; }
+    private TablerColor? Color { get; set; }
+    private bool Dismiss { get; set; }
+    private TablerTagSize Size { get; set; } = TablerTagSize.Normal;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerTag"/> class.
+    /// </summary>
+    /// <param name="text">Text displayed inside the tag.</param>
+    /// <param name="color">Optional background color.</param>
+    public TablerTag(string text, TablerColor? color = null) {
+        Text = text;
+        Color = color;
+    }
+
+    /// <summary>
+    /// Sets the tag background color.
+    /// </summary>
+    /// <param name="color">Color to apply.</param>
+    /// <returns>The current instance.</returns>
+    public TablerTag TagColor(TablerColor color) {
+        Color = color;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the dismiss icon inside the tag.
+    /// </summary>
+    /// <returns>The current instance.</returns>
+    public TablerTag Dismissable() {
+        Dismiss = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the tag size.
+    /// </summary>
+    /// <param name="size">Desired size.</param>
+    /// <returns>The current instance.</returns>
+    public TablerTag TagSize(TablerTagSize size) {
+        Size = size;
+        return this;
+    }
+
+    /// <summary>
+    /// Converts the tag to its HTML representation.
+    /// </summary>
+    /// <returns>HTML string.</returns>
+    public override string ToString() {
+        var tag = new HtmlTag("span").Class("tag");
+        var sizeClass = Size.EnumToString();
+        if (!string.IsNullOrEmpty(sizeClass)) {
+            tag.Class(sizeClass);
+        }
+        if (Color != null) {
+            tag.Class(Color.Value.ToTablerBackground());
+        }
+        tag.Value(Text);
+        if (Dismiss) {
+            var dismiss = new HtmlTag("a")
+                .Class("tag-remove")
+                .Attribute("href", "#")
+                .Value(new TablerIconElement(TablerIcon.X));
+            tag.Value(dismiss);
+        }
+        return tag.ToString();
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -175,6 +175,8 @@ document.Body.Page(page => {
                     dataGrid.Title("Outline").Content(new TablerBadgeSpan("Testing", TablerColor.Azure, TablerBadgeStyle.Outline, TablerColor.Cyan));
                     dataGrid.Title("Text Color").Content(new TablerBadgeSpan("Testing", TablerColor.Facebook, TablerBadgeStyle.Normal, TablerColor.Green));
                     dataGrid.Title("Normal").Content(new TablerBadgeSpan("Testing", TablerColor.AzureLight, TablerBadgeStyle.Normal));
+                    dataGrid.Title("Tag").Content(new TablerTag("New", TablerColor.Lime).Dismissable());
+                    dataGrid.Title("Large Tag").Content(new TablerTag("Download", TablerColor.Green).TagSize(TablerTagSize.Large).Dismissable());
 
                 });
             });


### PR DESCRIPTION
## Summary
- add TablerTag to an existing Tabler data grid example
- showcase TablerTag usage in the DomainHealthCheck sample
- update ExampleTablerTag to render a small demo document

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6867c04a38a4832e8d300bacb39beafa