### PR TITLE
Add additional unit tests

### DIFF
--- a/HtmlForgeX.Tests/TestApexChartTypeConverter.cs
+++ b/HtmlForgeX.Tests/TestApexChartTypeConverter.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestApexChartTypeConverter {
+    [TestMethod]
+    public void ApexChartType_SerializesAndDeserializes() {
+        var type = ApexChartType.Bar;
+        var json = JsonSerializer.Serialize(type);
+        Assert.AreEqual("\"bar\"", json);
+        var back = JsonSerializer.Deserialize<ApexChartType>(json);
+        Assert.AreEqual(type, back);
+    }
+}

--- a/HtmlForgeX.Tests/TestApexCharts.cs
+++ b/HtmlForgeX.Tests/TestApexCharts.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestApexCharts {
+    [TestMethod]
+    public void ApexCharts_GeneratesPieChartHtml() {
+        var chart = new ApexCharts();
+        chart.AddPie("A", 5);
+        var html = chart.ToString();
+        Assert.IsTrue(html.Contains("ApexCharts"));
+        Assert.IsTrue(html.Contains("\"pie\""));
+        Assert.IsTrue(html.Contains("A"));
+    }
+}

--- a/HtmlForgeX.Tests/TestApexChartsTitle.cs
+++ b/HtmlForgeX.Tests/TestApexChartsTitle.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestApexChartsTitle {
+    [TestMethod]
+    public void TitleBuilder_SetsProperties() {
+        var title = new ApexChartsTitle()
+            .Text("Demo")
+            .Color("red")
+            .FontSize("14px")
+            .FontWeight("bold");
+
+        Assert.IsTrue(title.IsSet);
+        var json = JsonSerializer.Serialize(title);
+        Assert.IsTrue(json.Contains("\"text\":\"Demo\""));
+        Assert.IsTrue(json.Contains("red"));
+    }
+
+    [TestMethod]
+    public void SubtitleBuilder_SetsProperties() {
+        var sub = new ApexChartSubtitle()
+            .Text("Sub")
+            .Color(RGBColor.Blue)
+            .FontSize("12px")
+            .FontWeight("bold");
+
+        Assert.IsTrue(sub.IsSet);
+        var json = JsonSerializer.Serialize(sub);
+        Assert.IsTrue(json.Contains("\"text\":\"Sub\""));
+        Assert.IsTrue(json.Contains(RGBColor.Blue.ToHex()));
+    }
+}

--- a/HtmlForgeX.Tests/TestDocumentSaveBasic.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveBasic.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDocumentSaveBasic {
+    [TestMethod]
+    public void Document_SaveCreatesFile() {
+        var doc = new Document();
+        doc.Body.Add(new HtmlTag("p", "Hello"));
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+        doc.Save(path, false);
+        Assert.IsTrue(File.Exists(path));
+        File.Delete(path);
+    }
+}

--- a/HtmlForgeX.Tests/TestHelpersEncoding.cs
+++ b/HtmlForgeX.Tests/TestHelpersEncoding.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestHelpersEncoding {
+    [TestMethod]
+    public void HtmlEncode_EncodesSpecialCharacters() {
+        var helpers = typeof(Document).Assembly.GetType("HtmlForgeX.Helpers")!;
+        var method = helpers.GetMethod("HtmlEncode", BindingFlags.Public | BindingFlags.Static)!;
+        var encoded = (string)method.Invoke(null, new object[] { "<div class=\"t\">&</div>" })!;
+        Assert.AreEqual("&lt;div class=&quot;t&quot;&gt;&amp;&lt;/div&gt;", encoded);
+    }
+
+    [TestMethod]
+    public void Open_ReturnsTrueWhenDisabled() {
+        var helpers = typeof(Document).Assembly.GetType("HtmlForgeX.Helpers")!;
+        var method = helpers.GetMethod("Open", BindingFlags.Public | BindingFlags.Static)!;
+        var result = (bool)method.Invoke(null, new object?[] { "dummy", false })!;
+        Assert.IsTrue(result);
+    }
+}

--- a/HtmlForgeX.Tests/TestLibraryDownloaderIcons.cs
+++ b/HtmlForgeX.Tests/TestLibraryDownloaderIcons.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestLibraryDownloaderIcons {
+    [TestMethod]
+    public async Task GenerateTablerIconCodeAsync_ParsesIcons() {
+        var css = ".ti-user:before{} .ti-3d-cube:before{}";
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), "icons.css");
+        await File.WriteAllTextAsync(path, css);
+
+        try {
+            var dl = new LibraryDownloader();
+            var icons = await dl.GenerateTablerIconCodeAsync(path);
+            Assert.IsTrue(icons.Contains("public static TablerIcon User => new TablerIcon(\"ti-user\");"));
+            Assert.IsTrue(icons.Contains("public static TablerIcon ThreedCube => new TablerIcon(\"ti-3d-cube\");"));
+        } finally {
+            File.Delete(path);
+        }
+    }
+}

