### PR TITLE
Add path validation for async save

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSave.cs
+++ b/HtmlForgeX.Tests/TestDocumentSave.cs
@@ -33,4 +33,10 @@ public class TestDocumentSave {
         File.Delete(tempPath);
         Assert.AreEqual(doc.ToString(), contents);
     }
+
+    [TestMethod]
+    public async Task SaveAsync_InvalidPath_ThrowsArgumentException() {
+        var doc = new Document();
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await doc.SaveAsync("invalid\0path.html"));
+    }
 }

--- a/HtmlForgeX.Tests/TestEmailSave.cs
+++ b/HtmlForgeX.Tests/TestEmailSave.cs
@@ -32,4 +32,10 @@ public class TestEmailSave {
         File.Delete(tempPath);
         Assert.AreEqual(email.ToString(), contents);
     }
+
+    [TestMethod]
+    public async Task SaveAsync_InvalidPath_ThrowsArgumentException() {
+        var email = new Email();
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await email.SaveAsync("invalid\0path.html"));
+    }
 }

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -71,6 +71,7 @@ public class Document : Element {
     /// <param name="scriptPath">Optional scripts path.</param>
     /// <param name="stylePath">Optional styles path.</param>
     public void Save(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "") {
+        PathUtilities.Validate(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath)) {
             Configuration.ScriptPath = scriptPath;
@@ -111,6 +112,7 @@ public class Document : Element {
     /// <param name="scriptPath">Optional scripts path.</param>
     /// <param name="stylePath">Optional styles path.</param>
     public async Task SaveAsync(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "") {
+        PathUtilities.Validate(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath)) {
             Configuration.ScriptPath = scriptPath;

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -245,6 +245,7 @@ public class Email : Element {
     /// <param name="path">File path.</param>
     /// <param name="openInBrowser">Whether to open the file after saving.</param>
     public void Save(string path, bool openInBrowser = false) {
+        PathUtilities.Validate(path);
         Configuration.Email.DefaultPadding = path; // Store path in configuration
 
         var countErrors = Configuration.Email.LogEmbeddingWarnings ? 0 : 0; // TODO: Implement error counting
@@ -276,6 +277,7 @@ public class Email : Element {
     /// <param name="path">File path.</param>
     /// <param name="openInBrowser">Whether to open the file after saving.</param>
     public async Task SaveAsync(string path, bool openInBrowser = false) {
+        PathUtilities.Validate(path);
         Configuration.Email.DefaultPadding = path; // Store path in configuration
 
         var countErrors = Configuration.Email.LogEmbeddingWarnings ? 0 : 0; // TODO: Implement error counting

--- a/HtmlForgeX/Utilities/PathUtilities.cs
+++ b/HtmlForgeX/Utilities/PathUtilities.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+
+namespace HtmlForgeX;
+
+internal static class PathUtilities {
+    public static void Validate(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentException("Path cannot be null or whitespace.", nameof(path));
+        }
+
+        if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0) {
+            throw new ArgumentException("Path contains invalid characters.", nameof(path));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure paths are validated before saving in Document and Email async methods
- add `PathUtilities` helper
- test invalid paths throw `ArgumentException` for async saves

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6872cac0d6e4832ea2b266767b2ed299