### PR TITLE
Handle library file read errors with logging

### DIFF
--- a/HtmlForgeX.Tests/TestAddLibraryErrors.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryErrors.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Reflection;
+using HtmlForgeX.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestAddLibraryErrors {
+    private static InternalLogger GetLogger() {
+        var field = typeof(Document).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field);
+        return (InternalLogger)field!.GetValue(null)!;
+    }
+
+    [TestMethod]
+    public void AddLibrary_CssFileLocked_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var cssPath = Path.Combine(tempDir, $"locked_{Guid.NewGuid():N}.css");
+        File.WriteAllText(cssPath, "body {}", System.Text.Encoding.UTF8);
+        using (File.Open(cssPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
+            var lib = new Library { Header = new LibraryLinks { Css = [cssPath] } };
+            var doc = new Document { LibraryMode = LibraryMode.Offline };
+            doc.AddLibrary(lib);
+        }
+
+        logger.OnErrorMessage -= handler;
+        File.Delete(cssPath);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, cssPath);
+    }
+
+    [TestMethod]
+    public void AddLibrary_JsFileLocked_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var jsPath = Path.Combine(tempDir, $"locked_{Guid.NewGuid():N}.js");
+        File.WriteAllText(jsPath, "console.log('hi');", System.Text.Encoding.UTF8);
+        using (File.Open(jsPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
+            var lib = new Library { Header = new LibraryLinks { Js = [jsPath] } };
+            var doc = new Document { LibraryMode = LibraryMode.Offline };
+            doc.AddLibrary(lib);
+        }
+
+        logger.OnErrorMessage -= handler;
+        File.Delete(jsPath);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, jsPath);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -219,8 +219,12 @@ public class Document : Element {
                     _logger.WriteError($"CSS file '{css}' not found.");
                     continue;
                 }
-                var cssContent = File.ReadAllText(css);
-                this.Head.AddCssInline(cssContent);
+                try {
+                    var cssContent = File.ReadAllText(css);
+                    this.Head.AddCssInline(cssContent);
+                } catch (Exception ex) {
+                    _logger.WriteError($"Failed to read CSS file '{css}'. {ex.Message}");
+                }
             }
 
             foreach (var js in library.Header.Js) {
@@ -228,8 +232,12 @@ public class Document : Element {
                     _logger.WriteError($"JS file '{js}' not found.");
                     continue;
                 }
-                var jsContent = File.ReadAllText(js);
-                this.Head.AddJsInline(jsContent);
+                try {
+                    var jsContent = File.ReadAllText(js);
+                    this.Head.AddJsInline(jsContent);
+                } catch (Exception ex) {
+                    _logger.WriteError($"Failed to read JS file '{js}'. {ex.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- log failures when loading CSS or JS files in AddLibrary
- add tests ensuring locked CSS/JS files report errors instead of crashing

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6870efecb5c0832e9a03e0e9af718d5f