### PR TITLE
Expose internals for testing

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 
 using HtmlForgeX.Logging;
 
@@ -11,9 +10,7 @@ namespace HtmlForgeX.Tests;
 [TestClass]
 public class TestDocumentSaveErrors {
     private static InternalLogger GetLogger() {
-        var field = typeof(Document).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.IsNotNull(field);
-        return (InternalLogger)field!.GetValue(null)!;
+        return Document._logger;
     }
 
 
@@ -70,6 +67,4 @@ public class TestDocumentSaveErrors {
         Assert.IsNotNull(received);
         StringAssert.Contains(received!, dirPath);
     }
-
-
 }

--- a/HtmlForgeX.Tests/TestHelpers.cs
+++ b/HtmlForgeX.Tests/TestHelpers.cs
@@ -1,6 +1,5 @@
 using HtmlForgeX;
 
-using System.Reflection;
 
 namespace HtmlForgeX.Tests;
 
@@ -14,19 +13,15 @@ public class TestHelpers {
         var fileInfo = new FileInfo(path);
 
         using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None);
-        var helpers = typeof(Document).Assembly.GetType("HtmlForgeX.Helpers")!;
-        var fiMethod = helpers.GetMethod("IsFileLocked", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(FileInfo) }, null)!;
-        var pathMethod = helpers.GetMethod("IsFileLocked", BindingFlags.Public | BindingFlags.Static, null, new[] { typeof(string) }, null)!;
-
-        var lockedViaInfo = (bool)fiMethod.Invoke(null, new object[] { fileInfo })!;
-        var lockedViaPath = (bool)pathMethod.Invoke(null, new object[] { path })!;
+        var lockedViaInfo = fileInfo.IsFileLocked();
+        var lockedViaPath = path.IsFileLocked();
         Assert.IsTrue(lockedViaInfo);
         Assert.IsTrue(lockedViaPath);
 
         stream.Dispose();
 
-        lockedViaInfo = (bool)fiMethod.Invoke(null, new object[] { fileInfo })!;
-        lockedViaPath = (bool)pathMethod.Invoke(null, new object[] { path })!;
+        lockedViaInfo = fileInfo.IsFileLocked();
+        lockedViaPath = path.IsFileLocked();
         Assert.IsFalse(lockedViaInfo);
         Assert.IsFalse(lockedViaPath);
         File.Delete(path);

--- a/HtmlForgeX.Tests/TestHelpersEncoding.cs
+++ b/HtmlForgeX.Tests/TestHelpersEncoding.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Reflection;
 
 namespace HtmlForgeX.Tests;
 
@@ -7,17 +6,13 @@ namespace HtmlForgeX.Tests;
 public class TestHelpersEncoding {
     [TestMethod]
     public void HtmlEncode_EncodesSpecialCharacters() {
-        var helpers = typeof(Document).Assembly.GetType("HtmlForgeX.Helpers")!;
-        var method = helpers.GetMethod("HtmlEncode", BindingFlags.Public | BindingFlags.Static)!;
-        var encoded = (string)method.Invoke(null, new object[] { "<div class=\"t\">&</div>" })!;
+        var encoded = Helpers.HtmlEncode("<div class=\"t\">&</div>");
         Assert.AreEqual("&lt;div class=&quot;t&quot;&gt;&amp;&lt;/div&gt;", encoded);
     }
 
     [TestMethod]
     public void Open_ReturnsTrueWhenDisabled() {
-        var helpers = typeof(Document).Assembly.GetType("HtmlForgeX.Helpers")!;
-        var method = helpers.GetMethod("Open", BindingFlags.Public | BindingFlags.Static)!;
-        var result = (bool)method.Invoke(null, new object?[] { "dummy", false })!;
+        var result = Helpers.Open("dummy", false);
         Assert.IsTrue(result);
     }
 }

--- a/HtmlForgeX.Tests/TestIdGeneration.cs
+++ b/HtmlForgeX.Tests/TestIdGeneration.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 
 namespace HtmlForgeX.Tests;
 