--- a/HtmlForgeX.Tests/TestLibraryDownloaderIcons.cs
+++ b/HtmlForgeX.Tests/TestLibraryDownloaderIcons.cs
@@ -10,7 +10,11 @@ public class TestLibraryDownloaderIcons {
     public async Task GenerateTablerIconCodeAsync_ParsesIcons() {
         var css = ".ti-user:before{} .ti-3d-cube:before{}";
         var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), "icons.css");
+#if NET8_0_OR_GREATER
         await File.WriteAllTextAsync(path, css);
+#else
+        File.WriteAllText(path, css);
+#endif
 
         try {
             var dl = new LibraryDownloader();

--- a/HtmlForgeX.Tests/TestStringBuilderCache.cs
+++ b/HtmlForgeX.Tests/TestStringBuilderCache.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System.Text;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestStringBuilderCache {
+    [TestMethod]
+    public void AcquireRelease_ReusesInstance() {
+        var cache = typeof(Document).Assembly.GetType("HtmlForgeX.StringBuilderCache")!;
+        var acquire = cache.GetMethod("Acquire", BindingFlags.Public | BindingFlags.Static)!;
+        var release = cache.GetMethod("Release", BindingFlags.Public | BindingFlags.Static)!;
+        var get = cache.GetMethod("GetStringAndRelease", BindingFlags.Public | BindingFlags.Static)!;
+
+        var sb1 = (StringBuilder)acquire.Invoke(null, null)!;
+        sb1.Append("data");
+        release.Invoke(null, new object?[] { sb1 });
+
+        var sb2 = (StringBuilder)acquire.Invoke(null, null)!;
+        Assert.AreSame(sb1, sb2);
+
+        sb2.Clear();
+        sb2.Append("abc");
+        var result = (string)get.Invoke(null, new object[] { sb2 })!;
+        Assert.AreEqual("abc", result);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerProgressBar.cs
+++ b/HtmlForgeX.Tests/TestTablerProgressBar.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerProgressBar {
+    [TestMethod]
+    public void ProgressBarItem_WritesAriaAttributes() {
+        var item = new TablerProgressBarItem(TablerColor.Success, 30, "Label", 30, 0, 100);
+        var html = item.ToString();
+        Assert.IsTrue(html.Contains("aria-valuenow=\"30\""));
+        Assert.IsTrue(html.Contains("aria-valuemin=\"0\""));
+        Assert.IsTrue(html.Contains("aria-valuemax=\"100\""));
+        Assert.IsTrue(html.Contains("Label"));
+    }
+
+    [TestMethod]
+    public void ProgressBar_RendersItems() {
+        var bar = new TablerProgressBar();
+        bar.Item(TablerColor.Primary, 50, "Done");
+        var html = bar.ToString();
+        Assert.IsTrue(html.Contains("progress-bar"));
+        Assert.IsTrue(html.Contains("Done"));
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerTagExtras.cs
+++ b/HtmlForgeX.Tests/TestTablerTagExtras.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerTagExtras {
+    [TestMethod]
+    public void TablerTag_GeneratesExpectedHtml() {
+        var tag = new TablerTag("Hi", TablerColor.Primary)
+            .Dismissable()
+            .TagSize(TablerTagSize.Large);
+
+        var html = tag.ToString();
+        Assert.IsTrue(html.Contains("bg-primary"));
+        Assert.IsTrue(html.Contains("btn-close"));
+        Assert.IsTrue(html.Contains("tag-lg"));
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerTagSizeEnum.cs
+++ b/HtmlForgeX.Tests/TestTablerTagSizeEnum.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerTagSizeEnum {
+    [TestMethod]
+    public void EnumToString_ReturnsExpectedCssClass() {
+        Assert.AreEqual("tag-sm", TablerTagSize.Small.EnumToString());
+        Assert.AreEqual("tag-lg", TablerTagSize.Large.EnumToString());
+        Assert.AreEqual(string.Empty, TablerTagSize.Normal.EnumToString());
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for ApexChartType JSON serialization
- add helper and cache reflection tests
- cover ApexCharts title builders
- test TablerTag extras, progress bar, library downloader icon code
- test ApexCharts pie chart output
- verify basic document save
- add EnumToString coverage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686bee291f08832e84b7890f6253df36