### PR TITLE
Add email save tests and wrap directory creation

### DIFF
--- a/HtmlForgeX.Tests/TestEmailSave.cs
+++ b/HtmlForgeX.Tests/TestEmailSave.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailSave {
+    [TestMethod]
+    public void Save_CreatesDirectoryAndWritesUtf8() {
+        var email = new Email();
+        string tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString());
+        string dir = Path.Combine(tempDir, "subDirectory");
+        string path = Path.Combine(dir, "testSubDirectory.html");
+        email.Save(path);
+        Assert.IsTrue(Directory.Exists(dir));
+        string content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(email.ToString(), content);
+        Directory.Delete(tempDir, true);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_WritesFile() {
+        var email = new Email();
+        var tempPath = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"file_{Guid.NewGuid():N}.html");
+
+        await email.SaveAsync(tempPath);
+        Assert.IsTrue(File.Exists(tempPath));
+        var contents = File.ReadAllText(tempPath);
+        File.Delete(tempPath);
+        Assert.AreEqual(email.ToString(), contents);
+    }
+}

--- a/HtmlForgeX.Tests/TestEmailSaveBasic.cs
+++ b/HtmlForgeX.Tests/TestEmailSaveBasic.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailSaveBasic {
+    [TestMethod]
+    public void Email_SaveCreatesFile() {
+        var email = new Email();
+        email.Body.Add(new HtmlTag("p", "Hello"));
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+        email.Save(path, false);
+        Assert.IsTrue(File.Exists(path));
+        File.Delete(path);
+    }
+}

--- a/HtmlForgeX.Tests/TestEmailSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestEmailSaveErrors.cs
@@ -1,19 +1,18 @@
 using System;
 using System.IO;
-
+using System.Reflection;
 using HtmlForgeX.Logging;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HtmlForgeX.Tests;
 
 [TestClass]
-public class TestDocumentSaveErrors {
+public class TestEmailSaveErrors {
     private static InternalLogger GetLogger() {
-        return Document._logger;
+        var field = typeof(Email).GetField("_logger", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field);
+        return (InternalLogger)field!.GetValue(null)!;
     }
-
-
 
     [TestMethod]
     public void Save_PathIsDirectory_LogsError() {
@@ -21,15 +20,15 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        var email = new Email();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var dir = Path.Combine(tempDir, Guid.NewGuid().ToString());
         try {
             Directory.CreateDirectory(dir);
         } catch (Exception ex) {
-            Document._logger.WriteError($"Failed to create directory '{dir}'. {ex.Message}");
+            logger.WriteError($"Failed to create directory '{dir}'. {ex.Message}");
         }
-        doc.Save(dir);
+        email.Save(dir);
         logger.OnErrorMessage -= handler;
         Directory.Delete(dir, true);
         Assert.IsNotNull(received);
@@ -42,11 +41,11 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        var email = new Email();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid()}.html");
         using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
-            doc.Save(path);
+            email.Save(path);
         }
         logger.OnErrorMessage -= handler;
         File.Delete(path);
@@ -60,12 +59,12 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received ??= e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        var email = new Email();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var dirPath = Path.Combine(tempDir, $"dir_{Guid.NewGuid()}");
         File.WriteAllText(dirPath, string.Empty);
         var filePath = Path.Combine(dirPath, "file.html");
-        doc.Save(filePath);
+        email.Save(filePath);
         logger.OnErrorMessage -= handler;
         File.Delete(dirPath);
         Assert.IsNotNull(received);

--- a/HtmlForgeX.Tests/TestUtilities.cs
+++ b/HtmlForgeX.Tests/TestUtilities.cs
@@ -18,7 +18,11 @@ public static class TestUtilities {
 #endif
         var tempPath = Path.Combine(Path.GetTempPath(), "HtmlForgeX_Tests", frameworkId);
         if (!Directory.Exists(tempPath)) {
-            Directory.CreateDirectory(tempPath);
+            try {
+                Directory.CreateDirectory(tempPath);
+            } catch (Exception ex) {
+                Document._logger.WriteError($"Failed to create directory '{tempPath}'. {ex.Message}");
+            }
         }
         return tempPath;
     }

--- a/HtmlForgeX.Tests/TestUtilitiesAndHelpers.cs
+++ b/HtmlForgeX.Tests/TestUtilitiesAndHelpers.cs
@@ -11,7 +11,11 @@ public class TestUtilitiesAndHelpers {
     public async Task LibraryDownloader_DownloadLibrary() {
         var downloader = new LibraryDownloader();
         var tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"lib_test_{System.Guid.NewGuid()}");
-        Directory.CreateDirectory(tempDir);
+        try {
+            Directory.CreateDirectory(tempDir);
+        } catch (Exception ex) {
+            Document._logger.WriteError($"Failed to create directory '{tempDir}'. {ex.Message}");
+        }
         
         try {
             await downloader.DownloadLibraryAsync(tempDir, Libraries.JQuery);


### PR DESCRIPTION
## Summary
- wrap directory creation in test helpers with try/catch and logging
- add Email save tests mirroring Document save tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6871752e2a10832ea15a9d050ad1e500