### PR TITLE
Fix null children iterations

### DIFF
--- a/HtmlForgeX.Tests/TestNullChildFiltering.cs
+++ b/HtmlForgeX.Tests/TestNullChildFiltering.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestNullChildFiltering {
+    [TestMethod]
+    public void DocumentToString_IgnoresNullChildren() {
+        var document = new Document();
+        document.Body.Children.Add(null);
+        document.Body.Children.Add(new Span().AddContent("Test"));
+
+        var html = document.ToString();
+
+        Assert.IsTrue(html.Contains("Test"));
+    }
+
+    [TestMethod]
+    public void SpanToString_IgnoresNullChildren() {
+        var span = new Span();
+        span.Children.Add(null);
+        span.Children.Add(new Span { Content = "Inner" });
+
+        var html = span.ToString();
+
+        Assert.IsTrue(html.Contains("Inner"));
+    }
+}

--- a/HtmlForgeX/Containers/Core/BasicElement.cs
+++ b/HtmlForgeX/Containers/Core/BasicElement.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -68,7 +71,7 @@ public class BasicElement : Element {
         }
 
         // Render child elements
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             var childContent = child.ToString();
             if (!string.IsNullOrEmpty(childContent)) {
                 html.AppendLine(childContent);

--- a/HtmlForgeX/Containers/Core/Body.cs
+++ b/HtmlForgeX/Containers/Core/Body.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Linq;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -81,7 +83,7 @@ public class Body : Element {
         }
 
         // Add the HTML of the child elements
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             bodyBuilder.AppendLine(child.ToString());
         }
 

