### PR TITLE
Fix null child handling in HtmlTag

### DIFF
--- a/HtmlForgeX.Tests/TestHtmlTagValidation.cs
+++ b/HtmlForgeX.Tests/TestHtmlTagValidation.cs
@@ -121,5 +121,10 @@ public class TestHtmlTagValidation {
         Assert.IsTrue(result.Contains("data-price=\"19.99\""));
     }
 
+    [TestMethod]
+    public void HtmlTag_NullConstructorValue_ShouldNotCreateTextNode() {
+        var tag = new HtmlTag("div", (string?)null);
+        Assert.AreEqual("<div></div>", tag.ToString());
+    }
 
 }

--- a/HtmlForgeX/Containers/Core/Body.cs
+++ b/HtmlForgeX/Containers/Core/Body.cs
@@ -23,7 +23,7 @@ public class Body : Element {
     /// </summary>
     /// <param name="element">Element to add.</param>
     /// <returns>The current <see cref="Body"/> instance.</returns>
-    public new Body Add(Element element) {
+    public new Body Add(Element? element) {
         base.Add(element);
         return this;
     }

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -44,7 +44,11 @@ public abstract class Element {
     /// </summary>
     /// <param name="element">The element to add.</param>
     /// <returns>This element for method chaining.</returns>
-    public virtual Element Add(Element element) {
+    public virtual Element Add(Element? element) {
+        if (element is null) {
+            return this;
+        }
+
         element.Email = this.Email;
         element.Document = this.Document;
         Children.Add(element);

--- a/HtmlForgeX/Containers/Core/EmailBody.cs
+++ b/HtmlForgeX/Containers/Core/EmailBody.cs
@@ -79,7 +79,11 @@ public class EmailBody : Element {
     /// </summary>
     /// <param name="element">The element to add.</param>
     /// <returns>The EmailBody object, allowing for method chaining.</returns>
-    public EmailBody Add(Element element) {
+    public EmailBody Add(Element? element) {
+        if (element is null) {
+            return this;
+        }
+
         element.Email = _email;
         Children.Add(element);
         return this;

--- a/HtmlForgeX/Containers/Email/EmailColumn.cs
+++ b/HtmlForgeX/Containers/Email/EmailColumn.cs
@@ -146,12 +146,16 @@ public class EmailColumn : Element {
     /// </summary>
     /// <param name="element">The element to add.</param>
     /// <returns>The EmailColumn object, allowing for method chaining.</returns>
-    public override Element Add(Element element) {
+    public override Element Add(Element? element) {
+        if (element is null) {
+            return this;
+        }
+
         // Set a parent reference so child elements know they're in a column
         element.ParentColumn = this;
 
         // Propagate Email reference to child elements for configuration access
-        if (element != null && this.Email != null) {
+        if (this.Email != null) {
             element.Email = this.Email;
         }
 

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -27,9 +27,11 @@ public class HtmlTag : Element {
     /// </summary>
     /// <param name="tag">The name of the tag.</param>
     /// <param name="value">The inner value for the tag.</param>
-    public HtmlTag(string tag, string value) {
+    public HtmlTag(string tag, string? value) {
         PrivateTag = tag;
-        Children.Add(value);
+        if (value is not null) {
+            Children.Add(value);
+        }
     }
 
     /// <summary>
@@ -48,10 +50,12 @@ public class HtmlTag : Element {
     /// <param name="tag">The name of the tag.</param>
     /// <param name="value">The inner value for the tag.</param>
     /// <param name="tagMode">The <see cref="TagMode"/> indicating how the tag should be rendered.</param>
-    public HtmlTag(string tag, string value, TagMode tagMode) {
+    public HtmlTag(string tag, string? value, TagMode tagMode) {
         PrivateTag = tag;
         PrivateTagMode = tagMode;
-        Children.Add(value);
+        if (value is not null) {
+            Children.Add(value);
+        }
     }
 
     /// <summary>
@@ -61,9 +65,11 @@ public class HtmlTag : Element {
     /// <param name="value">The inner value for the tag.</param>
     /// <param name="attributes">Optional attributes to apply.</param>
     /// <param name="tagMode">The <see cref="TagMode"/> indicating how the tag should be rendered.</param>
-    public HtmlTag(string tag, string value, Dictionary<string, object>? attributes = null, TagMode tagMode = TagMode.Normal) {
+    public HtmlTag(string tag, string? value, Dictionary<string, object>? attributes = null, TagMode tagMode = TagMode.Normal) {
         PrivateTag = tag;
-        Children.Add(value);
+        if (value is not null) {
+            Children.Add(value);
+        }
         PrivateTagMode = tagMode;
 
         if (attributes != null) {
@@ -224,8 +230,10 @@ public class HtmlTag : Element {
     /// </summary>
     /// <param name="child">The child tag to add.</param>
     /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
-    public HtmlTag Value(HtmlTag child) {
-        Children.Add(child);
+    public HtmlTag Value(HtmlTag? child) {
+        if (child is not null) {
+            Children.Add(child);
+        }
         return this;
     }
 
@@ -234,8 +242,10 @@ public class HtmlTag : Element {
     /// </summary>
     /// <param name="value">The child element.</param>
     /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
-    public HtmlTag Value(Element value) {
-        Children.Add(value);
+    public HtmlTag Value(Element? value) {
+        if (value is not null) {
+            Children.Add(value);
+        }
         return this;
     }
 
@@ -256,9 +266,11 @@ public class HtmlTag : Element {
     /// </summary>
     /// <param name="value">String values to append.</param>
     /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
-    public HtmlTag Value(params string[] value) {
+    public HtmlTag Value(params string?[] value) {
         foreach (var val in value) {
-            Children.Add(val);
+            if (val is not null) {
+                Children.Add(val);
+            }
         }
         return this;
     }
@@ -267,10 +279,12 @@ public class HtmlTag : Element {
     /// </summary>
     /// <param name="value">Objects to append.</param>
     /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
-    public HtmlTag Value(params object[] value) {
+    public HtmlTag Value(params object?[] value) {
         // this largely works because of ToString() on the object that we should make sure is there, implemented correctly
         foreach (var val in value) {
-            Children.Add(val);
+            if (val is not null) {
+                Children.Add(val);
+            }
         }
         return this;
     }


### PR DESCRIPTION
## Summary
- avoid adding null elements or values to `Children`
- test that `HtmlTag` constructor skips null content

## Testing
- `dotnet build HtmlForgeX.sln -c Debug`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6873766df52c832ea425e04d134c541f