### PR TITLE
Improve configuration thread safety

### DIFF
--- a/HtmlForgeX.Examples/Experimenting/ExampleThreadSafeErrors.cs
+++ b/HtmlForgeX.Examples/Experimenting/ExampleThreadSafeErrors.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HtmlForgeX.Examples.Experimenting;
+
+internal static class ExampleThreadSafeErrors {
+    public static void Create() {
+        var document = new Document();
+        var tasks = new List<Task>();
+        for (int i = 0; i < 5; i++) {
+            int copy = i;
+            tasks.Add(Task.Run(() => document.Configuration.Errors.Add($"error {copy}")));
+        }
+        Task.WaitAll(tasks.ToArray());
+        Console.WriteLine($"Total errors: {document.Configuration.Errors.Count}");
+    }
+}

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -38,6 +38,7 @@ internal class Program {
 
         // Experimental examples (console output)
         Experiments01.Create();
+        ExampleThreadSafeErrors.Create();
 
         // Manual HTML building examples
         BasicHtmlBuilding.Demo1(openInBrowser);

--- a/HtmlForgeX.Tests/TestThreadSafety.cs
+++ b/HtmlForgeX.Tests/TestThreadSafety.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestThreadSafety {
+    [TestMethod]
+    public void DocumentConfiguration_Errors_ConcurrentAdd() {
+        var config = new DocumentConfiguration();
+        var tasks = new List<Task>();
+        for (int i = 0; i < 100; i++) {
+            int copy = i;
+            tasks.Add(Task.Run(() => config.Errors.Add($"err {copy}")));
+        }
+        Task.WaitAll(tasks.ToArray());
+        Assert.AreEqual(100, config.Errors.Count);
+    }
+
+    [TestMethod]
+    public void EmailConfiguration_Errors_ConcurrentAdd() {
+        var config = new EmailConfiguration();
+        var tasks = new List<Task>();
+        for (int i = 0; i < 100; i++) {
+            int copy = i;
+            tasks.Add(Task.Run(() => config.Errors.Add($"err {copy}")));
+        }
+        Task.WaitAll(tasks.ToArray());
+        Assert.AreEqual(100, config.Errors.Count);
+    }
+}

--- a/HtmlForgeX/Containers/Core/EmailConfiguration.cs
+++ b/HtmlForgeX/Containers/Core/EmailConfiguration.cs
@@ -7,6 +7,8 @@ namespace HtmlForgeX;
 /// Manages state, libraries, and settings specific to email generation.
 /// </summary>
 public class EmailConfiguration {
+    private readonly object _syncRoot = new();
+    private string _path = string.Empty;
     /// <summary>
     /// Gets or sets the library mode for this email document.
     /// Email documents only support inline CSS mode.
@@ -21,7 +23,10 @@ public class EmailConfiguration {
     /// <summary>
     /// Gets or sets the file path for this email document.
     /// </summary>
-    public string Path { get; set; } = string.Empty;
+    public string Path {
+        get { lock (_syncRoot) { return _path; } }
+        set { lock (_syncRoot) { _path = value; } }
+    }
 
     /// <summary>
     /// Collection of libraries registered for this email document.
@@ -31,7 +36,7 @@ public class EmailConfiguration {
     /// <summary>
     /// Collection of errors that occurred during email generation.
     /// </summary>
-    public List<string> Errors { get; } = new();
+    public ConcurrentBag<string> Errors { get; } = new();
 
     /// <summary>
     /// Gets or sets the maximum width for the email content (in pixels).

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -7,6 +7,10 @@ namespace HtmlForgeX;
 /// Manages state, libraries, and settings for document generation.
 /// </summary>
 public class DocumentConfiguration {
+    private readonly object _syncRoot = new();
+    private string _path = System.IO.Path.GetTempPath();
+    private string _stylePath = string.Empty;
+    private string _scriptPath = string.Empty;
     /// <summary>
     /// Gets or sets the library mode for this document.
     /// </summary>
@@ -20,17 +24,26 @@ public class DocumentConfiguration {
     /// <summary>
     /// Gets or sets the file path for this document.
     /// </summary>
-    public string Path { get; set; } = System.IO.Path.GetTempPath();
+    public string Path {
+        get { lock (_syncRoot) { return _path; } }
+        set { lock (_syncRoot) { _path = value; } }
+    }
 
     /// <summary>
     /// Gets or sets the style path for this document.
     /// </summary>
-    public string StylePath { get; set; } = string.Empty;
+    public string StylePath {
+        get { lock (_syncRoot) { return _stylePath; } }
+        set { lock (_syncRoot) { _stylePath = value; } }
+    }
 
     /// <summary>
     /// Gets or sets the script path for this document.
     /// </summary>
-    public string ScriptPath { get; set; } = string.Empty;
+    public string ScriptPath {
+        get { lock (_syncRoot) { return _scriptPath; } }
+        set { lock (_syncRoot) { _scriptPath = value; } }
+    }
 
     /// <summary>
     /// Gets or sets whether deferred scripts are enabled.
@@ -50,7 +63,7 @@ public class DocumentConfiguration {
     /// <summary>
     /// Collection of errors that occurred during document generation.
     /// </summary>
-    public List<string> Errors { get; } = new();
+    public ConcurrentBag<string> Errors { get; } = new();
 
     /// <summary>
     /// Email-specific configuration.


### PR DESCRIPTION
## Summary
- safeguard DocumentConfiguration and EmailConfiguration against concurrent access
- show concurrent error tracking in examples
- add multithreaded tests for thread safety

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release -f net8.0 --no-build`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release -f net472 --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6872cb3d78cc832e8f9a4abf47b7a9e6