### PR TITLE
Ensure StringBuilder released

### DIFF
--- a/HtmlForgeX.Tests/TestStringBuilderLeak.cs
+++ b/HtmlForgeX.Tests/TestStringBuilderLeak.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using HtmlForgeX;
 
 namespace HtmlForgeX.Tests;
 
@@ -11,7 +13,7 @@ public class TestStringBuilderLeak {
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        long before = GC.GetAllocatedBytesForCurrentThread();
+        long before = GetAllocated();
         for (int i = 0; i < 1000; i++) {
             var element = new BasicElement();
             _ = element.ToString();
@@ -19,9 +21,17 @@ public class TestStringBuilderLeak {
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
-        long after = GC.GetAllocatedBytesForCurrentThread();
+        long after = GetAllocated();
 
         // Ensure allocations stay reasonably low indicating the cached builder was reused
         Assert.IsTrue(after - before < 150_000, $"Too many bytes allocated: {after - before}");
+    }
+
+    private static long GetAllocated() {
+#if NETFRAMEWORK
+        return GC.GetTotalMemory(false);
+#else
+        return GC.GetAllocatedBytesForCurrentThread();
+#endif
     }
 }

--- a/HtmlForgeX.Tests/TestStringBuilderLeak.cs
+++ b/HtmlForgeX.Tests/TestStringBuilderLeak.cs
@@ -1,0 +1,27 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestStringBuilderLeak {
+    [TestMethod]
+    public void BasicElement_Empty_NoStringBuilderLeak() {
+        // Warm up GC and ensure clean state
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 1000; i++) {
+            var element = new BasicElement();
+            _ = element.ToString();
+        }
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        // Ensure allocations stay reasonably low indicating the cached builder was reused
+        Assert.IsTrue(after - before < 150_000, $"Too many bytes allocated: {after - before}");
+    }
+}

--- a/HtmlForgeX/Containers/Core/BasicElement.cs
+++ b/HtmlForgeX/Containers/Core/BasicElement.cs
@@ -54,6 +54,10 @@ public class BasicElement : Element {
     /// </summary>
     /// <returns>HTML string representing the element.</returns>
     public override string ToString() {
+        if (string.IsNullOrEmpty(HtmlContent) && string.IsNullOrEmpty(TextContent) && Children.Count == 0) {
+            return string.Empty;
+        }
+
         var html = StringBuilderCache.Acquire();
 
         // Render HTML content if available, otherwise text content


### PR DESCRIPTION
## Summary
- avoid unnecessary builder creation in `BasicElement` when empty
- test StringBuilder allocation to detect leaks

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6871753a3094832e910e5c4dceb1b549