### PR TITLE
Handle missing file in IsFileLocked

### DIFF
--- a/HtmlForgeX.Tests/TestHelpers.cs
+++ b/HtmlForgeX.Tests/TestHelpers.cs
@@ -26,4 +26,21 @@ public class TestHelpers {
         Assert.IsFalse(lockedViaPath);
         File.Delete(path);
     }
+
+    [TestMethod]
+    public void IsFileLocked_ReturnsFalseForMissingFileInfo() {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, Path.GetRandomFileName());
+        var fileInfo = new FileInfo(path);
+        var lockedViaInfo = fileInfo.IsFileLocked();
+        Assert.IsFalse(lockedViaInfo);
+    }
+
+    [TestMethod]
+    public void IsFileLocked_ReturnsFalseForMissingPath() {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, Path.GetRandomFileName());
+        var lockedViaPath = path.IsFileLocked();
+        Assert.IsFalse(lockedViaPath);
+    }
 }

--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -61,6 +61,9 @@ internal static class Helpers {
     /// <param name="file"></param>
     /// <returns></returns>
     public static bool IsFileLocked(this FileInfo file) {
+        if (!file.Exists) {
+            return false;
+        }
         try {
             using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
                 stream.Close();
@@ -89,6 +92,9 @@ internal static class Helpers {
     /// <param name="fileName"></param>
     /// <returns></returns>
     public static bool IsFileLocked(this string fileName) {
+        if (!File.Exists(fileName)) {
+            return false;
+        }
         try {
             var file = new FileInfo(fileName);
             using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {


### PR DESCRIPTION
## Summary
- return `false` when checking if nonexistent files are locked
- add tests verifying `IsFileLocked` handles nonexistent file paths

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68734b9dd278832eb7c480fc82396053