--- a/HtmlForgeX/Containers/Core/Document.cs
+++ b/HtmlForgeX/Containers/Core/Document.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 using HtmlForgeX.Logging;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -193,7 +195,7 @@ public class Document : Element {
     /// </summary>
     /// <param name="element">The element to process.</param>
     private void RegisterLibrariesFromElement(Element element) {
-        foreach (var child in element.Children) {
+        foreach (var child in element.Children.WhereNotNull()) {
             child.RegisterLibraries();
             RegisterLibrariesFromElement(child);
         }

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using HtmlForgeX.Tags;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -66,7 +68,7 @@ public abstract class Element {
     /// Recursively sets the document reference for all child elements.
     /// </summary>
     private void PropagateDocumentToChildren() {
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             child.Document = Document;
         }
     }
@@ -75,7 +77,7 @@ public abstract class Element {
     /// Recursively sets the email reference for all child elements.
     /// </summary>
     private void PropagateEmailToChildren() {
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             child.Email = Email;
         }
     }

--- a/HtmlForgeX/Containers/Core/ElementContainer.cs
+++ b/HtmlForgeX/Containers/Core/ElementContainer.cs
@@ -1,7 +1,10 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class ElementContainer : Element {
     public override string ToString() {
-        return string.Join("", Children.Select(child => child.ToString()));
+        return string.Join("", Children.WhereNotNull().Select(child => child.ToString()));
     }
 }

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 using HtmlForgeX.Logging;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -384,7 +386,7 @@ public class Email : Element {
     /// </summary>
     /// <param name="element">The element to process.</param>
     private void RegisterLibrariesFromElement(Element element) {
-        foreach (var child in element.Children) {
+        foreach (var child in element.Children.WhereNotNull()) {
             child.RegisterLibraries();
             RegisterLibrariesFromElement(child);
         }

--- a/HtmlForgeX/Containers/Core/EmailBody.cs
+++ b/HtmlForgeX/Containers/Core/EmailBody.cs
@@ -1,5 +1,7 @@
 using System.Text;
+using System.Linq;
 using HtmlForgeX.Logging;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -156,7 +158,7 @@ public class EmailBody : Element {
         body.AppendLine("\t\t\t\t\t\t\t<td class=\"p-sm\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; padding: 8px;\">");
 
         // Render child elements
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             var childContent = child.ToString();
             if (!string.IsNullOrEmpty(childContent)) {
                 body.AppendLine(childContent);

--- a/HtmlForgeX/Containers/Core/EmailHead.cs
+++ b/HtmlForgeX/Containers/Core/EmailHead.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text;
+using System.Linq;
+using HtmlForgeX.Extensions;
 using HtmlForgeX.Logging;
 
 namespace HtmlForgeX;
@@ -215,7 +217,7 @@ public class EmailHead : Element {
     /// <returns>A string that represents the head section of an email document.</returns>
     public override string ToString() {
         // Process any registered email libraries
-        foreach (var libraryEnum in _email.Configuration.Email.Libraries.Keys) {
+        foreach (var libraryEnum in _email.Configuration.Email.Libraries.Keys.WhereNotNull()) {
             var library = EmailLibrariesConverter.MapLibraryEnumToLibraryObject(libraryEnum);
             ProcessEmailLibrary(library);
         }
@@ -249,7 +251,7 @@ public class EmailHead : Element {
         }
 
         // Additional meta tags
-        foreach (var metaTag in MetaTags) {
+        foreach (var metaTag in MetaTags.WhereNotNull()) {
             head.AppendLine($"\t{metaTag.ToString()}");
         }
 
@@ -306,7 +308,7 @@ public class EmailHead : Element {
         // Inline styles
         if (InlineStyles.Count > 0) {
             head.AppendLine("\t<style>");
-            foreach (var style in InlineStyles) {
+            foreach (var style in InlineStyles.WhereNotNull()) {
                 head.AppendLine(style);
             }
             head.AppendLine("\t</style>");
@@ -318,7 +320,7 @@ public class EmailHead : Element {
 
     private void ProcessEmailLibrary(EmailLibrary library) {
         // Add inline CSS from the library
-        foreach (var css in library.InlineCss) {
+        foreach (var css in library.InlineCss.WhereNotNull()) {
             AddCssInline(css);
         }
     }

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using System.Collections.Concurrent;
 using System.Collections;
 using System.Text;
+using System.Linq;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -82,7 +84,7 @@ public class Table : Element {
 
         if (firstObject is IEnumerable enumerable && firstObject is not string && firstObject is not IDictionary) {
             var flattened = new List<object>();
-            foreach (var obj in objects) {
+            foreach (var obj in objects.WhereNotNull()) {
                 if (obj is IEnumerable inner && obj is not string && obj is not IDictionary) {
                     foreach (var innerItem in inner) {
                         flattened.Add(innerItem!);
@@ -126,7 +128,7 @@ public class Table : Element {
         }
 
         // Add the rows
-        foreach (var obj in objects) {
+        foreach (var obj in objects.WhereNotNull()) {
             var row = new List<string>();
             foreach (var property in properties) {
                 try {
@@ -196,7 +198,7 @@ public class Table : Element {
             }
 
             // Add the rows
-            foreach (var obj in objects) {
+            foreach (var obj in objects.WhereNotNull()) {
                 var row = new List<string>();
                 foreach (var property in GetPsObjectProperties(obj)) {
                     row.Add(property.Value?.ToString() ?? "");
@@ -222,7 +224,7 @@ public class Table : Element {
             var enumerable = propertiesValue as IEnumerable;
 
             if (enumerable != null) {
-                foreach (var item in enumerable) {
+                foreach (var item in enumerable.Cast<object?>().WhereNotNull()) {
                     var nameProperty = GetCachedProperty(item.GetType(), "Name");
                     var valueProperty = GetCachedProperty(item.GetType(), "Value");
 

--- a/HtmlForgeX/Containers/Email/EmailColumn.cs
+++ b/HtmlForgeX/Containers/Email/EmailColumn.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Linq;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -227,7 +229,7 @@ public class EmailColumn : Element {
 
         var content = StringBuilderCache.Acquire();
 
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             var childContent = child.ToString();
             if (!string.IsNullOrEmpty(childContent)) {
                 content.AppendLine(childContent);

--- a/HtmlForgeX/Containers/Email/EmailHeader.cs
+++ b/HtmlForgeX/Containers/Email/EmailHeader.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -50,7 +53,7 @@ public class EmailHeader : Element {
         element.Email = email;
 
         // Recursively propagate to all children
-        foreach (var child in element.Children) {
+        foreach (var child in element.Children.WhereNotNull()) {
             PropagateEmailReference(child, email);
         }
     }
@@ -169,7 +172,7 @@ public class EmailHeader : Element {
         html.AppendLine($@"  <tr>");
         html.AppendLine($@"    <td style=""padding: {Padding};"">");
 
-        foreach (var child in base.Children) {
+        foreach (var child in base.Children.WhereNotNull()) {
             html.AppendLine(child.ToString());
         }
 

--- a/HtmlForgeX/Containers/Email/EmailList.cs
+++ b/HtmlForgeX/Containers/Email/EmailList.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -160,12 +163,12 @@ public class EmailList : Element {
 ");
 
         // Render items
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             html.AppendLine(item.ToString());
         }
 
         // Render child elements (nested lists, etc.)
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             html.AppendLine(child.ToString());
         }
 

--- a/HtmlForgeX/Containers/Email/EmailTable.cs
+++ b/HtmlForgeX/Containers/Email/EmailTable.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Linq;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -197,7 +199,7 @@ public class EmailTable : Element {
         AddHeader(properties);
 
         // Add rows from data
-        foreach (var item in dataList) {
+        foreach (var item in dataList.WhereNotNull()) {
             var values = new string[properties.Length];
             for (int i = 0; i < properties.Length; i++) {
                 var prop = typeof(T).GetProperty(properties[i]);
@@ -237,7 +239,7 @@ public class EmailTable : Element {
         AddHeader(properties);
 
         // Add rows from data
-        foreach (var item in dataList) {
+        foreach (var item in dataList.WhereNotNull()) {
             var values = new string[properties.Length];
             for (int i = 0; i < properties.Length; i++) {
                 var prop = item.GetType().GetProperty(properties[i]);

--- a/HtmlForgeX/Containers/Email/EmailTextBox.cs
+++ b/HtmlForgeX/Containers/Email/EmailTextBox.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -248,7 +251,7 @@ public class EmailTextBox : Element {
         }
 
         // Render child elements (nested content)
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             html.AppendLine(child.ToString());
         }
 

--- a/HtmlForgeX/Containers/ScrollingText/ScrollingText.cs
+++ b/HtmlForgeX/Containers/ScrollingText/ScrollingText.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -56,7 +59,7 @@ public class ScrollingText : Element {
         var sectionScrollingDiv = new HtmlTag("div").Attribute("class", "sectionScrolling");
         var divTagEmpty = new HtmlTag("div");
 
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             divTagEmpty.Value(item);
         }
 
@@ -75,7 +78,7 @@ public class ScrollingText : Element {
         var navTag = new HtmlTag("nav").Attribute("class", "section-nav");
         var olTag = new HtmlTag("ol");
 
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             olTag.Value(RenderNavItem(item));
         }
 

--- a/HtmlForgeX/Containers/ScrollingText/ScrollingTextItem.cs
+++ b/HtmlForgeX/Containers/ScrollingText/ScrollingTextItem.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -59,12 +62,12 @@ public class ScrollingTextItem : Element {
         }
 
         // Render all child elements recursively
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             sectionTag.Value(child);
         }
 
         // Render all nested items (aka ScrollingTextItems)
-        foreach (var child in Items) {
+        foreach (var child in Items.WhereNotNull()) {
             sectionTag.Value(child);
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerAccordion.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAccordion.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerAccordion : Element {
@@ -32,7 +35,7 @@ public class TablerAccordion : Element {
     public override string ToString() {
         var accordionDiv = new HtmlTag("div").Class("accordion").Id(Id);
 
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             accordionDiv.Value(item);
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerCard.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCard.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerCard : Element {
@@ -57,7 +60,7 @@ public class TablerCard : Element {
         cardDiv.Value(cardBodyDiv);
 
         // Add any child elements to the card body
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             cardBodyDiv.Value(child);
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerCardFooter : Element {
@@ -14,7 +17,7 @@ public class TablerCardFooter : Element {
             var footerDiv = new HtmlTag("div");
             footerDiv.Class("card-footer").Value(Content);
 
-            foreach (var child in Children) {
+            foreach (var child in Children.WhereNotNull()) {
                 footerDiv.Value(child);
             }
 

--- a/HtmlForgeX/Containers/Tabler/TablerColumn.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerColumn.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerColumn : Element {
@@ -21,7 +24,7 @@ public class TablerColumn : Element {
 
     public override string ToString() {
         //Console.WriteLine("Generating HtmlColumn...");
-        var childrenHtml = string.Join("", Children.Select(child => child.ToString()));
+        var childrenHtml = string.Join("", Children.WhereNotNull().Select(child => child.ToString()));
         var result = $"<div class=\"{Class}\">{childrenHtml}</div>";
         //Console.WriteLine("Generated HtmlColumn: " + result);
         return result;

--- a/HtmlForgeX/Containers/Tabler/TablerDataGrid.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerDataGrid.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerDataGrid : Element {
@@ -30,7 +33,7 @@ public class TablerDataGrid : Element {
         var html = StringBuilderCache.Acquire();
         html.Append("<div class=\"datagrid\">");
 
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             html.Append(item.ToString());
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerIcon.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerIcon.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
@@ -201,7 +203,7 @@ public class TablerIcon : Element {
             container.Class(ContainerClasses);
         }
 
-        foreach (var style in ContainerStyles) {
+        foreach (var style in ContainerStyles.WhereNotNull()) {
             container.Style(style.Key, style.Value);
         }
 
@@ -209,14 +211,14 @@ public class TablerIcon : Element {
         var svg = new HtmlTag("svg");
 
         // Add all SVG attributes
-        foreach (var attr in SvgAttributes) {
+        foreach (var attr in SvgAttributes.WhereNotNull()) {
             svg.Attribute(attr.Key, attr.Value);
         }
 
         // Add SVG styles
         if (SvgStyles.Count > 0) {
             var styleBuilder = new StringBuilder();
-            foreach (var style in SvgStyles) {
+            foreach (var style in SvgStyles.WhereNotNull()) {
                 styleBuilder.Append($"{style.Key}:{style.Value};");
             }
             svg.Attribute("style", styleBuilder.ToString());

--- a/HtmlForgeX/Containers/Tabler/TablerPage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerPage.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerPage : Element {
@@ -29,7 +32,7 @@ public class TablerPage : Element {
         pageWrapper.Value(pageBody);
 
         var container = new HtmlTag("div").Class("container-xl");
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             container.Value(child);
         }
         pageBody.Value(container);

--- a/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -144,7 +147,7 @@ public class TablerProgressBar : Element {
         }
         // TODO: We need to add handling for mb-3 and similar for margins and padding
 
-        foreach (var item in Items) {
+        foreach (var item in Items.WhereNotNull()) {
             progressBarTag.Value(item);
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerRow.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerRow.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -22,7 +25,7 @@ public class TablerRow : Element {
         foreach (var rowType in RowTypes) {
             rowTag.Class(rowType.EnumToString());
         }
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             rowTag.Value(child);
         }
         return rowTag.ToString();

--- a/HtmlForgeX/Containers/Tabler/TablerSteps.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerSteps.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerSteps : Element {
@@ -40,7 +43,7 @@ public class TablerSteps : Element {
         }
         stepsUl.Class(PrivateStepsColor?.ToTablerSteps());
 
-        foreach (var stepItem in StepItems) {
+        foreach (var stepItem in StepItems.WhereNotNull()) {
             stepsUl.Value(stepItem.ToString(PrivateOrientation));
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerTabs.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTabs.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerTabs : Element {
@@ -36,7 +39,7 @@ public class TablerTabs : Element {
 
         var cardBodyDiv = new HtmlTag("div").Class("card-body");
 
-        foreach (var panel in Panels) {
+        foreach (var panel in Panels.WhereNotNull()) {
             tabsDiv.Value(panel);
             var anchor = new Anchor()
                 .Class("nav-link")

--- a/HtmlForgeX/Containers/Tabler/TablerTabsPanel.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTabsPanel.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerTabsPanel : ElementContainer {
@@ -48,7 +51,7 @@ public class TablerTabsPanel : ElementContainer {
             .Id(Id);
 
         // Convert child elements to string and add them to the panelDiv
-        foreach (var child in Children) {
+        foreach (var child in Children.WhereNotNull()) {
             panelDiv.Value(child);
         }
 

--- a/HtmlForgeX/Containers/Tabler/TablerTracking.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTracking.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class TablerTracking : Element {
@@ -16,7 +19,7 @@ public class TablerTracking : Element {
     public override string ToString() {
         var trackingContainerTag = new HtmlTag("div").Class("tracking");
 
-        foreach (var block in Blocks) {
+        foreach (var block in Blocks.WhereNotNull()) {
             trackingContainerTag.Value(block);
         }
 

--- a/HtmlForgeX/Extensions/EnumerableExtensions.cs
+++ b/HtmlForgeX/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,9 @@
+namespace HtmlForgeX.Extensions;
+
+internal static class EnumerableExtensions
+{
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
+    {
+        return source.Where(item => item is not null)!;
+    }
+}

--- a/HtmlForgeX/Extensions/EnumerableExtensions.cs
+++ b/HtmlForgeX/Extensions/EnumerableExtensions.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Extensions;
 
 internal static class EnumerableExtensions
 {
-    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T> source)
     {
         return source.Where(item => item is not null)!;
     }

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Globalization;
+using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 /// <summary>
@@ -190,7 +192,7 @@ public class HtmlTag : Element {
         } else {
             // if the tag is normal we add the children
             html.Append(">");
-            foreach (var child in Children) {
+            foreach (var child in Children.WhereNotNull()) {
                 if (child is string str) {
                     //html.Append(Helpers.HtmlEncode(str));
                     html.Append(str);

--- a/HtmlForgeX/Tags/Span.cs
+++ b/HtmlForgeX/Tags/Span.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 public class Span : Element {
@@ -381,9 +384,9 @@ public class Span : Element {
         var styleString = GenerateStyle();
         styleString = !string.IsNullOrEmpty(styleString) ? $" style=\"{Helpers.HtmlEncode(styleString)}\"" : "";
 
-        var childrenHtml = string.Join("", Children.Select(child => child.ToString()));
+        var childrenHtml = string.Join("", Children.WhereNotNull().Select(child => child.ToString()));
 
-        var childrenParentHtml = string.Join("", this.Parent.HtmlSpans.Select(child => {
+        var childrenParentHtml = string.Join("", this.Parent.HtmlSpans.WhereNotNull().Select(child => {
             var childStyle = child.GenerateStyle();
             childStyle = !string.IsNullOrEmpty(childStyle) ? $" style=\"{Helpers.HtmlEncode(childStyle)}\"" : "";
             var content = Helpers.HtmlEncode(child.Content ?? string.Empty);


### PR DESCRIPTION
## Summary
- add `WhereNotNull` enumerable extension
- skip null children when generating HTML
- test ignoring null children

## Testing
- `dotnet test -c Release` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68734b900100832e81615fee1b328090