### PR TITLE
Add async save error tests

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 using HtmlForgeX.Logging;
 
@@ -47,6 +48,24 @@ public class TestDocumentSaveErrors {
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid()}.html");
         using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
             doc.Save(path);
+        }
+        logger.OnErrorMessage -= handler;
+        File.Delete(path);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, path);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_UnwritableLocation_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+        var doc = new Document();
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, $"file_{Guid.NewGuid():N}.html");
+        using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
+            await doc.SaveAsync(path);
         }
         logger.OnErrorMessage -= handler;
         File.Delete(path);

--- a/HtmlForgeX.Tests/TestEmailSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestEmailSaveErrors.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using HtmlForgeX.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -46,6 +47,24 @@ public class TestEmailSaveErrors {
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid()}.html");
         using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
             email.Save(path);
+        }
+        logger.OnErrorMessage -= handler;
+        File.Delete(path);
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, path);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_UnwritableLocation_LogsError() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnErrorMessage += handler;
+        var email = new Email();
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, $"file_{Guid.NewGuid():N}.html");
+        using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
+            await email.SaveAsync(path);
         }
         logger.OnErrorMessage -= handler;
         File.Delete(path);


### PR DESCRIPTION
## Summary
- extend `TestDocumentSaveErrors` and `TestEmailSaveErrors` to cover async save methods
- use temporary files with open handles to simulate locked files when saving asynchronously

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release -f net472` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d44a77a8832eac0d6917aa9cecff