### PR TITLE
Improve Helpers.Open error handling

### DIFF
--- a/HtmlForgeX.Tests/TestHelpersEncoding.cs
+++ b/HtmlForgeX.Tests/TestHelpersEncoding.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System.Runtime.InteropServices;
+using HtmlForgeX.Logging;
 
 namespace HtmlForgeX.Tests;
 
@@ -22,5 +24,22 @@ public class TestHelpersEncoding {
         var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName());
         var result = Helpers.Open(path, true);
         Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void Open_UnsupportedOS_LogsError() {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, Path.GetRandomFileName());
+        File.WriteAllText(path, "test");
+        string? message = null;
+        EventHandler<LogEventArgs> handler = (_, e) => message = e.FullMessage;
+        Document._logger.OnErrorMessage += handler;
+        Helpers.PlatformOverride = OSPlatform.Create("other");
+        var result = Helpers.Open(path, true);
+        Helpers.PlatformOverride = null;
+        Document._logger.OnErrorMessage -= handler;
+        File.Delete(path);
+        Assert.IsFalse(result);
+        Assert.IsNotNull(message);
     }
 }


### PR DESCRIPTION
## Summary
- add optional `PlatformOverride` to Helpers for testing
- handle `Win32Exception` and `FileNotFoundException` when opening files
- log unsupported OS and process launch errors
- test unsupported OS path

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6872caf1d488832e974930804a6cbf18