### PR TITLE
Add TablerTag dismissable size test

### DIFF
--- a/HtmlForgeX.Tests/TestTablerTag.cs
+++ b/HtmlForgeX.Tests/TestTablerTag.cs
@@ -16,4 +16,11 @@ public class TestTablerTag {
         var expected = "<span class=\"tag tag-sm bg-red\">Close<a class=\"btn-close\" href=\"#\"></a></span>";
         Assert.AreEqual(expected, tag.ToString());
     }
+    [TestMethod]
+    public void DismissableAndSize_GeneratesExpectedHtml() {
+        var tag = new TablerTag("Close", TablerColor.Red).Dismissable().TagSize(TablerTagSize.Small);
+        var expected = "<span class=\"tag tag-sm bg-red\">Close<a class=\"btn-close\" href=\"#\"></a></span>";
+        Assert.AreEqual(expected, tag.ToString());
+    }
+
 }


### PR DESCRIPTION
## Summary
- extend `TestTablerTag` to cover dismissable tags with sizes

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6869402c1608832ebd05f0f3ac6748f1