### PR TITLE
Add Tabler alert v1 styles

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -16,7 +16,7 @@ using HtmlForgeX.Examples.Tags;
 //BasicHtmlTagBuilding.Demo3();
 //BasicHtmlTagBuilding.Demo4();
 //BasicHtmlTagBuilding02.Demo1();
-ExampleTablerTag.Demo();
+ExampleTablerAlerts.Demo();
 // ExampleTablerIcon.Demo();
 // ExampleSvgIcons.Demo();
 // BasicHtmlBuilding.Demo1(true);

--- a/HtmlForgeX.Examples/Tags/ExampleTablerAlerts.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerAlerts.cs
@@ -1,0 +1,97 @@
+namespace HtmlForgeX.Examples.Tags;
+
+internal static class ExampleTablerAlerts {
+    public static void Demo() {
+        var document = new Document { Head = { Title = "Alerts Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Alert(string.Empty, "An error occurred!", TablerColor.Danger)
+                            .Icon(TablerIconType.AlertCircle);
+                        card.Alert(string.Empty, "Some information is missing!", TablerColor.Warning)
+                            .Icon(TablerIconType.AlertTriangle);
+                        card.Alert(string.Empty, "Completed successfully!", TablerColor.Success)
+                            .Icon(TablerIconType.Check);
+                        card.Alert(string.Empty, "Just a quick note!", TablerColor.Info)
+                            .Icon(TablerIconType.InfoCircle);
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Alert(string.Empty, "An error occurred!", TablerColor.Danger, TablerAlertType.Dismissible)
+                            .Icon(TablerIconType.AlertCircle)
+                            .Action("https://example.com", "Link");
+                        card.Alert(string.Empty, "Some information is missing!", TablerColor.Warning, TablerAlertType.Dismissible)
+                            .Icon(TablerIconType.AlertTriangle)
+                            .Action("https://example.com", "Link");
+                        card.Alert(string.Empty, "Completed successfully!", TablerColor.Success, TablerAlertType.Dismissible)
+                            .Icon(TablerIconType.Check)
+                            .Action("https://example.com", "Link");
+                        card.Alert(string.Empty, "Just a quick note!", TablerColor.Info, TablerAlertType.Dismissible)
+                            .Icon(TablerIconType.InfoCircle)
+                            .Action("https://example.com", "Link");
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Alert("Password does not meet requirements:", "<ul class=\"alert-list\"><li>Minimum 8 characters</li><li>Include a special character</li></ul>", TablerColor.Danger, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertCircle);
+                        card.Alert("Some information is missing!", "This is a custom alert box with a description.", TablerColor.Warning, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertTriangle);
+                        card.Alert("Completed successfully!", "This is a custom alert box with a description.", TablerColor.Success, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.Check);
+                        card.Alert("Just a quick note!", "This is a custom alert box with a description.", TablerColor.Info, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.InfoCircle);
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Alert("Password does not meet requirements:", "<ul class=\"alert-list\"><li>Minimum 8 characters</li><li>Include a special character</li></ul>", TablerColor.Danger, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertCircle)
+                            .Important();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Success, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.Check)
+                            .Important();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Warning, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertTriangle)
+                            .Important();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Info, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.InfoCircle)
+                            .Important();
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Alert("Password does not meet requirements:", "<ul class=\"alert-list\"><li>Minimum 8 characters</li><li>Include a special character</li></ul>", TablerColor.Danger, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertCircle)
+                            .Minor();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Success, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.Check)
+                            .Minor();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Warning, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.AlertTriangle)
+                            .Minor();
+                        card.Alert("This is a custom alert box!", "This is a custom alert box with a description.", TablerColor.Info, TablerAlertType.Dismissible)
+                            .WithDescription()
+                            .Icon(TablerIconType.InfoCircle)
+                            .Minor();
+                    });
+                });
+            });
+        });
+
+        document.Save("TablerAlertsDemo.html", true);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerAlerts.cs
+++ b/HtmlForgeX.Tests/TestTablerAlerts.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerAlerts {
+    [TestMethod]
+    public void AlertImportant() {
+        var alert = new TablerAlert("Title", "Message").Important();
+        StringAssert.Contains(alert.ToString(), "alert-important");
+    }
+
+    [TestMethod]
+    public void AlertMinor() {
+        var alert = new TablerAlert("Title", "Message").Minor();
+        StringAssert.Contains(alert.ToString(), "alert-minor");
+    }
+
+    [TestMethod]
+    public void AlertActionLink() {
+        var alert = new TablerAlert(string.Empty, "Info", TablerColor.Info, TablerAlertType.Dismissible)
+            .Action("https://example.com", "Link");
+        StringAssert.Contains(alert.ToString(), "alert-action");
+        StringAssert.Contains(alert.ToString(), "btn-close");
+    }
+
+    [TestMethod]
+    public void AlertDescription() {
+        var alert = new TablerAlert("Heading", "Description").WithDescription();
+        var html = alert.ToString();
+        StringAssert.Contains(html, "alert-heading");
+        StringAssert.Contains(html, "alert-description");
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerAlerts.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAlerts.cs
@@ -7,6 +7,10 @@ public class TablerAlert : Element {
     private TablerAlertType AlertType { get; }
     private TablerIconElement? AlertIcon { get; set; }
     private string AlertImportant { get; set; }
+    private string AlertMinor { get; set; }
+    private bool UseHeadingStyle { get; set; }
+    private string? ActionHref { get; set; }
+    private string? ActionText { get; set; }
 
     public TablerAlert(string title, string message, TablerColor alertColor = TablerColor.Default, TablerAlertType alertType = TablerAlertType.Regular) {
         Title = title;
@@ -30,6 +34,22 @@ public class TablerAlert : Element {
         return this;
     }
 
+    public TablerAlert Minor() {
+        AlertMinor = "alert-minor";
+        return this;
+    }
+
+    public TablerAlert WithDescription() {
+        UseHeadingStyle = true;
+        return this;
+    }
+
+    public TablerAlert Action(string href, string text) {
+        ActionHref = href;
+        ActionText = text;
+        return this;
+    }
+
     public override string ToString() {
         var alertTypeClass = AlertType == TablerAlertType.Dismissible ? "alert-dismissible" : "";
         var alertTag = new HtmlTag("div")
@@ -37,29 +57,30 @@ public class TablerAlert : Element {
             .Class(AlertColor.ToTablerAlert())
             .Class(alertTypeClass)
             .Class(AlertImportant)
+            .Class(AlertMinor)
             .Attribute("role", "alert");
 
-        var flex = new HtmlTag("div").Class("d-flex");
-
-        var divAlertDetails = new HtmlTag("div");
-
         if (AlertIcon != null) {
-            var divIcon = new HtmlTag("div")
-                .Value(AlertIcon)
-                .Value(new NonBreakingSpace(), new NonBreakingSpace()); // Add some space between icon and text, not great but works
-
-            flex.Value(divIcon);
+            var divIcon = new HtmlTag("div").Class("alert-icon").Value(AlertIcon);
+            alertTag.Value(divIcon);
         }
 
-        if (!string.IsNullOrEmpty(Title)) {
-            divAlertDetails.Value(new HtmlTag("h4").Class("alert-title").Value(Title));
+        if (!string.IsNullOrEmpty(Title) || !string.IsNullOrEmpty(Message)) {
+            var divAlertDetails = new HtmlTag("div");
+            if (!string.IsNullOrEmpty(Title)) {
+                var cls = UseHeadingStyle ? "alert-heading" : "alert-title";
+                divAlertDetails.Value(new HtmlTag("h4").Class(cls).Value(Title));
+            }
+            if (!string.IsNullOrEmpty(Message)) {
+                var cls = UseHeadingStyle ? "alert-description" : "text-secondary";
+                divAlertDetails.Value(new HtmlTag("div").Class(cls).Value(Message));
+            }
+            alertTag.Value(divAlertDetails);
         }
 
-        if (!string.IsNullOrEmpty(Message)) {
-            divAlertDetails.Value(new HtmlTag("div").Class("text-secondary").Value(Message));
+        if (!string.IsNullOrEmpty(ActionHref) && !string.IsNullOrEmpty(ActionText)) {
+            alertTag.Value(new Anchor(ActionHref, ActionText).Class("alert-action"));
         }
-        flex.Value(divAlertDetails);
-        alertTag.Value(flex);
 
         if (AlertType == TablerAlertType.Dismissible) {
             alertTag.Value(new HtmlTag("a").Class("btn-close").Attribute("data-bs-dismiss", "alert").Attribute("aria-label", "close"));


### PR DESCRIPTION
## Summary
- extend `TablerAlert` with additional styles and actions
- add new example `ExampleTablerAlerts` showing alert variants
- run alerts demo from `Program.cs`
- add unit tests for new alert features

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686844bdfda8832e88140779a62b5984