### PR TITLE
Add DataTables options configuration

### DIFF
--- a/HtmlForgeX.Tests/TestDataTablesOptions.cs
+++ b/HtmlForgeX.Tests/TestDataTablesOptions.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDataTablesOptions
+{
+    [TestMethod]
+    public void ConfigureOptions_ShouldSerializeValues()
+    {
+        var table = new DataTablesTable();
+        table.Configure(o =>
+        {
+            o.PageLength = 25;
+            o.StateSave = true;
+        });
+
+        var html = table.ToString();
+        StringAssert.Contains(html, "\"pageLength\": 25");
+        StringAssert.Contains(html, "\"stateSave\": true");
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
@@ -1,0 +1,108 @@
+using System.Text.Json.Serialization;
+
+namespace HtmlForgeX;
+
+public class DataTablesOptions
+{
+    [JsonPropertyName("pageLength")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? PageLength { get; set; }
+
+    [JsonPropertyName("lengthMenu")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int[]? LengthMenu { get; set; }
+
+    [JsonPropertyName("stateSave")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? StateSave { get; set; }
+
+    [JsonPropertyName("scrollY")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ScrollY { get; set; }
+
+    [JsonPropertyName("scrollCollapse")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ScrollCollapse { get; set; }
+
+    [JsonPropertyName("autoWidth")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? AutoWidth { get; set; }
+
+    [JsonPropertyName("deferRender")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? DeferRender { get; set; }
+
+    [JsonPropertyName("processing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Processing { get; set; }
+
+    [JsonPropertyName("serverSide")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ServerSide { get; set; }
+
+    [JsonPropertyName("language")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DataTablesLanguage? Language { get; set; }
+
+    [JsonPropertyName("dom")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Dom { get; set; }
+}
+
+public class DataTablesLanguage
+{
+    [JsonPropertyName("search")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Search { get; set; }
+
+    [JsonPropertyName("lengthMenu")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LengthMenu { get; set; }
+
+    [JsonPropertyName("info")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Info { get; set; }
+
+    [JsonPropertyName("infoEmpty")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InfoEmpty { get; set; }
+
+    [JsonPropertyName("infoFiltered")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InfoFiltered { get; set; }
+
+    [JsonPropertyName("loadingRecords")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LoadingRecords { get; set; }
+
+    [JsonPropertyName("processing")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Processing { get; set; }
+
+    [JsonPropertyName("zeroRecords")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ZeroRecords { get; set; }
+
+    [JsonPropertyName("paginate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DataTablesPaginate? Paginate { get; set; }
+}
+
+public class DataTablesPaginate
+{
+    [JsonPropertyName("first")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? First { get; set; }
+
+    [JsonPropertyName("last")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Last { get; set; }
+
+    [JsonPropertyName("next")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Next { get; set; }
+
+    [JsonPropertyName("previous")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Previous { get; set; }
+}

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+
 
 namespace HtmlForgeX;
 
@@ -8,6 +10,8 @@ public class DataTablesTable : Table {
     public string Id;
     public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();
     private readonly Dictionary<string, object> config = new Dictionary<string, object>();
+
+    public DataTablesOptions Options { get; } = new();
 
     public bool EnablePaging {
         get => config.ContainsKey("paging") && (bool)config["paging"];
@@ -42,6 +46,11 @@ public class DataTablesTable : Table {
         return this;
     }
 
+    public DataTablesTable Configure(Action<DataTablesOptions> configure) {
+        configure?.Invoke(Options);
+        return this;
+    }
+
     public override string BuildTable() {
         string tableInside = base.BuildTable();
         string classNames = StyleList.BuildTableStyles();
@@ -51,8 +60,14 @@ public class DataTablesTable : Table {
             .Value(tableInside)
             .Attribute("width", "100%");
 
-        //var configuration = System.Text.Json.JsonSerializer.Serialize(config);
-        var configuration = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        var merged = new Dictionary<string, object>(config);
+        var optionsJson = JsonSerializer.Serialize(Options, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        var optionsDict = JsonSerializer.Deserialize<Dictionary<string, object>>(optionsJson) ?? new Dictionary<string, object>();
+        foreach (var kv in optionsDict) {
+            merged[kv.Key] = kv.Value;
+        }
+
+        var configuration = JsonSerializer.Serialize(merged, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
 
         var scriptTag = new HtmlTag("script").Value($@"
         $(document).ready(function() {{


### PR DESCRIPTION
## Summary
- introduce `DataTablesOptions` for advanced DataTable configuration
- allow `DataTablesTable` to serialize new options
- add unit test verifying option serialization

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6872d4aa3dec832eb179a3b75f79c5f9