### PR TITLE
Fix style append trimming

### DIFF
--- a/HtmlForgeX.Examples/Tags/BasicHtmlTagBuilding03.cs
+++ b/HtmlForgeX.Examples/Tags/BasicHtmlTagBuilding03.cs
@@ -1,0 +1,13 @@
+using HtmlForgeX.Tags;
+
+namespace HtmlForgeX.Examples.Tags;
+
+internal partial class BasicHtmlTagBuilding {
+    public static void Demo7() {
+        var tag = new HtmlTag("span")
+            .Style("color", "red")
+            .Style("font-weight", "bold");
+
+        HelpersSpectre.PrintHtmlTag("HtmlTag - Demo 7", tag);
+    }
+}

--- a/HtmlForgeX.Tests/TestHtmlAdditional.cs
+++ b/HtmlForgeX.Tests/TestHtmlAdditional.cs
@@ -22,7 +22,15 @@ public class TestHtmlAdditional {
     public void HtmlTagClassAndStyleChainingProducesCorrectOutput() {
         var tag = new HtmlTag("p").Style("color", "red").Style("font-size", "12px")
             .Class(null).Class(string.Empty).Class("first").Class("second");
-        Assert.AreEqual("<p style=\"color: red; font-size: 12px;\" class=\"first second\"></p>", tag.ToString());
+        Assert.AreEqual("<p style=\"color: red; font-size: 12px\" class=\"first second\"></p>", tag.ToString());
+    }
+
+    [TestMethod]
+    public void HtmlTagStyleShouldNotHaveTrailingSemicolonOrSpace() {
+        var tag = new HtmlTag("div").Style("margin", "10px").Style("padding", "5px");
+        var html = tag.ToString();
+        Assert.IsFalse(html.Contains(";\""));
+        Assert.AreEqual("<div style=\"margin: 10px; padding: 5px\"></div>", html);
     }
 
     [TestMethod]

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -103,10 +103,20 @@ public class HtmlTag : Element {
     /// <param name="value">The CSS property value.</param>
     /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
     public HtmlTag Style(string name, string value) {
-        if (!Attributes.ContainsKey("style")) {
+        if (!Attributes.ContainsKey("style") || Attributes["style"] is null) {
             Attributes["style"] = string.Empty;
         }
-        Attributes["style"] += $"{name}: {value}; ";
+
+        var current = Attributes["style"]?.ToString() ?? string.Empty;
+        current = current.Trim().TrimEnd(';');
+
+        if (string.IsNullOrEmpty(current)) {
+            current = $"{name}: {value}";
+        } else {
+            current = $"{current}; {name}: {value}";
+        }
+
+        Attributes["style"] = current.Trim().TrimEnd(';');
         return this;
     }
 


### PR DESCRIPTION
## Summary
- trim spaces and semicolons when appending style declarations
- check that style attribute doesn't end with a semicolon or space
- add example showing trimmed style chaining

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6872d40b8804832eb364bcb36de96f08