### PR TITLE
Fix library registration collection type

### DIFF
--- a/HtmlForgeX/Containers/Core/EmailConfiguration.cs
+++ b/HtmlForgeX/Containers/Core/EmailConfiguration.cs
@@ -29,9 +29,10 @@ public class EmailConfiguration {
     }
 
     /// <summary>
-    /// Collection of libraries registered for this email document.
+    /// Collection of libraries registered for this email document. Works as a
+    /// set to prevent duplicate library registrations.
     /// </summary>
-    public ConcurrentDictionary<EmailLibraries, int> Libraries { get; } = new();
+    public ConcurrentDictionary<EmailLibraries, byte> Libraries { get; } = new();
 
     /// <summary>
     /// Collection of errors that occurred during email generation.

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -56,9 +56,10 @@ public class DocumentConfiguration {
     public bool DarkModeSupport { get; set; } = true;
 
     /// <summary>
-    /// Collection of libraries registered for this document.
+    /// Collection of libraries registered for this document. Acts as a
+    /// thread-safe set to avoid duplicate registrations.
     /// </summary>
-    public ConcurrentDictionary<Libraries, int> Libraries { get; } = new();
+    public ConcurrentDictionary<Libraries, byte> Libraries { get; } = new();
 
     /// <summary>
     /// Collection of errors that occurred during document generation.


### PR DESCRIPTION
## Summary
- use `byte` values in `ConcurrentDictionary` for tracking libraries
- keep library registration idempotent

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6872d3e1ddf4832e8edf2a27d249204e