### PR TITLE
Fix QR code escaping

### DIFF
--- a/HtmlForgeX.Tests/TestQRCodeComponent.cs
+++ b/HtmlForgeX.Tests/TestQRCodeComponent.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 
 namespace HtmlForgeX.Tests;
 
@@ -145,6 +147,22 @@ public class TestQRCodeComponent {
         if (qrCodeMatches.Count >= 2) {
             Assert.AreNotEqual(qrCodeMatches[0].Value, qrCodeMatches[1].Value, "QR code IDs should be unique");
         }
+    }
+
+    [TestMethod]
+    public void QRCode_TextWithQuotesAndNewlines() {
+        var doc = new Document();
+
+        doc.Body.Add(element => {
+            element.QRCode("Line1\n\"Quoted\"");
+        });
+
+        var html = doc.ToString();
+
+        var encoded = JsonSerializer.Serialize("Line1\n\"Quoted\"",
+            new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+
+        Assert.IsTrue(html.Contains(encoded), "QR data should be JSON-encoded with escaped characters");
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
+++ b/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
@@ -1,3 +1,6 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
 namespace HtmlForgeX;
 
 public class EasyQRCodeElement : Element {
@@ -20,9 +23,14 @@ public class EasyQRCodeElement : Element {
     public override string ToString() {
         var divTag = new HtmlTag("div").Class("qrcode").Id(Id);
 
+        var serializedText = JsonSerializer.Serialize(
+            PrivateText,
+            new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }
+        );
+
         var scriptTag = new HtmlTag("script").Value($@"
             var options = {{
-                ""text"": ""{PrivateText}""
+                ""text"": {serializedText}
             }};
         new QRCode(document.getElementById(""{Id}""), options);
     ");


### PR DESCRIPTION
## Summary
- sanitize QR code text using `JsonSerializer`
- test QR code text that contains quotes and newlines

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68717555debc832e9f41c077e95478e2