### PR TITLE
Add XML docs to various core types

### DIFF
--- a/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
@@ -3,6 +3,9 @@ using System.Text.Json;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Supported ApexChart chart types.
+/// </summary>
 [JsonConverter(typeof(ApexChartTypeConverter))]
 public enum ApexChartType {
     Pie,

--- a/HtmlForgeX/Containers/ChartJs/ChartJs.cs
+++ b/HtmlForgeX/Containers/ChartJs/ChartJs.cs
@@ -3,7 +3,13 @@ using System.Text.Json;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Helper for building simple Chart.js charts.
+/// </summary>
 public class ChartJs : Element {
+    /// <summary>
+    /// Gets or sets the canvas identifier.
+    /// </summary>
     public string Id { get; set; }
     public ChartJsType Type { get; set; } = ChartJsType.Bar;
     public List<string> Labels { get; } = new();

--- a/HtmlForgeX/Containers/ChartJs/ChartJsType.cs
+++ b/HtmlForgeX/Containers/ChartJs/ChartJsType.cs
@@ -4,6 +4,9 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Available Chart.js chart types.
+/// </summary>
 [JsonConverter(typeof(ChartJsTypeConverter))]
 public enum ChartJsType {
     Line,

--- a/HtmlForgeX/Containers/Core/ElementContainer.cs
+++ b/HtmlForgeX/Containers/Core/ElementContainer.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Basic container element rendering its children.
+/// </summary>
 public class ElementContainer : Element {
     public override string ToString() {
         return string.Join("", Children.Select(child => child.ToString()));

--- a/HtmlForgeX/Containers/Core/Enums/AnalyticsProvider.cs
+++ b/HtmlForgeX/Containers/Core/Enums/AnalyticsProvider.cs
@@ -1,7 +1,11 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Supported analytics providers.
+/// </summary>
 public enum AnalyticsProvider
 {
+    /// <summary>No provider.</summary>
     None,
     GoogleAnalytics,
     CloudflareInsights

--- a/HtmlForgeX/Containers/Core/Enums/Direction.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Direction.cs
@@ -1,6 +1,11 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Text direction.
+/// </summary>
 public enum Direction {
-    Ltr,  // Left-to-right
-    Rtl   // Right-to-left
+    /// <summary>Left to right.</summary>
+    Ltr,
+    /// <summary>Right to left.</summary>
+    Rtl
 }

--- a/HtmlForgeX/Containers/Core/Enums/Display.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Display.cs
@@ -2,8 +2,12 @@ using System.ComponentModel;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// CSS <c>display</c> property values.
+/// </summary>
 public enum Display {
     [Description("none")]
+    /// <summary>Specifies <c>display: none</c>.</summary>
     None = 1,
 
     [Description("inline")]

--- a/HtmlForgeX/Containers/Core/Enums/FontStyle.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontStyle.cs
@@ -1,6 +1,10 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// CSS font-style options.
+/// </summary>
 public enum FontStyle {
+    /// <summary>Normal style.</summary>
     Normal = 1,
     Italic,
     Oblique

--- a/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
@@ -1,11 +1,17 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// CSS font-variant values.
+/// </summary>
 public enum FontVariant {
     Normal = 1,
     SmallCaps
 }
 
 public static class FontVariantExtensions {
+    /// <summary>
+    /// Converts the variant to its CSS string.
+    /// </summary>
     public static string EnumToString(this FontVariant value) {
         return value switch {
             FontVariant.Normal => "normal",

--- a/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
+++ b/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
@@ -1,6 +1,10 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// HTML heading level tags.
+/// </summary>
 public enum HeaderLevelTag {
+    /// <summary>&lt;h1&gt; element.</summary>
     H1,
     H2,
     H3,

--- a/HtmlForgeX/Containers/Core/Enums/LibraryMode.cs
+++ b/HtmlForgeX/Containers/Core/Enums/LibraryMode.cs
@@ -1,4 +1,7 @@
 namespace HtmlForgeX;
+/// <summary>
+/// Determines how libraries are loaded.
+/// </summary>
 public enum LibraryMode {
     Online,
     Offline,

--- a/HtmlForgeX/Containers/Core/Enums/TableType.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TableType.cs
@@ -1,4 +1,7 @@
 namespace HtmlForgeX;
+/// <summary>
+/// Table library type.
+/// </summary>
 public enum TableType {
     None,
     BootstrapTable,

--- a/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
@@ -2,8 +2,12 @@ using System.ComponentModel;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Text decoration values.
+/// </summary>
 public enum TextDecoration {
     [Description("none")]
+    /// <summary>No decoration.</summary>
     None = 1,
 
     [Description("line-through")]

--- a/HtmlForgeX/Containers/Core/Enums/TextTransform.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextTransform.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Text transformation options.
+/// </summary>
 public enum TextTransform {
     Uppercase,
     Lowercase,

--- a/HtmlForgeX/Containers/Core/Enums/ThemeMode.cs
+++ b/HtmlForgeX/Containers/Core/Enums/ThemeMode.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Theme mode selection.
+/// </summary>
 public enum ThemeMode {
     System,
     Light,

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -4,7 +4,13 @@ using System.Text.Json;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Table integrated with the DataTables library.
+/// </summary>
 public class DataTablesTable : Table {
+    /// <summary>
+    /// Gets the table identifier.
+    /// </summary>
     public string Id;
     public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();
     private readonly Dictionary<string, object> config = new Dictionary<string, object>();

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
@@ -3,6 +3,9 @@ using System.Reflection;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Converts <see cref="DateTime"/> values to ISO-8601 date strings.
+/// </summary>
 public class Iso8601DateConverter : JsonConverter<DateTime> {
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         return DateTime.Parse(reader.GetString());

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
@@ -1,9 +1,13 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Configuration options for the FullCalendar component.
+/// </summary>
 public class FullCalendarOptions {
     [JsonConverter(typeof(FullCalendarToolbarConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("headerToolbar")]
+    /// <summary>Toolbar displayed at the top.</summary>
     public FullCalendarToolbar HeaderToolbar { get; set; }
 
     [JsonConverter(typeof(FullCalendarToolbarConverter))]

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbar.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbar.cs
@@ -2,8 +2,12 @@ using System.ComponentModel;
 using System.Reflection;
 
 namespace HtmlForgeX;
+/// <summary>
+/// Toolbar configuration for FullCalendar.
+/// </summary>
 public class FullCalendarToolbar {
     [JsonPropertyName("left")]
+    /// <summary>Options on the left side.</summary>
     public List<FullCalendarToolbarOption> LeftOptions { get; set; } = new List<FullCalendarToolbarOption>();
     [JsonPropertyName("center")]
     public List<FullCalendarToolbarOption> CenterOptions { get; set; } = new List<FullCalendarToolbarOption>();

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbarOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbarOption.cs
@@ -2,9 +2,13 @@ using System.ComponentModel;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Options that can be placed on a FullCalendar toolbar.
+/// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<FullCalendarToolbarOption>))]
 public enum FullCalendarToolbarOption {
     [Description("title")]
+    /// <summary>Displays the current view title.</summary>
     Title,
 
     [Description("prev")]

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
@@ -5,10 +5,13 @@ using System.Text;
 
 namespace HtmlForgeX;
 
-
+/// <summary>
+/// Built-in calendar view options.
+/// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<FullCalendarViewOption>))]
 public enum FullCalendarViewOption {
     [Description("listWeek")]
+    /// <summary>List events for a week.</summary>
     ListWeek,
 
     [Description("listMonth")]

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkEdge.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkEdge.cs
@@ -3,5 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX;
+/// <summary>
+/// Represents an edge in a Vis Network diagram.
+/// </summary>
 public class VisNetworkEdge {
 }

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
@@ -1,4 +1,7 @@
 namespace HtmlForgeX;
+/// <summary>
+/// Represents a node in a Vis Network diagram.
+/// </summary>
 public class VisNetworkNode {
 
 }


### PR DESCRIPTION
## Summary
- document various enum types and components with basic XML docs
- provide brief docs for core FullCalendar and ChartJs helpers

## Testing
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68734f402788832eb06b661f2cc03821