### PR TITLE
Wrap directory creation with logging

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -53,5 +53,23 @@ public class TestDocumentSaveErrors {
         StringAssert.Contains(received!, path);
     }
 
+    [TestMethod]
+    public void Save_DirectoryCreationFails_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received ??= e.FullMessage;
+        logger.OnErrorMessage += handler;
+        var doc = new Document();
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var dirPath = Path.Combine(tempDir, $"dir_{Guid.NewGuid()}");
+        File.WriteAllText(dirPath, string.Empty);
+        var filePath = Path.Combine(dirPath, "file.html");
+        doc.Save(filePath);
+        logger.OnErrorMessage -= handler;
+        File.Delete(dirPath);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, dirPath);
+    }
+
 
 }

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -127,7 +127,11 @@ public class Document : Element {
 
         var directory = System.IO.Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory)) {
-            System.IO.Directory.CreateDirectory(directory);
+            try {
+                System.IO.Directory.CreateDirectory(directory);
+            } catch (Exception ex) {
+                _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
+            }
         }
         try {
 #if NET5_0_OR_GREATER

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -99,7 +99,11 @@ public class Email : Element {
 
         var directory = System.IO.Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(directory)) {
-            System.IO.Directory.CreateDirectory(directory);
+            try {
+                System.IO.Directory.CreateDirectory(directory);
+            } catch (Exception ex) {
+                _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
+            }
         }
         try {
 #if NET5_0_OR_GREATER

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -338,7 +338,11 @@ public class Head : Element {
                 var jsFileName = Path.Combine(_document.Configuration.Path, Path.GetFileName(js));
                 var jsDirectory = Path.GetDirectoryName(jsFileName);
                 if (!string.IsNullOrEmpty(jsDirectory)) {
-                    Directory.CreateDirectory(jsDirectory);
+                    try {
+                        Directory.CreateDirectory(jsDirectory);
+                    } catch (Exception ex) {
+                        _logger.WriteError($"Failed to create directory '{jsDirectory}'. {ex.Message}");
+                    }
                 }
                 try {
                     File.WriteAllText(jsFileName, jsContent, Encoding.UTF8);

--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -104,7 +104,11 @@ public class LibraryDownloader {
         if (string.IsNullOrEmpty(directory)) {
             directory = rootPath;
         }
-        Directory.CreateDirectory(directory);
+        try {
+            Directory.CreateDirectory(directory);
+        } catch (Exception ex) {
+            _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
+        }
         using (FileStream fileStream = new(localPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
             using HttpResponseMessage response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode) {


### PR DESCRIPTION
## Summary
- add try/catch around Directory.CreateDirectory in async save methods
- log failures when preparing output paths for resources
- test save path when the directory cannot be created

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6870d6c623a8832ea26555edce05c517