### PR TITLE
Adjust StringBuilder cache size

### DIFF
--- a/HtmlForgeX.Tests/TestStringBuilderCache.cs
+++ b/HtmlForgeX.Tests/TestStringBuilderCache.cs
@@ -19,4 +19,15 @@ public class TestStringBuilderCache {
         var result = StringBuilderCache.GetStringAndRelease(sb2);
         Assert.AreEqual("abc", result);
     }
+
+    [TestMethod]
+    public void Release_DoesNotCacheWhenOverThreshold() {
+        var sb1 = StringBuilderCache.Acquire();
+        sb1.EnsureCapacity(StringBuilderCache.MaxBuilderSize + 1);
+        StringBuilderCache.Release(sb1);
+
+        var sb2 = StringBuilderCache.Acquire();
+        Assert.AreNotSame(sb1, sb2);
+        StringBuilderCache.Release(sb2);
+    }
 }

--- a/HtmlForgeX/Utilities/StringBuilderCache.cs
+++ b/HtmlForgeX/Utilities/StringBuilderCache.cs
@@ -4,6 +4,8 @@ internal static class StringBuilderCache {
     [ThreadStatic]
     private static StringBuilder? _cachedInstance;
 
+    internal const int MaxBuilderSize = 1024;
+
     public static StringBuilder Acquire() {
         var sb = _cachedInstance;
         if (sb == null) {
@@ -21,7 +23,7 @@ internal static class StringBuilderCache {
     }
 
     public static void Release(StringBuilder sb) {
-        if (sb.Capacity <= 360) {
+        if (sb.Capacity <= MaxBuilderSize) {
             _cachedInstance = sb;
         }
     }


### PR DESCRIPTION
## Summary
- tweak StringBuilder caching to avoid holding large builders
- add unit test to guard against caching oversized builders

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68737651723c832ea2060e596ab02106