### PR TITLE
Add responsive styling to TablerTable

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -61,6 +61,7 @@ internal class Program {
         BasicHtmlTable01.Create(openInBrowser);
         BasicHtmlTable02.Create(openInBrowser);
         BasicHtmlTable03.Create(openInBrowser);
+        BasicHtmlTable04.Create(openInBrowser);
 
         // Email examples - showcasing the new Document-style configuration!
         Console.WriteLine("📧 Running Email Examples with Document-Style Configuration:");

--- a/HtmlForgeX.Examples/Tables/BasicHtmlTable04.cs
+++ b/HtmlForgeX.Examples/Tables/BasicHtmlTable04.cs
@@ -1,0 +1,66 @@
+namespace HtmlForgeX.Examples.Tables;
+
+internal class BasicHtmlTable04 {
+
+    public static void Create(bool openInBrowser = false) {
+        HelpersSpectre.PrintTitle("Tabler Table Styling Demo");
+
+        // Create a new document with the title and author
+        Document document = new Document {
+            Head = {
+                Title = "Tabler Table Styling Demo",
+                Author = "Przemysław Kłys",
+                Revised = DateTime.Now,
+                Description = "Showcases styling options for Tabler tables",
+                Keywords = "table, tabler, styling",
+                Charset = "utf-8"
+            }
+        };
+
+        // Create a list of simple objects
+        var data = new List<dynamic> {
+            new { Name = "John", Age = 30, Occupation = "Engineer" },
+            new { Name = "Jane", Age = 28, Occupation = "Doctor" },
+            new { Name = "Bob", Age = 35, Occupation = "Architect" }
+        };
+
+        // Add the table to the document and enable basic styling
+        var tablerTable = (TablerTable)document.Body.Table(data, TableType.Tabler);
+        tablerTable.Style(BootStrapTableStyle.Striped)
+                   .Style(BootStrapTableStyle.Hover);
+
+        // Add the table to the document again using DataTables
+        document.Body.Table(data, TableType.DataTables);
+
+        // Get drive information
+        var drives = System.IO.DriveInfo.GetDrives().Select(d => new {
+            Name = d.Name,
+            Type = d.DriveType,
+            Format = d.IsReady ? d.DriveFormat : "N/A",
+            TotalSize = d.IsReady ? d.TotalSize / (1024 * 1024 * 1024) + " GB" : "N/A",
+            AvailableSpace = d.IsReady ? d.AvailableFreeSpace / (1024 * 1024 * 1024) + " GB" : "N/A"
+        }).ToList();
+
+        // Add the drive information to the document
+        var table3 = document.Body.Table(drives, TableType.Tabler);
+
+        // Add the drive information to the document again using DataTables
+        var table4 = (DataTablesTable)document.Body.Table(drives, TableType.DataTables);
+        table4.Style(BootStrapTableStyle.Hover).Style(BootStrapTableStyle.Striped);
+        table4.EnablePaging = true;
+        table4.EnableSearching = false;
+        table4.EnableOrdering = true;
+        table4.EnableScrollX = true;
+        table4.Configure(o =>
+        {
+            o.PageLength = 25;
+            o.StateSave = true;
+        });
+
+        var table5 = (BootstrapTable)document.Body.Table(drives, TableType.BootstrapTable);
+        table5.Style(BootStrapTableStyle.Striped).Style(BootStrapTableStyle.Hover);
+        table5.Style(BootStrapTableStyle.Responsive);
+        document.Save("TablerTableStylingDemo.html", openInBrowser);
+    }
+
+}

--- a/HtmlForgeX.Tests/TestTablerComponentsBasic.cs
+++ b/HtmlForgeX.Tests/TestTablerComponentsBasic.cs
@@ -66,8 +66,8 @@ public class TestTablerComponentsBasic {
         var data = new List<object> { "Item 1", "Item 2" };
         var table = new TablerTable(data, TableType.Tabler);
         var html = table.ToString();
-        
-        Assert.IsTrue(html.Contains("class=\"table\""));
+
+        Assert.IsTrue(html.Contains("table-responsive"));
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/Tabler/TablerTable.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTable.cs
@@ -2,13 +2,26 @@ namespace HtmlForgeX;
 
 public class TablerTable : Table {
     public string Id;
-    public TablerTable(IEnumerable<object> objects, TableType library) : base(objects, library) {
+    public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();
 
+    public TablerTable() : base() {
+        Id = GlobalStorage.GenerateRandomId("table");
+        StyleList.Add(BootStrapTableStyle.Responsive);
+    }
+
+    public TablerTable(IEnumerable<object> objects, TableType library) : base(objects, library) {
+        Id = GlobalStorage.GenerateRandomId("table");
+        StyleList.Add(BootStrapTableStyle.Responsive);
+    }
+
+    public TablerTable Style(BootStrapTableStyle style) {
+        StyleList.Add(style);
+        return this;
     }
 
     public override string BuildTable() {
         string tableInside = base.BuildTable();
-        string classNames = "table";
+        string classNames = StyleList.BuildTableStyles();
         var tableTag = new HtmlTag("table")
             .Id(Id)
             .Class(classNames)


### PR DESCRIPTION
## Summary
- add style list and responsive default to `TablerTable`
- add new Tabler table styling example
- reference new example in `Program`
- verify responsive class in Tabler table tests

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -v minimal`
- `dotnet build HtmlForgeX.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687376ad8434832e8d301dd4b4cd6e89