@@ -18,21 +17,13 @@ public class TestIdGeneration {
 
     [TestMethod]
     public void GenerateRandomIdCustomLength() {
-        var globalStorage = typeof(DataTablesTable).Assembly.GetType("HtmlForgeX.GlobalStorage")!;
-        var method = globalStorage.GetMethod("GenerateRandomId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-        var id = (string)method.Invoke(null, new object?[] { "test", 5 })!;
+        var id = GlobalStorage.GenerateRandomId("test", 5);
         Assert.AreEqual("test-".Length + 5, id.Length);
     }
 
     [TestMethod]
     public void GenerateRandomIdInvalidInput() {
-        var globalStorage = typeof(DataTablesTable).Assembly.GetType("HtmlForgeX.GlobalStorage")!;
-        var method = globalStorage.GetMethod("GenerateRandomId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-
-        var ex1 = Assert.ThrowsException<TargetInvocationException>(() => method.Invoke(null, new object?[] { null, 5 }));
-        Assert.IsInstanceOfType(ex1.InnerException, typeof(ArgumentException));
-
-        var ex2 = Assert.ThrowsException<TargetInvocationException>(() => method.Invoke(null, new object?[] { " ", 5 }));
-        Assert.IsInstanceOfType(ex2.InnerException, typeof(ArgumentException));
+        Assert.ThrowsException<ArgumentException>(() => GlobalStorage.GenerateRandomId(null!, 5));
+        Assert.ThrowsException<ArgumentException>(() => GlobalStorage.GenerateRandomId(" ", 5));
     }
 }

--- a/HtmlForgeX.Tests/TestLibraryDownloader.cs
+++ b/HtmlForgeX.Tests/TestLibraryDownloader.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HtmlForgeX.Tests;
@@ -45,8 +44,7 @@ public class TestLibraryDownloader {
         string url = $"{prefix}file{extension}";
         string tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString());
         var downloader = new LibraryDownloader();
-        var method = typeof(LibraryDownloader).GetMethod("DownloadFileAsync", BindingFlags.Instance | BindingFlags.NonPublic);
-        await (Task)method!.Invoke(downloader, new object[] { tempDir, url })!;
+        await downloader.DownloadFileAsync(tempDir, url);
         string expected = Path.Combine(tempDir, folder, $"file{extension}");
         Assert.IsTrue(File.Exists(expected));
         Directory.Delete(tempDir, true);

--- a/HtmlForgeX.Tests/TestLibraryIntegration.cs
+++ b/HtmlForgeX.Tests/TestLibraryIntegration.cs
@@ -13,9 +13,7 @@ public class TestLibraryIntegration {
             }
         };
 
-        var storage = typeof(Document).Assembly.GetType("HtmlForgeX.GlobalStorage")!;
-        var prop = storage.GetProperty("LibraryMode", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-        prop.SetValue(null, LibraryMode.Online);
+        GlobalStorage.LibraryMode = LibraryMode.Online;
         var doc = new Document();
         doc.AddLibrary(customLibrary);
         var html = doc.ToString();

--- a/HtmlForgeX.Tests/TestStringBuilderCache.cs
+++ b/HtmlForgeX.Tests/TestStringBuilderCache.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Reflection;
 using System.Text;
 
 namespace HtmlForgeX.Tests;
@@ -8,21 +7,16 @@ namespace HtmlForgeX.Tests;
 public class TestStringBuilderCache {
     [TestMethod]
     public void AcquireRelease_ReusesInstance() {
-        var cache = typeof(Document).Assembly.GetType("HtmlForgeX.StringBuilderCache")!;
-        var acquire = cache.GetMethod("Acquire", BindingFlags.Public | BindingFlags.Static)!;
-        var release = cache.GetMethod("Release", BindingFlags.Public | BindingFlags.Static)!;
-        var get = cache.GetMethod("GetStringAndRelease", BindingFlags.Public | BindingFlags.Static)!;
-
-        var sb1 = (StringBuilder)acquire.Invoke(null, null)!;
+        var sb1 = StringBuilderCache.Acquire();
         sb1.Append("data");
-        release.Invoke(null, new object?[] { sb1 });
+        StringBuilderCache.Release(sb1);
 
-        var sb2 = (StringBuilder)acquire.Invoke(null, null)!;
+        var sb2 = StringBuilderCache.Acquire();
         Assert.AreSame(sb1, sb2);
 
         sb2.Clear();
         sb2.Append("abc");
-        var result = (string)get.Invoke(null, new object[] { sb2 })!;
+        var result = StringBuilderCache.GetStringAndRelease(sb2);
         Assert.AreEqual("abc", result);
     }
 }

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -10,7 +10,7 @@ namespace HtmlForgeX;
 /// Represents an HTML document.
 /// </summary>
 public class Document : Element {
-    private static readonly InternalLogger _logger = new();
+    internal static readonly InternalLogger _logger = new();
 
     /// <summary>
     /// Configuration and state for this document instance.

--- a/HtmlForgeX/Properties/AssemblyInfo.cs
+++ b/HtmlForgeX/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HtmlForgeX.Tests")]

--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -86,7 +86,7 @@ public class LibraryDownloader {
     /// <param name="rootPath">The root path.</param>
     /// <param name="url">The URL.</param>
     /// <exception cref="System.ArgumentException">Unsupported file type: {fileName}</exception>
-    private async Task DownloadFileAsync(string rootPath, string url) {
+    internal async Task DownloadFileAsync(string rootPath, string url) {
         var uri = new Uri(url);
         var fileName = Path.GetFileName(uri.AbsolutePath);
         var extension = Path.GetExtension(fileName).ToLowerInvariant();


### PR DESCRIPTION
## Summary
- allow tests to access internals
- remove reflection usage in unit tests

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6870f00892f4832eb3962e67a4446bc1