### PR TITLE
Add converter for FullCalendar JS delegates

### DIFF
--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
@@ -234,6 +234,10 @@ internal class BasicHtmlContainer03 {
                                 .AddEvent("Test Event 2", "Special event 2", DateTime.Today.AddDays(1).AddHours(13))
                                 .Color(RGBColor.Yellow);
 
+                            calendar.Options.EventClick = @"function(info) {
+                                alert('Clicked ' + info.event.title); 
+                            }";
+
                             calendar.AddHeaderToolbar()
                                 .Left(FullCalendarToolbarOption.Prev, FullCalendarToolbarOption.Next,
                                     FullCalendarToolbarOption.Today)

--- a/HtmlForgeX.Tests/TestFullCalendarComponent.cs
+++ b/HtmlForgeX.Tests/TestFullCalendarComponent.cs
@@ -261,4 +261,21 @@ public class TestFullCalendarComponent {
         Assert.IsTrue(html.Contains("Weekly Meeting"), "Should contain recurring event");
         Assert.IsTrue(html.Contains("Team standup"), "Should contain event description");
     }
+
+    [TestMethod]
+    public void FullCalendar_EventHandlersSerialized() {
+        var doc = new Document();
+
+        doc.Body.Add(element => {
+            element.FullCalendar(calendar => {
+                calendar.AddEvent("Test", DateTime.Today);
+            });
+        });
+
+        var html = doc.ToString();
+
+        Assert.IsTrue(html.Contains("\"eventDidMount\":") && html.Contains("function"), "eventDidMount should be serialized as function");
+        Assert.IsTrue(html.Contains("\"eventClick\":") && html.Contains("function"), "eventClick should be serialized as function");
+        Assert.IsFalse(html.Contains("__EVENT_DID_MOUNT__") || html.Contains("__EVENT_CLICK__"), "Placeholders should not appear");
+    }
 }

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
@@ -85,8 +85,6 @@ public class FullCalendar : Element {
 
         var divTag = new HtmlTag("div").Attribute("id", Id).Attribute("class", "calendarFullCalendar");
         var serializedOptions = System.Text.Json.JsonSerializer.Serialize(Options, jsonOptions);
-        serializedOptions = serializedOptions.Replace("\"__EVENT_DID_MOUNT__\"", Options.EventDidMount);
-        serializedOptions = serializedOptions.Replace("\"__EVENT_CLICK__\"", Options.EventClick);
         var scriptTag = new HtmlTag("script").Value($@"
         document.addEventListener('DOMContentLoaded', function () {{
             var calendarEl = document.getElementById('{Id}');

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
@@ -96,3 +96,13 @@ public class RGBColorConverter : JsonConverter<RGBColor> {
         writer.WriteStringValue(value.ToHex());
     }
 }
+
+public class JavaScriptFunctionConverter : JsonConverter<string> {
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        return reader.GetString() ?? string.Empty;
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) {
+        writer.WriteRawValue(value, skipInputValidation: true);
+    }
+}

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
@@ -55,13 +55,8 @@ public class FullCalendarOptions {
     [JsonPropertyName("slotLabelFormat")]
     public FullCalendarEventTimeFormat TimeFormat { get; set; } = new FullCalendarEventTimeFormat();
 
+    [JsonConverter(typeof(JavaScriptFunctionConverter))]
     [JsonPropertyName("eventDidMount")]
-    public string EventDidMountPlaceHolder { get; set; } = "__EVENT_DID_MOUNT__";
-
-    [JsonPropertyName("eventClick")]
-    public string EventClickPlaceHolder { get; set; } = "__EVENT_CLICK__";
-
-    [JsonIgnore()]
     public string EventDidMount { get; set; } = @"
         function (info) {
             var tooltip = new Tooltip(info.el, {
@@ -73,7 +68,8 @@ public class FullCalendarOptions {
         }
     ";
 
-    [JsonIgnore()]
+    [JsonConverter(typeof(JavaScriptFunctionConverter))]
+    [JsonPropertyName("eventClick")]
     public string EventClick { get; set; } = @"
         function (info) {
             var eventObj = info.event;


### PR DESCRIPTION
## Summary
- implement `JavaScriptFunctionConverter` for raw JS serialization
- use converter on FullCalendar event handlers
- remove placeholder replacements in `ToString`
- demonstrate custom event click in example
- test delegate serialization

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build HtmlForgeX/HtmlForgeX.csproj -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_6872d40331c8832eb8516869bae2cbca