### PR TITLE
Add radar, heatmap and mixed chart support

### DIFF
--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
@@ -191,6 +191,31 @@ internal class BasicHtmlContainer03 {
                         });
                     });
                 });
+                row.Column(TablerColumnNumber.Four, column => {
+                    column.Card(card => {
+                        card.ApexChart(chart => {
+                            chart.Title.Text("Radar Chart");
+                            chart.AddRadar("R1", 10).AddRadar("R2", 20).AddRadar("R3", 30);
+                        });
+                    });
+                });
+                row.Column(TablerColumnNumber.Four, column => {
+                    column.Card(card => {
+                        card.ApexChart(chart => {
+                            chart.Title.Text("Heatmap Chart");
+                            chart.AddHeatmap("H1", 5).AddHeatmap("H2", 10).AddHeatmap("H3", 15);
+                        });
+                    });
+                });
+                row.Column(TablerColumnNumber.Four, column => {
+                    column.Card(card => {
+                        card.ApexChart(chart => {
+                            chart.Title.Text("Mixed Chart");
+                            chart.AddMixed("bar", "Bar", new[] { 1.0, 2.0, 3.0 });
+                            chart.AddMixed("line", "Line", new[] { 3.0, 4.0, 5.0 });
+                        });
+                    });
+                });
                 row.Column(TablerColumnNumber.Eight, column => {
                     column.Card(card => {
                         card.DiagramNetwork(diagam => {

--- a/HtmlForgeX.Tests/TestApexChartTypeConverter.cs
+++ b/HtmlForgeX.Tests/TestApexChartTypeConverter.cs
@@ -7,10 +7,13 @@ namespace HtmlForgeX.Tests;
 public class TestApexChartTypeConverter {
     [TestMethod]
     public void ApexChartType_SerializesAndDeserializes() {
-        var type = ApexChartType.Bar;
-        var json = JsonSerializer.Serialize(type);
+        var json = JsonSerializer.Serialize(ApexChartType.Bar);
         Assert.AreEqual("\"bar\"", json);
-        var back = JsonSerializer.Deserialize<ApexChartType>(json);
-        Assert.AreEqual(type, back);
+
+        var types = new[] { ApexChartType.Bar, ApexChartType.Radar, ApexChartType.Heatmap, ApexChartType.Mixed };
+        foreach (var type in types) {
+            var roundtrip = JsonSerializer.Deserialize<ApexChartType>(JsonSerializer.Serialize(type));
+            Assert.AreEqual(type, roundtrip);
+        }
     }
 }

--- a/HtmlForgeX.Tests/TestApexCharts.cs
+++ b/HtmlForgeX.Tests/TestApexCharts.cs
@@ -13,4 +13,31 @@ public class TestApexCharts {
         Assert.IsTrue(html.Contains("\"pie\""));
         Assert.IsTrue(html.Contains("A"));
     }
+
+    [TestMethod]
+    public void ApexCharts_GeneratesRadarChartHtml() {
+        var chart = new ApexCharts();
+        chart.AddRadar("A", 5);
+        var html = chart.ToString();
+        Assert.IsTrue(html.Contains("\"radar\""));
+    }
+
+    [TestMethod]
+    public void ApexCharts_GeneratesHeatmapChartHtml() {
+        var chart = new ApexCharts();
+        chart.AddHeatmap("A", 1);
+        var html = chart.ToString();
+        Assert.IsTrue(html.Contains("\"heatmap\""));
+    }
+
+    [TestMethod]
+    public void ApexCharts_GeneratesMixedChartHtml() {
+        var chart = new ApexCharts();
+        chart.AddMixed("bar", "Bar", new[] { 1.0, 2.0 });
+        chart.AddMixed("line", "Line", new[] { 2.0, 3.0 });
+        var html = chart.ToString();
+        Assert.IsTrue(html.Contains("\"series\""));
+        Assert.IsTrue(html.Contains("\"bar\""));
+        Assert.IsTrue(html.Contains("\"line\""));
+    }
 }

--- a/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Linq;
 
 namespace HtmlForgeX;
 
@@ -12,6 +13,7 @@ public class ApexCharts : Element {
     public string Type { get; set; }
     public List<double> Series { get; set; } = new List<double>();
     public List<string> Labels { get; set; } = new List<string>();
+    public List<ApexMixedSeries> MixedSeries { get; set; } = new();
     public ApexChartsTitle Title { get; set; } = new ApexChartsTitle();
     public ApexChartSubtitle Subtitle { get; set; } = new ApexChartSubtitle();
 
@@ -48,6 +50,26 @@ public class ApexCharts : Element {
         return this;
     }
 
+    public ApexCharts AddRadar(string name, double value) {
+        Type = "radar";
+        Labels.Add(name);
+        Series.Add(value);
+        return this;
+    }
+
+    public ApexCharts AddHeatmap(string name, double value) {
+        Type = "heatmap";
+        Labels.Add(name);
+        Series.Add(value);
+        return this;
+    }
+
+    public ApexCharts AddMixed(string type, string name, IEnumerable<double> data) {
+        Type = "line";
+        MixedSeries.Add(new ApexMixedSeries { Name = name, Type = type, Data = data.ToList() });
+        return this;
+    }
+
     public ApexCharts Data(string name, double value) {
         Labels.Add(name);
         Series.Add(value);
@@ -76,7 +98,9 @@ public class ApexCharts : Element {
             options["subtitle"] = Subtitle;
         }
 
-        if (Series.Count > 0) {
+        if (MixedSeries.Count > 0) {
+            options["series"] = MixedSeries;
+        } else if (Series.Count > 0) {
             if (Type == "bar") {
                 options["series"] = new List<object> { new { data = Series } };
             } else {
@@ -100,4 +124,10 @@ public class ApexCharts : Element {
 
         return divTag + scriptTag.ToString();
     }
+}
+
+public class ApexMixedSeries {
+    public string Name { get; set; }
+    public string Type { get; set; }
+    public List<double> Data { get; set; } = new();
 }

--- a/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
@@ -8,7 +8,10 @@ public enum ApexChartType {
     Pie,
     Donut,
     Bar,
-    RadialBar
+    RadialBar,
+    Radar,
+    Heatmap,
+    Mixed
 }
 
 public class ApexChartTypeConverter : JsonConverter<ApexChartType> {
@@ -20,6 +23,9 @@ public class ApexChartTypeConverter : JsonConverter<ApexChartType> {
             "donut" => ApexChartType.Donut,
             "bar" => ApexChartType.Bar,
             "radialBar" => ApexChartType.RadialBar,
+            "radar" => ApexChartType.Radar,
+            "heatmap" => ApexChartType.Heatmap,
+            "mixed" => ApexChartType.Mixed,
             _ => throw new JsonException()
         };
     }
@@ -30,6 +36,9 @@ public class ApexChartTypeConverter : JsonConverter<ApexChartType> {
             ApexChartType.Donut => "donut",
             ApexChartType.Bar => "bar",
             ApexChartType.RadialBar => "radialBar",
+            ApexChartType.Radar => "radar",
+            ApexChartType.Heatmap => "heatmap",
+            ApexChartType.Mixed => "mixed",
             _ => throw new JsonException()
         };
 


### PR DESCRIPTION
## Summary
- extend `ApexChartType` with radar, heatmap and mixed
- add `AddRadar`, `AddHeatmap` and `AddMixed` APIs
- support mixed series in chart serialization
- demonstrate new chart types in example container
- add unit tests for the new types

## Testing
- `dotnet test HtmlForgeX.sln -c Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6872cb88fe54832e9141ae40bf948154