### PR TITLE
Add test for nested Value calls

### DIFF
--- a/HtmlForgeX.Tests/TestHtmlTagEncoding.cs
+++ b/HtmlForgeX.Tests/TestHtmlTagEncoding.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestHtmlTagEncoding {
+    [TestMethod]
+    public void HtmlTagNestedValueCallsPreserveOrder() {
+        var tag = new HtmlTag("div")
+            .Value("Start ")
+            .Value(new HtmlTag("span").Value("inner"))
+            .Value(" middle ")
+            .Value(new HtmlTag("strong").Value("bold"))
+            .Value(" end");
+
+        const string expected = "<div>Start <span>inner</span> middle <strong>bold</strong> end</div>";
+        Assert.AreEqual(expected, tag.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- add new `TestHtmlTagEncoding` test covering nested `Value` calls
- ensure order of nested tags is preserved in final output

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68694016dcdc832e95dd166f84cf2004