### PR TITLE
Validate ID prefix

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentConfiguration.cs
+++ b/HtmlForgeX.Tests/TestDocumentConfiguration.cs
@@ -77,11 +77,19 @@ public class TestDocumentConfiguration {
     [TestMethod]
     public void DocumentConfiguration_GenerateRandomIdWithCustomLength() {
         var config = new DocumentConfiguration();
-        
+
         var id = config.GenerateRandomId("test", 12);
-        
+
         Assert.IsNotNull(id);
         Assert.IsTrue(id.StartsWith("test"));
         Assert.IsTrue(id.Length > 4);
+    }
+
+    [TestMethod]
+    public void DocumentConfiguration_GenerateRandomId_InvalidInput() {
+        var config = new DocumentConfiguration();
+
+        Assert.ThrowsException<ArgumentException>(() => config.GenerateRandomId(null!));
+        Assert.ThrowsException<ArgumentException>(() => config.GenerateRandomId(" \t\n"));
     }
 }

--- a/HtmlForgeX.Tests/TestIdGeneration.cs
+++ b/HtmlForgeX.Tests/TestIdGeneration.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace HtmlForgeX.Tests;
 
 [TestClass]
@@ -20,5 +22,17 @@ public class TestIdGeneration {
         var method = globalStorage.GetMethod("GenerateRandomId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
         var id = (string)method.Invoke(null, new object?[] { "test", 5 })!;
         Assert.AreEqual("test-".Length + 5, id.Length);
+    }
+
+    [TestMethod]
+    public void GenerateRandomIdInvalidInput() {
+        var globalStorage = typeof(DataTablesTable).Assembly.GetType("HtmlForgeX.GlobalStorage")!;
+        var method = globalStorage.GetMethod("GenerateRandomId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        var ex1 = Assert.ThrowsException<TargetInvocationException>(() => method.Invoke(null, new object?[] { null, 5 }));
+        Assert.IsInstanceOfType(ex1.InnerException, typeof(ArgumentException));
+
+        var ex2 = Assert.ThrowsException<TargetInvocationException>(() => method.Invoke(null, new object?[] { " ", 5 }));
+        Assert.IsInstanceOfType(ex2.InnerException, typeof(ArgumentException));
     }
 }

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace HtmlForgeX;
@@ -54,6 +55,10 @@ public class DocumentConfiguration {
     /// <param name="length">Length of the random part.</param>
     /// <returns>Generated identifier.</returns>
     public string GenerateRandomId(string preText, int length = DefaultRandomIdLength) {
+        if (string.IsNullOrWhiteSpace(preText)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(preText));
+        }
+
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         lock (_randomGenerator) {
             var randomId = new string(Enumerable.Repeat(chars, length)

--- a/HtmlForgeX/GlobalStorage.cs
+++ b/HtmlForgeX/GlobalStorage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace HtmlForgeX;
@@ -29,6 +30,10 @@ internal static class GlobalStorage {
     /// <param name="preText">Prefix for the identifier.</param>
     /// <returns>Generated identifier.</returns>
     internal static string GenerateRandomId(string preText, int length = DefaultRandomIdLength) {
+        if (string.IsNullOrWhiteSpace(preText)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(preText));
+        }
+
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         lock (RandomGenerator) {
             var randomId = new string(Enumerable.Repeat(chars, length)


### PR DESCRIPTION
## Summary
- validate ID prefixes in `GenerateRandomId`
- test invalid input cases
- remove the unused random ID example

## Testing
- `dotnet test --no-build --verbosity minimal`
- `dotnet build --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6870d6cd4624832e914f04e93526f469