### PR TITLE
Improve stream disposal logic

### DIFF
--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer04.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer04.cs
@@ -12,21 +12,6 @@ internal class BasicHtmlContainer04 {
             new { Name = "Bob", Age = 35, Occupation = "Architect" }
         };
 
-        var logs =
-            """
-            Effective URL            https://evotec.xyz
-            Redirect count           0
-            Name lookup time         3.4e-05
-            Connect time             0.000521
-            Pre-transfer time        0.0
-            Start-transfer time      0.0
-            App connect time         0.0
-            Redirect time            0.0
-            Total time               28.000601
-            Response code            0
-            Return keyword           operation_timedout
-            """;
-
         var document = new Document {
             Head = {
                 Title = "Basic Demo Document Container 4", Author = "Przemysław Kłys", Revised = DateTime.Now,

--- a/HtmlForgeX.Tests/HtmlForgeX.Tests.csproj
+++ b/HtmlForgeX.Tests/HtmlForgeX.Tests.csproj
@@ -24,6 +24,10 @@
         <ProjectReference Include="..\HtmlForgeX\HtmlForgeX.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)'=='net472' OR '$(TargetFramework)'=='net48'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+
     <ItemGroup>
         <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     </ItemGroup>

--- a/HtmlForgeX.Tests/TestLibraryDownloader.cs
+++ b/HtmlForgeX.Tests/TestLibraryDownloader.cs
@@ -39,6 +39,23 @@ public class TestLibraryDownloader {
         return prefix;
     }
 
+    private static string StartErrorServer() {
+        int port = GetFreePort();
+        string prefix = $"http://localhost:{port}/";
+        HttpListener listener = new();
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        _ = Task.Run(async () =>
+        {
+            var context = await listener.GetContextAsync();
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            context.Response.KeepAlive = false;
+            context.Response.Close();
+            listener.Close();
+        });
+        return prefix;
+    }
+
     private static async Task RunTestAsync(string extension, string folder) {
         string prefix = StartServer();
         string url = $"{prefix}file{extension}";
@@ -57,6 +74,20 @@ public class TestLibraryDownloader {
     [DataRow(".svg", "Images")]
     public async Task DownloadFilePlacesCorrectly(string extension, string folder) {
         await RunTestAsync(extension, folder);
+    }
+
+    [TestMethod]
+    public async Task DownloadFileDisposesFileOnError() {
+        string prefix = StartErrorServer();
+        string url = $"{prefix}file.css";
+        string tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString());
+        var downloader = new LibraryDownloader();
+        await Assert.ThrowsExceptionAsync<HttpRequestException>(() => downloader.DownloadFileAsync(tempDir, url));
+        string expected = Path.Combine(tempDir, "Styles", "file.css");
+        Assert.IsTrue(File.Exists(expected));
+        using var fs = File.Open(expected, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        fs.Close();
+        Directory.Delete(tempDir, true);
     }
 
 

--- a/HtmlForgeX.Tests/TestLibraryDownloader.cs
+++ b/HtmlForgeX.Tests/TestLibraryDownloader.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -62,9 +62,8 @@ internal static class Helpers {
     /// <returns></returns>
     public static bool IsFileLocked(this FileInfo file) {
         try {
-            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
-                stream.Close();
-            }
+            using var stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
+            stream.Close();
         } catch (IOException) {
             //the file is unavailable because it is:
             //still being written to
@@ -91,9 +90,8 @@ internal static class Helpers {
     public static bool IsFileLocked(this string fileName) {
         try {
             var file = new FileInfo(fileName);
-            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None)) {
-                stream.Close();
-            }
+            using var stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
+            stream.Close();
         } catch (IOException) {
             //the file is unavailable because it is:
             //still being written to

--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -64,10 +64,10 @@ public class LibraryDownloader {
     public async Task<List<string>> GenerateTablerIconCodeAsync(string cssFilePath) {
         var icons = new List<string>();
         string cssText;
-#if NET472
-        using var stream = File.OpenRead(cssFilePath);
-#else
+#if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         await using var stream = File.OpenRead(cssFilePath);
+#else
+        using var stream = File.OpenRead(cssFilePath);
 #endif
         using var reader = new StreamReader(stream);
         cssText = await reader.ReadToEndAsync().ConfigureAwait(false);
@@ -112,10 +112,10 @@ public class LibraryDownloader {
         } catch (Exception ex) {
             _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
         }
-#if NET472
-        using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
-#else
+#if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
+#else
+        using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
 #endif
         using HttpResponseMessage response = await _client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
@@ -123,10 +123,10 @@ public class LibraryDownloader {
             throw new HttpRequestException($"Request for '{url}' failed with status code {response.StatusCode}");
         }
 
-#if NET472
-        using var httpStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#else
+#if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         await using var httpStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        using var httpStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
         await httpStream.CopyToAsync(fileStream).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary
- ensure icon and library downloads use `await using`
- update file lock helpers to modern `using var`
- verify file streams are closed on download error

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68734b8342bc832eb1d61ce49c1a3ed4