### PR TITLE
Refactor ID generation helper

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentConfiguration.cs
+++ b/HtmlForgeX.Tests/TestDocumentConfiguration.cs
@@ -1,3 +1,4 @@
+using HtmlForgeX;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Concurrent;
 
@@ -66,12 +67,13 @@ public class TestDocumentConfiguration {
         
         var id1 = config.GenerateRandomId("test");
         var id2 = config.GenerateRandomId("test");
-        
+
         Assert.IsNotNull(id1);
         Assert.IsNotNull(id2);
         Assert.AreNotEqual(id1, id2);
         Assert.IsTrue(id1.StartsWith("test"));
         Assert.IsTrue(id2.StartsWith("test"));
+        Assert.AreEqual("test-".Length + IdGenerator.DefaultRandomIdLength, id1.Length);
     }
 
     [TestMethod]
@@ -82,7 +84,7 @@ public class TestDocumentConfiguration {
 
         Assert.IsNotNull(id);
         Assert.IsTrue(id.StartsWith("test"));
-        Assert.IsTrue(id.Length > 4);
+        Assert.AreEqual("test-".Length + 12, id.Length);
     }
 
     [TestMethod]

--- a/HtmlForgeX.Tests/TestIdGeneration.cs
+++ b/HtmlForgeX.Tests/TestIdGeneration.cs
@@ -1,3 +1,5 @@
+using HtmlForgeX;
+
 
 namespace HtmlForgeX.Tests;
 
@@ -11,7 +13,7 @@ public class TestIdGeneration {
         for (var i = 0; i < iterations; i++) {
             var table = new DataTablesTable();
             Assert.IsTrue(ids.Add(table.Id), $"Duplicate id generated: {table.Id}");
-            Assert.AreEqual("table-".Length + 8, table.Id.Length);
+            Assert.AreEqual("table-".Length + IdGenerator.DefaultRandomIdLength, table.Id.Length);
         }
     }
 

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -1,5 +1,3 @@
-using System;
-using System;
 using System.Collections.Concurrent;
 
 namespace HtmlForgeX;
@@ -75,11 +73,8 @@ public class DocumentConfiguration {
     /// <param name="preText">The prefix for the ID.</param>
     /// <param name="length">Length of the random part (default: 8).</param>
     /// <returns>Generated identifier.</returns>
-    public string GenerateRandomId(string preText, int length = 8) {
-        if (string.IsNullOrWhiteSpace(preText)) {
-            throw new ArgumentException("PreText cannot be null or empty.", nameof(preText));
-        }
-        return GlobalStorage.GenerateRandomId(preText, length);
+    public string GenerateRandomId(string preText, int length = IdGenerator.DefaultRandomIdLength) {
+        return IdGenerator.GenerateRandomId(preText, length);
     }
 }
 

--- a/HtmlForgeX/DocumentState.cs
+++ b/HtmlForgeX/DocumentState.cs
@@ -7,7 +7,6 @@ namespace HtmlForgeX;
 /// Handles library tracking, error collection, and ID generation.
 /// </summary>
 internal class DocumentState {
-    internal const int DefaultRandomIdLength = 8;
 
     /// <summary>
     /// Gets or sets the theme mode for the document.
@@ -46,7 +45,6 @@ internal class DocumentState {
     /// <summary>Location for script resources.</summary>
     public string ScriptPath { get; set; } = "";
 
-    private readonly Random _randomGenerator = new();
 
     /// <summary>
     /// Generates a pseudo random identifier with a prefix.
@@ -54,12 +52,7 @@ internal class DocumentState {
     /// <param name="preText">Prefix for the identifier.</param>
     /// <param name="length">Length of the random part.</param>
     /// <returns>Generated identifier.</returns>
-    public string GenerateRandomId(string preText, int length = DefaultRandomIdLength) {
-        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        lock (_randomGenerator) {
-            var randomId = new string(Enumerable.Repeat(chars, length)
-                .Select(s => s[_randomGenerator.Next(s.Length)]).ToArray());
-            return $"{preText}-{randomId}";
-        }
+    public string GenerateRandomId(string preText, int length = IdGenerator.DefaultRandomIdLength) {
+        return IdGenerator.GenerateRandomId(preText, length);
     }
 }

--- a/HtmlForgeX/GlobalStorage.cs
+++ b/HtmlForgeX/GlobalStorage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Concurrent;
 
 namespace HtmlForgeX;
@@ -7,7 +6,6 @@ namespace HtmlForgeX;
 /// Provides application wide storage for configuration and state.
 /// </summary>
 internal static class GlobalStorage {
-    internal const int DefaultRandomIdLength = 8;
     /// <summary>Gets or sets the current theme mode.</summary>
     internal static ThemeMode ThemeMode { get; set; } = ThemeMode.Light;
     /// <summary>Gets or sets the library mode.</summary>
@@ -22,23 +20,13 @@ internal static class GlobalStorage {
     internal static string StylePath { get; set; } = "";
     /// <summary>Location for script resources.</summary>
     internal static string ScriptPath { get; set; } = "";
-    private static readonly Random RandomGenerator = new();
 
     /// <summary>
     /// Generates a pseudo random identifier with a prefix.
     /// </summary>
     /// <param name="preText">Prefix for the identifier.</param>
     /// <returns>Generated identifier.</returns>
-    internal static string GenerateRandomId(string preText, int length = DefaultRandomIdLength) {
-        if (string.IsNullOrWhiteSpace(preText)) {
-            throw new ArgumentException("Value cannot be null or whitespace.", nameof(preText));
-        }
-
-        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        lock (RandomGenerator) {
-            var randomId = new string(Enumerable.Repeat(chars, length)
-                .Select(s => s[RandomGenerator.Next(s.Length)]).ToArray());
-            return $"{preText}-{randomId}";
-        }
+    internal static string GenerateRandomId(string preText, int length = IdGenerator.DefaultRandomIdLength) {
+        return IdGenerator.GenerateRandomId(preText, length);
     }
 }

--- a/HtmlForgeX/IdGenerator.cs
+++ b/HtmlForgeX/IdGenerator.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+namespace HtmlForgeX;
+
+internal static class IdGenerator
+{
+    internal const int DefaultRandomIdLength = 8;
+    private const string Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static readonly Random RandomGenerator = new();
+
+    internal static string GenerateRandomId(string preText, int length = DefaultRandomIdLength)
+    {
+        if (string.IsNullOrWhiteSpace(preText))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(preText));
+        }
+
+        lock (RandomGenerator)
+        {
+            var randomId = new string(Enumerable.Repeat(Characters, length)
+                .Select(s => s[RandomGenerator.Next(s.Length)]).ToArray());
+            return $"{preText}-{randomId}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize ID creation logic into `IdGenerator`
- use new helper from `DocumentConfiguration`, `DocumentState` and `GlobalStorage`
- test ID lengths via helper constants
- avoid redundant validation in `DocumentConfiguration`

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687175902164832ea86f8b716c0c3542