### PR TITLE
Add file write lock and multithreaded save tests

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveMultithreaded.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveMultithreaded.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDocumentSaveMultithreaded {
+    [TestMethod]
+    public void Save_MultipleThreads_OneFileProduced() {
+        var doc = new Document();
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+
+        var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => doc.Save(path)));
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.IsTrue(File.Exists(path));
+        var files = Directory.GetFiles(Path.GetDirectoryName(path)!, Path.GetFileName(path));
+        Assert.AreEqual(1, files.Length);
+        var content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(doc.ToString(), content);
+        File.Delete(path);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_MultipleThreads_OneFileProduced() {
+        var doc = new Document();
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+
+        var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => doc.SaveAsync(path)));
+        await Task.WhenAll(tasks);
+
+        Assert.IsTrue(File.Exists(path));
+        var files = Directory.GetFiles(Path.GetDirectoryName(path)!, Path.GetFileName(path));
+        Assert.AreEqual(1, files.Length);
+        var content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(doc.ToString(), content);
+        File.Delete(path);
+    }
+}

--- a/HtmlForgeX.Tests/TestEmailSaveMultithreaded.cs
+++ b/HtmlForgeX.Tests/TestEmailSaveMultithreaded.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailSaveMultithreaded {
+    [TestMethod]
+    public void Save_MultipleThreads_OneFileProduced() {
+        var email = new Email();
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+
+        var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => email.Save(path)));
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.IsTrue(File.Exists(path));
+        var files = Directory.GetFiles(Path.GetDirectoryName(path)!, Path.GetFileName(path));
+        Assert.AreEqual(1, files.Length);
+        var content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(email.ToString(), content);
+        File.Delete(path);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_MultipleThreads_OneFileProduced() {
+        var email = new Email();
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
+
+        var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => email.SaveAsync(path)));
+        await Task.WhenAll(tasks);
+
+        Assert.IsTrue(File.Exists(path));
+        var files = Directory.GetFiles(Path.GetDirectoryName(path)!, Path.GetFileName(path));
+        Assert.AreEqual(1, files.Length);
+        var content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(email.ToString(), content);
+        File.Delete(path);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -95,9 +95,12 @@ public class Document : Element {
             }
         }
         try {
+            FileWriteLock.Semaphore.Wait();
             File.WriteAllText(path, ToString(), Encoding.UTF8);
         } catch (Exception ex) {
             _logger.WriteError($"Failed to write file '{path}'. {ex.Message}");
+        } finally {
+            FileWriteLock.Semaphore.Release();
         }
         if (!Helpers.Open(path, openInBrowser)) {
             _logger.WriteError($"Failed to open file '{path}' using the default application.");
@@ -135,16 +138,18 @@ public class Document : Element {
                 _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
             }
         }
+        await FileWriteLock.Semaphore.WaitAsync().ConfigureAwait(false);
         try {
 #if NET5_0_OR_GREATER
             await File.WriteAllTextAsync(path, ToString(), Encoding.UTF8).ConfigureAwait(false);
 #else
             using var writer = new StreamWriter(path, false, Encoding.UTF8);
-            // Prevent returning to the captured context (e.g. UI thread)
             await writer.WriteAsync(ToString()).ConfigureAwait(false);
 #endif
         } catch (Exception ex) {
             _logger.WriteError($"Failed to write file '{path}'. {ex.Message}");
+        } finally {
+            FileWriteLock.Semaphore.Release();
         }
         if (!Helpers.Open(path, openInBrowser)) {
             _logger.WriteError($"Failed to open file '{path}' using the default application.");

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -358,10 +358,13 @@ public class Head : Element {
                         _logger.WriteError($"Failed to create directory '{jsDirectory}'. {ex.Message}");
                     }
                 }
+                FileWriteLock.Semaphore.Wait();
                 try {
                     File.WriteAllText(jsFileName, jsContent, Encoding.UTF8);
                 } catch (Exception ex) {
                     _logger.WriteError($"Failed to write file '{jsFileName}'. {ex.Message}");
+                } finally {
+                    FileWriteLock.Semaphore.Release();
                 }
             }
         }

--- a/HtmlForgeX/Utilities/FileWriteLock.cs
+++ b/HtmlForgeX/Utilities/FileWriteLock.cs
@@ -1,0 +1,5 @@
+namespace HtmlForgeX;
+
+internal static class FileWriteLock {
+    internal static readonly System.Threading.SemaphoreSlim Semaphore = new(1, 1);
+}


### PR DESCRIPTION
## Summary
- protect file writes with a semaphore to prevent concurrent writes
- add tests verifying only one output file is produced

## Testing
- `dotnet test HtmlForgeX.sln -c Release`
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6872d4358870832e868d60542a731374