### PR TITLE
Fix UTF-8 loading for custom library files

### DIFF
--- a/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestAddLibraryUtf8 {
+    [TestMethod]
+    public void AddLibrary_LoadsUtf8Files() {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var cssPath = Path.Combine(tempDir, $"utf8_{System.Guid.NewGuid():N}.css");
+        var jsPath = Path.Combine(tempDir, $"utf8_{System.Guid.NewGuid():N}.js");
+        var cssContent = "body::after { content: 'żółć'; }";
+        var jsContent = "console.log('żółć');";
+        File.WriteAllText(cssPath, cssContent, Encoding.UTF8);
+        File.WriteAllText(jsPath, jsContent, Encoding.UTF8);
+
+        var lib = new Library {
+            Header = new LibraryLinks {
+                Css = [cssPath],
+                Js = [jsPath]
+            }
+        };
+        var doc = new Document { LibraryMode = LibraryMode.Offline };
+        doc.AddLibrary(lib);
+        var headHtml = doc.Head.ToString();
+
+        File.Delete(cssPath);
+        File.Delete(jsPath);
+
+        StringAssert.Contains(headHtml, cssContent);
+        StringAssert.Contains(headHtml, jsContent);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -220,7 +220,7 @@ public class Document : Element {
                     continue;
                 }
                 try {
-                    var cssContent = File.ReadAllText(css);
+                    var cssContent = File.ReadAllText(css, Encoding.UTF8);
                     this.Head.AddCssInline(cssContent);
                 } catch (Exception ex) {
                     _logger.WriteError($"Failed to read CSS file '{css}'. {ex.Message}");
@@ -233,7 +233,7 @@ public class Document : Element {
                     continue;
                 }
                 try {
-                    var jsContent = File.ReadAllText(js);
+                    var jsContent = File.ReadAllText(js, Encoding.UTF8);
                     this.Head.AddJsInline(jsContent);
                 } catch (Exception ex) {
                     _logger.WriteError($"Failed to read JS file '{js}'. {ex.Message}");


### PR DESCRIPTION
## Summary
- ensure `Document.AddLibrary` reads CSS and JS files using UTF-8
- add unit test verifying UTF-8 CSS/JS files load correctly

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6872cad8b0cc832e9b9e6ea637ecf856