### PR TITLE
Fix TablerBadgeSpan color null handling

### DIFF
--- a/HtmlForgeX.Tests/TestTablerComponentsBasic.cs
+++ b/HtmlForgeX.Tests/TestTablerComponentsBasic.cs
@@ -82,8 +82,16 @@ public class TestTablerComponentsBasic {
     public void TablerBadgeSpan_BasicCreation() {
         var badge = new TablerBadgeSpan("Test", TablerColor.Primary);
         var html = badge.ToString();
-        
+
         Assert.IsTrue(html.Contains("Test"));
         Assert.IsTrue(html.Contains("class=\"badge bg-primary\""));
+    }
+
+    [TestMethod]
+    public void TablerBadgeSpan_NullColor() {
+        var badge = new TablerBadgeSpan("txt", null);
+        var html = badge.ToString();
+
+        Assert.IsTrue(html.Contains("class=\"badge\""));
     }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerBadgeSpan.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerBadgeSpan.cs
@@ -6,7 +6,7 @@ public class TablerBadgeSpan : Element {
     public TablerColor? TextColor { get; set; }
     public TablerBadgeStyle Style { get; set; }
 
-    public TablerBadgeSpan(string text, TablerColor color, TablerBadgeStyle style = TablerBadgeStyle.Normal, TablerColor? textColor = null) {
+    public TablerBadgeSpan(string text, TablerColor? color, TablerBadgeStyle style = TablerBadgeStyle.Normal, TablerColor? textColor = null) {
         Text = text;
         Color = color;
         Style = style;
@@ -14,8 +14,6 @@ public class TablerBadgeSpan : Element {
     }
 
     public override string ToString() {
-        string colorString = Color.ToString().ToLower();
-
         var badgeTag = new HtmlTag("span")
             .Class("badge")
             .Value(Text);


### PR DESCRIPTION
## Summary
- make `TablerBadgeSpan` accept nullable color
- skip unused color string to avoid null exceptions
- test that null color renders correctly

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6870d6bb31e4832eaef68a51df302655