### PR TITLE
Add base64 mime validation

### DIFF
--- a/HtmlForgeX.Tests/TestEmailImageBase64Embedding.cs
+++ b/HtmlForgeX.Tests/TestEmailImageBase64Embedding.cs
@@ -396,6 +396,36 @@ public class TestEmailImageBase64Embedding
         Assert.AreEqual(httpsUrl, emailImage.Source);
     }
 
+    [TestMethod]
+    public void EmailImage_ToString_WithEmbedAsBase64WithoutMimeType_ShouldThrow()
+    {
+        // Arrange
+        var emailImage = new EmailImage
+        {
+            Base64Data = Convert.ToBase64String(_testImageData),
+            EmbedAsBase64 = true,
+            Source = $"data:;base64,{Convert.ToBase64String(_testImageData)}"
+        };
+
+        // Act & Assert
+        Assert.ThrowsException<InvalidOperationException>(() => emailImage.ToString());
+    }
+
+    [TestMethod]
+    public void EmailImage_ToString_WithEmbedFromBase64_ShouldContainDataUri()
+    {
+        // Arrange
+        var emailImage = new EmailImage();
+        var base64Data = Convert.ToBase64String(_testImageData);
+        emailImage.EmbedFromBase64(base64Data, "image/png");
+
+        // Act
+        var html = emailImage.ToString();
+
+        // Assert
+        Assert.IsTrue(html.Contains($"data:image/png;base64,{base64Data}"));
+    }
+
     [TestCleanup]
     public void TestCleanup()
     {

--- a/HtmlForgeX/Containers/Email/EmailImage.cs
+++ b/HtmlForgeX/Containers/Email/EmailImage.cs
@@ -812,6 +812,10 @@ public class EmailImage : Element {
     /// </summary>
     /// <returns>HTML string representing the email image.</returns>
     public override string ToString() {
+        if (EmbedAsBase64 && string.IsNullOrWhiteSpace(MimeType)) {
+            throw new InvalidOperationException("EmbedAsBase64 is enabled but MimeType is not specified.");
+        }
+
         var html = StringBuilderCache.Acquire();
 
         // Build image attributes for light mode image


### PR DESCRIPTION
## Summary
- validate MimeType when image is embedded as base64
- add unit tests for base64 MimeType validation

## Testing
- `dotnet test HtmlForgeX.sln`

------
https://chatgpt.com/codex/tasks/task_e_68717541d918832eb550367134f8a8c4