### PR TITLE
Add XML comments for RGBColor properties

### DIFF
--- a/HtmlForgeX/RGBColor.Colors.cs
+++ b/HtmlForgeX/RGBColor.Colors.cs
@@ -1,1087 +1,4324 @@
-﻿namespace HtmlForgeX;
-
-/// <summary>
-/// Predefined colors (potential for autogeneration)
-/// </summary>
-public partial class RGBColor {
-    public static RGBColor None => FromArgb(0, 0, 0);
-    public static RGBColor AirForceBlue => FromArgb(93, 138, 168);
-    public static RGBColor Akaroa => FromArgb(195, 176, 145);
-    public static RGBColor AlbescentWhite => FromArgb(227, 218, 201);
-    public static RGBColor AliceBlue => FromArgb(240, 248, 255);
-    public static RGBColor Alizarin => FromArgb(227, 38, 54);
-    public static RGBColor Allports => FromArgb(18, 97, 128);
-    public static RGBColor Amaranth => FromArgb(229, 43, 80);
-    public static RGBColor Amazon => FromArgb(59, 122, 87);
-    public static RGBColor Amber => FromArgb(255, 191, 0);
-    public static RGBColor Amethyst => FromArgb(153, 102, 204);
-    public static RGBColor AmethystSmoke => FromArgb(156, 138, 164);
-    public static RGBColor AntiqueWhite => FromArgb(250, 235, 215);
-    public static RGBColor Apple => FromArgb(102, 180, 71);
-    public static RGBColor AppleBlossom => FromArgb(176, 92, 82);
-    public static RGBColor Apricot => FromArgb(251, 206, 177);
-    public static RGBColor Aqua => FromArgb(0, 255, 255);
-    public static RGBColor Aquamarine => FromArgb(127, 255, 212);
-    public static RGBColor Armygreen => FromArgb(75, 83, 32);
-    public static RGBColor Arsenic => FromArgb(59, 68, 75);
-    public static RGBColor Astral => FromArgb(54, 117, 136);
-    public static RGBColor Atlantis => FromArgb(164, 198, 57);
-    public static RGBColor Atomic => FromArgb(65, 74, 76);
-    public static RGBColor AtomicTangerine => FromArgb(255, 153, 102);
-    public static RGBColor Axolotl => FromArgb(99, 119, 91);
-    public static RGBColor Azure => FromArgb(240, 255, 255);
-    public static RGBColor Bahia => FromArgb(176, 191, 26);
-    public static RGBColor BakersChocolate => FromArgb(93, 58, 26);
-    public static RGBColor BaliHai => FromArgb(124, 152, 171);
-    public static RGBColor BananaMania => FromArgb(250, 231, 181);
-    public static RGBColor BattleshipGrey => FromArgb(85, 93, 80);
-    public static RGBColor BayOfMany => FromArgb(35, 48, 103);
-    public static RGBColor Beige => FromArgb(245, 245, 220);
-    public static RGBColor Bermuda => FromArgb(136, 216, 192);
-    public static RGBColor Bilbao => FromArgb(42, 128, 0);
-    public static RGBColor BilobaFlower => FromArgb(181, 126, 220);
-    public static RGBColor Bismark => FromArgb(83, 104, 114);
-    public static RGBColor Bisque => FromArgb(255, 228, 196);
-    public static RGBColor Bistre => FromArgb(61, 43, 31);
-    public static RGBColor Bittersweet => FromArgb(254, 111, 94);
-    public static RGBColor Black => FromArgb(0, 0, 0);
-    public static RGBColor BlackPearl => FromArgb(31, 38, 42);
-    public static RGBColor BlackRose => FromArgb(85, 31, 47);
-    public static RGBColor BlackRussian => FromArgb(23, 24, 43);
-    public static RGBColor BlanchedAlmond => FromArgb(255, 235, 205);
-    public static RGBColor BlizzardBlue => FromArgb(172, 229, 238);
-    public static RGBColor Blue => FromArgb(0, 0, 255);
-    public static RGBColor BlueDiamond => FromArgb(77, 26, 127);
-    public static RGBColor BlueMarguerite => FromArgb(115, 102, 189);
-    public static RGBColor BlueSmoke => FromArgb(115, 130, 118);
-    public static RGBColor BlueViolet => FromArgb(138, 43, 226);
-    public static RGBColor Blush => FromArgb(169, 92, 104);
-    public static RGBColor BokaraGrey => FromArgb(22, 17, 13);
-    public static RGBColor Bole => FromArgb(121, 68, 59);
-    public static RGBColor BondiBlue => FromArgb(0, 147, 175);
-    public static RGBColor Bordeaux => FromArgb(88, 17, 26);
-    public static RGBColor Bossanova => FromArgb(86, 60, 92);
-    public static RGBColor Boulder => FromArgb(114, 116, 114);
-    public static RGBColor Bouquet => FromArgb(183, 132, 167);
-    public static RGBColor Bourbon => FromArgb(170, 108, 57);
-    public static RGBColor Brass => FromArgb(181, 166, 66);
-    public static RGBColor BrickRed => FromArgb(199, 44, 72);
-    public static RGBColor BrightGreen => FromArgb(102, 255, 0);
-    public static RGBColor BrightRed => FromArgb(146, 43, 62);
-    public static RGBColor BrightTurquoise => FromArgb(8, 232, 222);
-    public static RGBColor BrilliantRose => FromArgb(243, 100, 162);
-    public static RGBColor BrinkPink => FromArgb(250, 110, 121);
-    public static RGBColor BritishRacingGreen => FromArgb(0, 66, 37);
-    public static RGBColor Bronze => FromArgb(205, 127, 50);
-    public static RGBColor Brown => FromArgb(165, 42, 42);
-    public static RGBColor BrownPod => FromArgb(57, 24, 2);
-    public static RGBColor BuddhaGold => FromArgb(202, 169, 6);
-    public static RGBColor Buff => FromArgb(240, 220, 130);
-    public static RGBColor Burgundy => FromArgb(128, 0, 32);
-    public static RGBColor BurlyWood => FromArgb(222, 184, 135);
-    public static RGBColor BurntOrange => FromArgb(255, 117, 56);
-    public static RGBColor BurntSienna => FromArgb(233, 116, 81);
-    public static RGBColor BurntUmber => FromArgb(138, 51, 36);
-    public static RGBColor ButteredRum => FromArgb(156, 124, 56);
-    public static RGBColor CadetBlue => FromArgb(95, 158, 160);
-    public static RGBColor California => FromArgb(224, 141, 60);
-    public static RGBColor CamouflageGreen => FromArgb(120, 134, 107);
-    public static RGBColor Canary => FromArgb(255, 255, 153);
-    public static RGBColor CandyPink => FromArgb(255, 103, 149);
-    public static RGBColor Capri => FromArgb(0, 191, 255);
-    public static RGBColor Cardinal => FromArgb(196, 30, 58);
-    public static RGBColor Carmine => FromArgb(150, 0, 24);
-    public static RGBColor Carnation => FromArgb(255, 166, 201);
-    public static RGBColor CarnationPink => FromArgb(255, 166, 201);
-    public static RGBColor CarrotOrange => FromArgb(237, 145, 33);
-    public static RGBColor Casablanca => FromArgb(248, 184, 83);
-    public static RGBColor Cascade => FromArgb(139, 169, 165);
-    public static RGBColor Cashmere => FromArgb(236, 200, 176);
-    public static RGBColor CastletonGreen => FromArgb(0, 86, 63);
-    public static RGBColor CatalinaBlue => FromArgb(6, 42, 120);
-    public static RGBColor Catawba => FromArgb(112, 54, 66);
-    public static RGBColor Cedar => FromArgb(62, 28, 20);
-    public static RGBColor Celadon => FromArgb(172, 225, 175);
-    public static RGBColor CeladonBlue => FromArgb(0, 123, 167);
-    public static RGBColor CeladonGreen => FromArgb(47, 132, 124);
-    public static RGBColor Celeste => FromArgb(178, 255, 255);
-    public static RGBColor CelestialBlue => FromArgb(73, 151, 208);
-    public static RGBColor Cerise => FromArgb(222, 49, 99);
-    public static RGBColor CerisePink => FromArgb(236, 59, 131);
-    public static RGBColor Cerulean => FromArgb(0, 123, 167);
-    public static RGBColor CeruleanBlue => FromArgb(42, 82, 190);
-    public static RGBColor CeruleanFrost => FromArgb(109, 155, 195);
-    public static RGBColor Chamoisee => FromArgb(160, 120, 90);
-    public static RGBColor Champagne => FromArgb(250, 214, 165);
-    public static RGBColor Charcoal => FromArgb(54, 69, 79);
-    public static RGBColor Charm => FromArgb(208, 116, 139);
-    public static RGBColor Chartreuse => FromArgb(127, 255, 0);
-    public static RGBColor Cherry => FromArgb(222, 49, 99);
-    public static RGBColor CherryBlossomPink => FromArgb(255, 183, 197);
-    public static RGBColor Chestnut => FromArgb(149, 69, 53);
-    public static RGBColor ChinaPink => FromArgb(222, 111, 161);
-    public static RGBColor ChinaRose => FromArgb(168, 81, 110);
-    public static RGBColor ChineseRed => FromArgb(170, 56, 30);
-    public static RGBColor ChineseViolet => FromArgb(133, 96, 136);
-    public static RGBColor ChlorophyllGreen => FromArgb(74, 255, 0);
-    public static RGBColor Chocolate => FromArgb(210, 105, 30);
-    public static RGBColor ChromeYellow => FromArgb(255, 167, 0);
-    public static RGBColor Cinereous => FromArgb(152, 129, 123);
-    public static RGBColor Cinnabar => FromArgb(227, 66, 52);
-    public static RGBColor CinnamonSatin => FromArgb(205, 96, 126);
-    public static RGBColor Citrine => FromArgb(228, 208, 10);
-    public static RGBColor Citron => FromArgb(158, 169, 31);
-    public static RGBColor Claret => FromArgb(127, 23, 52);
-    public static RGBColor ClassicRose => FromArgb(251, 204, 231);
-    public static RGBColor CobaltBlue => FromArgb(0, 71, 171);
-    public static RGBColor CocoaBrown => FromArgb(210, 105, 30);
-    public static RGBColor Coconut => FromArgb(150, 90, 62);
-    public static RGBColor Coffee => FromArgb(111, 78, 55);
-    public static RGBColor ColumbiaBlue => FromArgb(196, 216, 226);
-    public static RGBColor CongoPink => FromArgb(248, 131, 121);
-    public static RGBColor CoolBlack => FromArgb(0, 46, 99);
-    public static RGBColor CoolGrey => FromArgb(140, 146, 172);
-    public static RGBColor Copper => FromArgb(184, 115, 51);
-    public static RGBColor CopperPenny => FromArgb(173, 111, 105);
-    public static RGBColor CopperRed => FromArgb(203, 109, 81);
-    public static RGBColor CopperRose => FromArgb(153, 102, 102);
-    public static RGBColor Coquelicot => FromArgb(255, 56, 0);
-    public static RGBColor Coral => FromArgb(255, 127, 80);
-    public static RGBColor CoralPink => FromArgb(248, 131, 121);
-    public static RGBColor CoralRed => FromArgb(255, 64, 64);
-    public static RGBColor Cordovan => FromArgb(137, 63, 69);
-    public static RGBColor Corn => FromArgb(251, 236, 93);
-    public static RGBColor CornellRed => FromArgb(179, 27, 27);
-    public static RGBColor CornflowerBlue => FromArgb(100, 149, 237);
-    public static RGBColor Cornsilk => FromArgb(255, 248, 220);
-    public static RGBColor CosmicCobalt => FromArgb(46, 45, 136);
-    public static RGBColor CosmicLatte => FromArgb(255, 248, 231);
-    public static RGBColor CoyoteBrown => FromArgb(129, 97, 60);
-    public static RGBColor CottonCandy => FromArgb(255, 188, 217);
-    public static RGBColor Cream => FromArgb(255, 253, 208);
-    public static RGBColor Crimson => FromArgb(220, 20, 60);
-    public static RGBColor CrimsonGlory => FromArgb(190, 0, 50);
-    public static RGBColor Cyan => FromArgb(0, 255, 255);
-    public static RGBColor CyanAzure => FromArgb(78, 130, 180);
-    public static RGBColor CyanBlueAzure => FromArgb(70, 130, 191);
-    public static RGBColor CyanCobaltBlue => FromArgb(40, 88, 156);
-    public static RGBColor CyanCornflowerBlue => FromArgb(24, 139, 194);
-    public static RGBColor CyanProcess => FromArgb(0, 183, 235);
-    public static RGBColor CyberGrape => FromArgb(88, 66, 124);
-    public static RGBColor CyberYellow => FromArgb(255, 211, 0);
-    public static RGBColor Daffodil => FromArgb(255, 255, 49);
-    public static RGBColor Dandelion => FromArgb(240, 225, 48);
-    public static RGBColor DarkBlue => FromArgb(0, 0, 139);
-    public static RGBColor DarkBrown => FromArgb(101, 67, 33);
-    public static RGBColor DarkByzantium => FromArgb(93, 57, 84);
-    public static RGBColor DarkCandyAppleRed => FromArgb(164, 0, 0);
-    public static RGBColor DarkCerulean => FromArgb(8, 69, 126);
-    public static RGBColor DarkChestnut => FromArgb(152, 105, 96);
-    public static RGBColor DarkCoral => FromArgb(205, 91, 69);
-    public static RGBColor DarkCyan => FromArgb(0, 139, 139);
-    public static RGBColor DarkElectricBlue => FromArgb(83, 104, 120);
-    public static RGBColor DarkGoldenrod => FromArgb(184, 134, 11);
-    public static RGBColor DarkGray => FromArgb(169, 169, 169);
-    public static RGBColor DarkGreen => FromArgb(1, 50, 32);
-    public static RGBColor DarkImperialBlue => FromArgb(0, 65, 106);
-    public static RGBColor DarkJungleGreen => FromArgb(26, 36, 33);
-    public static RGBColor DarkKhaki => FromArgb(189, 183, 107);
-    public static RGBColor DarkLava => FromArgb(72, 60, 50);
-    public static RGBColor DarkLavender => FromArgb(115, 79, 150);
-    public static RGBColor DarkLiver => FromArgb(83, 75, 79);
-    public static RGBColor DarkMagenta => FromArgb(139, 0, 139);
-    public static RGBColor DarkMediumGray => FromArgb(169, 169, 169);
-    public static RGBColor DarkMidnightBlue => FromArgb(0, 51, 102);
-    public static RGBColor DarkMossGreen => FromArgb(74, 93, 35);
-    public static RGBColor DarkOliveGreen => FromArgb(85, 107, 47);
-    public static RGBColor DarkOrange => FromArgb(255, 140, 0);
-    public static RGBColor DarkOrchid => FromArgb(153, 50, 204);
-    public static RGBColor DarkPastelBlue => FromArgb(119, 158, 203);
-    public static RGBColor DarkPastelGreen => FromArgb(3, 192, 60);
-    public static RGBColor DarkPastelPurple => FromArgb(150, 111, 214);
-    public static RGBColor DarkPastelRed => FromArgb(194, 59, 34);
-    public static RGBColor DarkPink => FromArgb(231, 84, 128);
-    public static RGBColor DarkPowderBlue => FromArgb(0, 51, 153);
-    public static RGBColor DarkPuce => FromArgb(79, 58, 60);
-    public static RGBColor DarkPurple => FromArgb(48, 25, 52);
-    public static RGBColor DarkRaspberry => FromArgb(135, 38, 87);
-    public static RGBColor DarkRed => FromArgb(139, 0, 0);
-    public static RGBColor DarkSalmon => FromArgb(233, 150, 122);
-    public static RGBColor DarkScarlet => FromArgb(86, 3, 25);
-    public static RGBColor DarkSeaGreen => FromArgb(143, 188, 143);
-    public static RGBColor DarkSienna => FromArgb(60, 20, 20);
-    public static RGBColor DarkSkyBlue => FromArgb(140, 190, 214);
-    public static RGBColor DarkSlateBlue => FromArgb(72, 61, 139);
-    public static RGBColor DarkSlateGray => FromArgb(47, 79, 79);
-    public static RGBColor DarkSpringGreen => FromArgb(23, 114, 69);
-    public static RGBColor DarkTan => FromArgb(145, 129, 81);
-    public static RGBColor DarkTangerine => FromArgb(255, 168, 18);
-    public static RGBColor DarkTaupe => FromArgb(72, 60, 50);
-    public static RGBColor DarkTerraCotta => FromArgb(204, 78, 92);
-    public static RGBColor DarkTurquoise => FromArgb(0, 206, 209);
-    public static RGBColor DarkVanilla => FromArgb(209, 190, 168);
-    public static RGBColor DarkViolet => FromArgb(148, 0, 211);
-    public static RGBColor DarkYellow => FromArgb(155, 135, 12);
-    public static RGBColor DartmouthGreen => FromArgb(0, 112, 60);
-    public static RGBColor DavysGrey => FromArgb(85, 85, 85);
-    public static RGBColor DebianRed => FromArgb(215, 10, 83);
-    public static RGBColor DeepAquamarine => FromArgb(64, 130, 109);
-    public static RGBColor DeepCarmine => FromArgb(169, 32, 62);
-    public static RGBColor DeepCarminePink => FromArgb(239, 48, 56);
-    public static RGBColor DeepCarrotOrange => FromArgb(233, 105, 44);
-    public static RGBColor DeepCerise => FromArgb(218, 50, 135);
-    public static RGBColor DeepChampagne => FromArgb(250, 214, 165);
-    public static RGBColor DeepChestnut => FromArgb(185, 78, 72);
-    public static RGBColor DeepCoffee => FromArgb(112, 66, 65);
-    public static RGBColor DeepFuchsia => FromArgb(193, 84, 193);
-    public static RGBColor DeepGreen => FromArgb(5, 102, 8);
-    public static RGBColor DeepGreenCyanTurquoise => FromArgb(14, 124, 97);
-    public static RGBColor DeepJungleGreen => FromArgb(0, 75, 73);
-    public static RGBColor DeepKoamaru => FromArgb(51, 51, 153);
-    public static RGBColor DeepLemon => FromArgb(245, 199, 26);
-    public static RGBColor DeepLilac => FromArgb(153, 85, 187);
-    public static RGBColor DeepMaroon => FromArgb(130, 0, 0);
-    public static RGBColor DeepMauve => FromArgb(212, 115, 212);
-    public static RGBColor DeepMossGreen => FromArgb(53, 94, 59);
-    public static RGBColor DeepPeach => FromArgb(255, 203, 164);
-    public static RGBColor DeepPink => FromArgb(255, 20, 147);
-    public static RGBColor DeepPuce => FromArgb(169, 92, 104);
-    public static RGBColor DeepRed => FromArgb(133, 1, 1);
-    public static RGBColor DeepRuby => FromArgb(132, 63, 91);
-    public static RGBColor DeepSaffron => FromArgb(255, 153, 51);
-    public static RGBColor DeepSkyBlue => FromArgb(0, 191, 255);
-    public static RGBColor DeepSpaceSparkle => FromArgb(74, 100, 108);
-    public static RGBColor DeepSpringBud => FromArgb(85, 107, 47);
-    public static RGBColor DeepTaupe => FromArgb(126, 94, 96);
-    public static RGBColor DeepTuscanRed => FromArgb(102, 66, 77);
-    public static RGBColor DeepViolet => FromArgb(51, 51, 153);
-    public static RGBColor Deer => FromArgb(186, 135, 89);
-    public static RGBColor Denim => FromArgb(21, 96, 189);
-    public static RGBColor DenimBlue => FromArgb(34, 67, 182);
-    public static RGBColor DesaturatedCyan => FromArgb(102, 153, 153);
-    public static RGBColor Desert => FromArgb(193, 154, 107);
-    public static RGBColor DesertSand => FromArgb(237, 201, 175);
-    public static RGBColor Desire => FromArgb(234, 60, 83);
-    public static RGBColor Diamond => FromArgb(185, 242, 255);
-    public static RGBColor DimGray => FromArgb(105, 105, 105);
-    public static RGBColor DingyDungeon => FromArgb(197, 49, 81);
-    public static RGBColor Dirt => FromArgb(155, 118, 83);
-    public static RGBColor DodgerBlue => FromArgb(30, 144, 255);
-    public static RGBColor DogwoodRose => FromArgb(215, 24, 104);
-    public static RGBColor DollarBill => FromArgb(133, 187, 101);
-    public static RGBColor DolphinGray => FromArgb(130, 142, 132);
-    public static RGBColor DonkeyBrown => FromArgb(102, 76, 40);
-    public static RGBColor Drab => FromArgb(150, 113, 23);
-    public static RGBColor DukeBlue => FromArgb(0, 0, 156);
-    public static RGBColor DustStorm => FromArgb(229, 204, 201);
-    public static RGBColor DutchWhite => FromArgb(239, 223, 187);
-    public static RGBColor EarthYellow => FromArgb(225, 169, 95);
-    public static RGBColor Ebony => FromArgb(85, 93, 80);
-    public static RGBColor Ecru => FromArgb(194, 178, 128);
-    public static RGBColor EerieBlack => FromArgb(27, 27, 27);
-    public static RGBColor Eggplant => FromArgb(97, 64, 81);
-    public static RGBColor Eggshell => FromArgb(240, 234, 214);
-    public static RGBColor EgyptianBlue => FromArgb(16, 52, 166);
-    public static RGBColor ElectricBlue => FromArgb(125, 249, 255);
-    public static RGBColor ElectricCrimson => FromArgb(255, 0, 63);
-    public static RGBColor ElectricCyan => FromArgb(0, 255, 255);
-    public static RGBColor ElectricGreen => FromArgb(0, 255, 0);
-    public static RGBColor ElectricIndigo => FromArgb(111, 0, 255);
-    public static RGBColor ElectricLavender => FromArgb(244, 187, 255);
-    public static RGBColor ElectricLime => FromArgb(204, 255, 0);
-    public static RGBColor ElectricPurple => FromArgb(191, 0, 255);
-    public static RGBColor ElectricUltramarine => FromArgb(63, 0, 255);
-    public static RGBColor ElectricViolet => FromArgb(143, 0, 255);
-    public static RGBColor ElectricYellow => FromArgb(255, 255, 0);
-    public static RGBColor Emerald => FromArgb(80, 200, 120);
-    public static RGBColor Eminence => FromArgb(108, 48, 130);
-    public static RGBColor EnglishGreen => FromArgb(27, 77, 62);
-    public static RGBColor EnglishLavender => FromArgb(180, 131, 149);
-    public static RGBColor EnglishRed => FromArgb(171, 75, 82);
-    public static RGBColor EnglishViolet => FromArgb(86, 60, 92);
-    public static RGBColor EtonBlue => FromArgb(150, 200, 162);
-    public static RGBColor Eucalyptus => FromArgb(38, 115, 77);
-    public static RGBColor Fallow => FromArgb(193, 154, 107);
-    public static RGBColor FaluRed => FromArgb(128, 24, 24);
-    public static RGBColor Fandango => FromArgb(181, 51, 137);
-    public static RGBColor FandangoPink => FromArgb(222, 82, 133);
-    public static RGBColor FashionFuchsia => FromArgb(244, 0, 161);
-    public static RGBColor Fawn => FromArgb(229, 170, 112);
-    public static RGBColor Feldgrau => FromArgb(77, 93, 83);
-    public static RGBColor Feldspar => FromArgb(253, 213, 177);
-    public static RGBColor FernGreen => FromArgb(79, 121, 66);
-    public static RGBColor FerrariRed => FromArgb(255, 40, 0);
-    public static RGBColor FieldDrab => FromArgb(108, 84, 30);
-    public static RGBColor FieryRose => FromArgb(255, 84, 112);
-    public static RGBColor FireEngineRed => FromArgb(206, 32, 41);
-    public static RGBColor Firebrick => FromArgb(178, 34, 34);
-    public static RGBColor Flame => FromArgb(226, 88, 34);
-    public static RGBColor Flamingo => FromArgb(242, 85, 42);
-    public static RGBColor Flax => FromArgb(238, 220, 130);
-    public static RGBColor Flirt => FromArgb(162, 0, 109);
-    public static RGBColor FloralWhite => FromArgb(255, 250, 240);
-    public static RGBColor Foam => FromArgb(216, 252, 250);
-    public static RGBColor Fog => FromArgb(215, 208, 255);
-    public static RGBColor FoggyGray => FromArgb(204, 204, 204);
-    public static RGBColor ForestGreen => FromArgb(34, 139, 34);
-    public static RGBColor ForgetMeNot => FromArgb(255, 241, 238);
-    public static RGBColor FountainBlue => FromArgb(86, 180, 190);
-    public static RGBColor Frangipani => FromArgb(255, 222, 179);
-    public static RGBColor FrenchGray => FromArgb(189, 189, 198);
-    public static RGBColor FrenchLilac => FromArgb(134, 96, 142);
-    public static RGBColor FrenchRose => FromArgb(246, 74, 138);
-    public static RGBColor FreshEggplant => FromArgb(105, 45, 84);
-    public static RGBColor Frost => FromArgb(237, 245, 255);
-    public static RGBColor FrostedMint => FromArgb(210, 255, 188);
-    public static RGBColor Frostee => FromArgb(219, 255, 248);
-    public static RGBColor FruitSalad => FromArgb(79, 157, 93);
-    public static RGBColor Fuchsia => FromArgb(255, 0, 255);
-    public static RGBColor FuchsiaPink => FromArgb(255, 119, 255);
-    public static RGBColor Fuego => FromArgb(190, 222, 13);
-    public static RGBColor FujiGreen => FromArgb(125, 176, 93);
-    public static RGBColor FuscousGray => FromArgb(84, 83, 77);
-    public static RGBColor FuzzyWuzzyBrown => FromArgb(204, 102, 102);
-    public static RGBColor GableGreen => FromArgb(22, 53, 49);
-    public static RGBColor Gallery => FromArgb(238, 238, 238);
-    public static RGBColor Galliano => FromArgb(220, 178, 12);
-    public static RGBColor Gamboge => FromArgb(228, 155, 15);
-    public static RGBColor GargoyleGas => FromArgb(255, 223, 70);
-    public static RGBColor Geebung => FromArgb(209, 143, 27);
-    public static RGBColor Genoa => FromArgb(21, 115, 107);
-    public static RGBColor Geraldine => FromArgb(251, 137, 137);
-    public static RGBColor Geyser => FromArgb(212, 223, 226);
-    public static RGBColor Ghost => FromArgb(199, 201, 213);
-    public static RGBColor GhostWhite => FromArgb(248, 248, 255);
-    public static RGBColor Gigas => FromArgb(82, 60, 148);
-    public static RGBColor Gimblet => FromArgb(184, 181, 106);
-    public static RGBColor Gin => FromArgb(216, 252, 250);
-    public static RGBColor GinFizz => FromArgb(255, 249, 226);
-    public static RGBColor Givry => FromArgb(248, 228, 191);
-    public static RGBColor Glacier => FromArgb(128, 179, 196);
-    public static RGBColor GladeGreen => FromArgb(97, 132, 95);
-    public static RGBColor GoBen => FromArgb(120, 107, 79);
-    public static RGBColor Gondola => FromArgb(38, 20, 20);
-    public static RGBColor GoodSamaritan => FromArgb(60, 100, 126);
-    public static RGBColor Gorse => FromArgb(255, 233, 21);
-    public static RGBColor Gothic => FromArgb(106, 120, 123);
-    public static RGBColor GovernorBay => FromArgb(47, 60, 179);
-    public static RGBColor GrainBrown => FromArgb(228, 213, 183);
-    public static RGBColor Grandis => FromArgb(255, 211, 140);
-    public static RGBColor GraniteGreen => FromArgb(141, 137, 116);
-    public static RGBColor GrannyApple => FromArgb(213, 246, 227);
-    public static RGBColor GrannySmith => FromArgb(132, 160, 160);
-    public static RGBColor GrannySmithApple => FromArgb(157, 224, 147);
-    public static RGBColor Grape => FromArgb(56, 26, 81);
-    public static RGBColor Graphite => FromArgb(37, 22, 7);
-    public static RGBColor GrassHopper => FromArgb(124, 118, 49);
-    public static RGBColor Gravel => FromArgb(74, 68, 75);
-    public static RGBColor Gray => FromArgb(128, 128, 128);
-    public static RGBColor GrayAsparagus => FromArgb(70, 89, 69);
-    public static RGBColor GrayChateau => FromArgb(163, 164, 165);
-    public static RGBColor GrayNickel => FromArgb(195, 195, 189);
-    public static RGBColor GrayNurse => FromArgb(231, 236, 230);
-    public static RGBColor GrayOlive => FromArgb(113, 107, 86);
-    public static RGBColor GraySuit => FromArgb(193, 190, 205);
-    public static RGBColor Green => FromArgb(0, 128, 0);
-    public static RGBColor GreenBlue => FromArgb(17, 100, 180);
-    public static RGBColor GreenCyan => FromArgb(0, 153, 102);
-    public static RGBColor GreenHaze => FromArgb(1, 170, 122);
-    public static RGBColor GreenHouse => FromArgb(36, 80, 15);
-    public static RGBColor GreenKelp => FromArgb(37, 49, 28);
-    public static RGBColor GreenLeaf => FromArgb(37, 49, 20);
-    public static RGBColor GreenMist => FromArgb(203, 211, 176);
-    public static RGBColor GreenPea => FromArgb(29, 97, 66);
-    public static RGBColor GreenSmoke => FromArgb(164, 175, 110);
-    public static RGBColor GreenSpring => FromArgb(184, 193, 162);
-    public static RGBColor GreenVogue => FromArgb(3, 43, 82);
-    public static RGBColor GreenWaterloo => FromArgb(16, 20, 5);
-    public static RGBColor GreenWhite => FromArgb(232, 235, 224);
-    public static RGBColor GreenYellow => FromArgb(173, 255, 47);
-    public static RGBColor Grenadier => FromArgb(213, 70, 0);
-    public static RGBColor Grey => FromArgb(128, 128, 128);
-    public static RGBColor GreyChateau => FromArgb(162, 170, 179);
-    public static RGBColor GreyGreen => FromArgb(69, 73, 54);
-    public static RGBColor GreyNurse => FromArgb(231, 236, 230);
-    public static RGBColor GreyOlive => FromArgb(169, 164, 145);
-    public static RGBColor GreySuit => FromArgb(193, 190, 205);
-    public static RGBColor GuardsmanRed => FromArgb(186, 12, 47);
-    public static RGBColor GulfBlue => FromArgb(5, 22, 87);
-    public static RGBColor GulfStream => FromArgb(128, 179, 174);
-    public static RGBColor GullGray => FromArgb(157, 172, 183);
-    public static RGBColor GumLeaf => FromArgb(182, 211, 191);
-    public static RGBColor Gumboot => FromArgb(60, 31, 31);
-    public static RGBColor GunPowder => FromArgb(130, 134, 133);
-    public static RGBColor Gunmetal => FromArgb(42, 52, 57);
-    public static RGBColor Gunsmoke => FromArgb(130, 134, 133);
-    public static RGBColor GypsyQueen => FromArgb(105, 155, 176);
-    public static RGBColor Hacienda => FromArgb(152, 129, 27);
-    public static RGBColor HairyHeath => FromArgb(107, 42, 20);
-    public static RGBColor Haiti => FromArgb(27, 16, 53);
-    public static RGBColor HalfBaked => FromArgb(133, 196, 204);
-    public static RGBColor HalfColonialWhite => FromArgb(253, 246, 211);
-    public static RGBColor HalfDutchWhite => FromArgb(254, 247, 222);
-    public static RGBColor HalfSpanishWhite => FromArgb(254, 244, 219);
-    public static RGBColor HalfAndHalf => FromArgb(255, 254, 225);
-    public static RGBColor Hampton => FromArgb(230, 242, 234);
-    public static RGBColor Harlequin => FromArgb(63, 255, 0);
-    public static RGBColor Harp => FromArgb(230, 242, 234);
-    public static RGBColor HarvestGold => FromArgb(224, 170, 15);
-    public static RGBColor HavelockBlue => FromArgb(85, 144, 217);
-    public static RGBColor HawaiianTan => FromArgb(157, 86, 22);
-    public static RGBColor HawkesBlue => FromArgb(212, 226, 252);
-    public static RGBColor Haystack => FromArgb(224, 185, 117);
-    public static RGBColor Hazel => FromArgb(142, 118, 24);
-    public static RGBColor Hazelnut => FromArgb(218, 157, 118);
-    public static RGBColor Heirloom => FromArgb(96, 26, 20);
-    public static RGBColor Hemp => FromArgb(144, 120, 116);
-    public static RGBColor Hibiscus => FromArgb(182, 49, 108);
-    public static RGBColor Highball => FromArgb(144, 141, 57);
-    public static RGBColor Highland => FromArgb(111, 142, 99);
-    public static RGBColor Hillary => FromArgb(172, 165, 134);
-    public static RGBColor HollywoodCerise => FromArgb(244, 0, 161);
-    public static RGBColor Honeydew => FromArgb(240, 255, 240);
-    public static RGBColor HonoluluBlue => FromArgb(0, 127, 191);
-    public static RGBColor HookersGreen => FromArgb(73, 121, 107);
-    public static RGBColor HotMagenta => FromArgb(255, 29, 206);
-    public static RGBColor HotPink => FromArgb(255, 105, 180);
-    public static RGBColor HunterGreen => FromArgb(53, 94, 59);
-    public static RGBColor Iceberg => FromArgb(113, 166, 210);
-    public static RGBColor Icterine => FromArgb(252, 247, 94);
-    public static RGBColor IlluminatingEmerald => FromArgb(49, 145, 119);
-    public static RGBColor Imperial => FromArgb(96, 47, 107);
-    public static RGBColor ImperialBlue => FromArgb(0, 35, 149);
-    public static RGBColor ImperialPurple => FromArgb(102, 2, 60);
-    public static RGBColor ImperialRed => FromArgb(237, 41, 57);
-    public static RGBColor Inchworm => FromArgb(178, 236, 93);
-    public static RGBColor Independence => FromArgb(76, 81, 109);
-    public static RGBColor IndiaGreen => FromArgb(19, 136, 8);
-    public static RGBColor IndianRed => FromArgb(205, 92, 92);
-    public static RGBColor IndianYellow => FromArgb(227, 168, 87);
-    public static RGBColor Indigo => FromArgb(75, 0, 130);
-    public static RGBColor IndigoDye => FromArgb(0, 65, 106);
-    public static RGBColor IndigoRainbow => FromArgb(35, 64, 86);
-    public static RGBColor InfraRed => FromArgb(255, 73, 108);
-    public static RGBColor InterdimensionalBlue => FromArgb(54, 12, 204);
-    public static RGBColor InternationalKleinBlue => FromArgb(0, 47, 167);
-    public static RGBColor InternationalOrange => FromArgb(255, 79, 0);
-    public static RGBColor Iris => FromArgb(90, 79, 207);
-    public static RGBColor Irresistible => FromArgb(179, 68, 108);
-    public static RGBColor Isabelline => FromArgb(244, 240, 236);
-    public static RGBColor IslamicGreen => FromArgb(0, 144, 0);
-    public static RGBColor ItalianSkyBlue => FromArgb(178, 255, 255);
-    public static RGBColor Ivory => FromArgb(255, 255, 240);
-    public static RGBColor Jade => FromArgb(0, 168, 107);
-    public static RGBColor JapaneseCarmine => FromArgb(157, 41, 51);
-    public static RGBColor JapaneseViolet => FromArgb(91, 50, 86);
-    public static RGBColor Jasmine => FromArgb(248, 222, 126);
-    public static RGBColor Jasper => FromArgb(215, 59, 62);
-    public static RGBColor JazzberryJam => FromArgb(165, 11, 94);
-    public static RGBColor JellyBean => FromArgb(218, 97, 78);
-    public static RGBColor Jet => FromArgb(52, 52, 52);
-    public static RGBColor Jonquil => FromArgb(250, 218, 94);
-    public static RGBColor JordyBlue => FromArgb(138, 185, 241);
-    public static RGBColor JuneBud => FromArgb(189, 218, 87);
-    public static RGBColor JungleGreen => FromArgb(41, 171, 135);
-    public static RGBColor KellyGreen => FromArgb(76, 187, 23);
-    public static RGBColor KenyanCopper => FromArgb(124, 28, 5);
-    public static RGBColor Keppel => FromArgb(58, 176, 158);
-    public static RGBColor KeyLime => FromArgb(232, 244, 140);
-    public static RGBColor Khaki => FromArgb(195, 176, 145);
-    public static RGBColor Kiwi => FromArgb(142, 229, 63);
-    public static RGBColor Kobe => FromArgb(136, 45, 23);
-    public static RGBColor Kobi => FromArgb(231, 159, 196);
-    public static RGBColor Kobicha => FromArgb(107, 68, 35);
-    public static RGBColor KombuGreen => FromArgb(53, 66, 48);
-    public static RGBColor KSUPurple => FromArgb(81, 40, 136);
-    public static RGBColor KUCrimson => FromArgb(232, 0, 13);
-    public static RGBColor LaSalleGreen => FromArgb(8, 120, 48);
-    public static RGBColor LanguidLavender => FromArgb(214, 202, 221);
-    public static RGBColor LapisLazuli => FromArgb(38, 97, 156);
-    public static RGBColor LaserLemon => FromArgb(254, 254, 34);
-    public static RGBColor LaurelGreen => FromArgb(169, 186, 157);
-    public static RGBColor Lava => FromArgb(207, 16, 32);
-    public static RGBColor Lavender => FromArgb(230, 230, 250);
-    public static RGBColor LavenderBlue => FromArgb(204, 204, 255);
-    public static RGBColor LavenderBlush => FromArgb(255, 240, 245);
-    public static RGBColor LavenderGray => FromArgb(196, 195, 208);
-    public static RGBColor LavenderIndigo => FromArgb(148, 87, 235);
-    public static RGBColor LavenderMagenta => FromArgb(238, 130, 238);
-    public static RGBColor LavenderMist => FromArgb(230, 230, 250);
-    public static RGBColor LavenderPink => FromArgb(251, 174, 210);
-    public static RGBColor LavenderPurple => FromArgb(150, 123, 182);
-    public static RGBColor LavenderRose => FromArgb(251, 160, 227);
-    public static RGBColor LawnGreen => FromArgb(124, 252, 0);
-    public static RGBColor Lemon => FromArgb(255, 247, 0);
-    public static RGBColor LemonChiffon => FromArgb(255, 250, 205);
-    public static RGBColor LemonCurry => FromArgb(204, 160, 29);
-    public static RGBColor LemonGlacier => FromArgb(253, 255, 0);
-    public static RGBColor LemonLime => FromArgb(227, 255, 0);
-    public static RGBColor LemonMeringue => FromArgb(246, 234, 190);
-    public static RGBColor LemonYellow => FromArgb(255, 244, 79);
-    public static RGBColor LemonYellowCrayola => FromArgb(255, 255, 159);
-    public static RGBColor Liberty => FromArgb(84, 90, 167);
-    public static RGBColor Licorice => FromArgb(26, 17, 16);
-    public static RGBColor LightApricot => FromArgb(253, 213, 177);
-    public static RGBColor LightBlue => FromArgb(173, 216, 230);
-    public static RGBColor LightBrown => FromArgb(181, 101, 29);
-    public static RGBColor LightCarminePink => FromArgb(230, 103, 113);
-    public static RGBColor LightCobaltBlue => FromArgb(136, 172, 224);
-    public static RGBColor LightCoral => FromArgb(240, 128, 128);
-    public static RGBColor LightCornflowerBlue => FromArgb(147, 204, 234);
-    public static RGBColor LightCrimson => FromArgb(245, 105, 145);
-    public static RGBColor LightCyan => FromArgb(224, 255, 255);
-    public static RGBColor LightDeepPink => FromArgb(255, 92, 205);
-    public static RGBColor LightFrenchBeige => FromArgb(200, 173, 127);
-    public static RGBColor LightFuchsiaPink => FromArgb(249, 132, 239);
-    public static RGBColor LightGold => FromArgb(230, 190, 138);
-    public static RGBColor LightGoldenrodYellow => FromArgb(250, 250, 210);
-    public static RGBColor LightGray => FromArgb(211, 211, 211);
-    public static RGBColor LightGreen => FromArgb(144, 238, 144);
-    public static RGBColor LightHotPink => FromArgb(255, 179, 222);
-    public static RGBColor LightKhaki => FromArgb(240, 230, 140);
-    public static RGBColor LightMediumOrchid => FromArgb(211, 155, 203);
-    public static RGBColor LightMossGreen => FromArgb(173, 223, 173);
-    public static RGBColor LightOrchid => FromArgb(230, 168, 215);
-    public static RGBColor LightPastelPurple => FromArgb(177, 156, 217);
-    public static RGBColor LightPink => FromArgb(255, 182, 193);
-    public static RGBColor LightRedOchre => FromArgb(233, 116, 81);
-    public static RGBColor LightSalmon => FromArgb(255, 160, 122);
-    public static RGBColor LightSalmonPink => FromArgb(255, 153, 153);
-    public static RGBColor LightSeaGreen => FromArgb(32, 178, 170);
-    public static RGBColor LightSkyBlue => FromArgb(135, 206, 250);
-    public static RGBColor LightSlateGray => FromArgb(119, 136, 153);
-    public static RGBColor LightSteelBlue => FromArgb(176, 196, 222);
-    public static RGBColor LightTaupe => FromArgb(179, 139, 109);
-    public static RGBColor LightThulianPink => FromArgb(230, 143, 172);
-    public static RGBColor LightYellow => FromArgb(255, 255, 224);
-    public static RGBColor Lilac => FromArgb(200, 162, 200);
-    public static RGBColor LilacLuster => FromArgb(174, 152, 170);
-    public static RGBColor Lime => FromArgb(0, 255, 0);
-    public static RGBColor LimeGreen => FromArgb(50, 205, 50);
-    public static RGBColor Limerick => FromArgb(157, 194, 9);
-    public static RGBColor LincolnGreen => FromArgb(25, 89, 5);
-    public static RGBColor Linen => FromArgb(250, 240, 230);
-    public static RGBColor Lion => FromArgb(193, 154, 107);
-    public static RGBColor LiseranPurple => FromArgb(222, 111, 161);
-    public static RGBColor LittleBoyBlue => FromArgb(108, 160, 220);
-    public static RGBColor Liver => FromArgb(103, 76, 71);
-    public static RGBColor LiverChestnut => FromArgb(152, 116, 86);
-    public static RGBColor LiverOrgan => FromArgb(108, 46, 31);
-    public static RGBColor LiverDogs => FromArgb(184, 109, 41);
-    public static RGBColor LustyGallant => FromArgb(102, 56, 84);
-    public static RGBColor MacaroniAndCheese => FromArgb(255, 189, 136);
-
-    public static RGBColor MadderLake => FromArgb(204, 51, 54);
-    public static RGBColor Magenta => FromArgb(255, 0, 255);
-    public static RGBColor MagentaCrayola => FromArgb(246, 83, 166);
-    public static RGBColor MagentaDye => FromArgb(202, 31, 123);
-    public static RGBColor MagentaPantone => FromArgb(208, 65, 126);
-    public static RGBColor MagentaProcess => FromArgb(255, 0, 144);
-    public static RGBColor MagentaHaze => FromArgb(159, 69, 118);
-    public static RGBColor MagicMint => FromArgb(170, 240, 209);
-    public static RGBColor Magnolia => FromArgb(248, 244, 255);
-    public static RGBColor Mahogany => FromArgb(192, 64, 0);
-    public static RGBColor Maize => FromArgb(251, 236, 93);
-    public static RGBColor Malachite => FromArgb(11, 218, 81);
-    public static RGBColor Manatee => FromArgb(151, 154, 170);
-    public static RGBColor Mandarin => FromArgb(243, 122, 72);
-    public static RGBColor MangoTango => FromArgb(255, 130, 67);
-    public static RGBColor Mantis => FromArgb(116, 195, 101);
-    public static RGBColor MardiGras => FromArgb(136, 0, 133);
-    public static RGBColor Marigold => FromArgb(234, 162, 33);
-    public static RGBColor Maroon => FromArgb(128, 0, 0);
-    public static RGBColor Mauve => FromArgb(224, 176, 255);
-    public static RGBColor MauveTaupe => FromArgb(145, 95, 109);
-    public static RGBColor Mauvelous => FromArgb(239, 152, 170);
-    public static RGBColor MaximumBlue => FromArgb(71, 171, 204);
-    public static RGBColor MaximumBlueGreen => FromArgb(48, 191, 191);
-    public static RGBColor MaximumBluePurple => FromArgb(172, 172, 230);
-    public static RGBColor MaximumGreen => FromArgb(94, 140, 49);
-    public static RGBColor MaximumGreenYellow => FromArgb(217, 230, 80);
-    public static RGBColor MaximumPurple => FromArgb(115, 51, 128);
-    public static RGBColor MaximumRed => FromArgb(217, 33, 33);
-    public static RGBColor MaximumRedPurple => FromArgb(166, 58, 121);
-    public static RGBColor MaximumYellow => FromArgb(250, 250, 55);
-    public static RGBColor MaximumYellowRed => FromArgb(242, 186, 73);
-    public static RGBColor MayGreen => FromArgb(76, 145, 65);
-    public static RGBColor MayaBlue => FromArgb(115, 194, 251);
-    public static RGBColor MediumAquamarine => FromArgb(102, 221, 170);
-    public static RGBColor MediumBlue => FromArgb(0, 0, 205);
-    public static RGBColor MediumCandyAppleRed => FromArgb(226, 6, 44);
-    public static RGBColor MediumCarmine => FromArgb(175, 64, 53);
-    public static RGBColor MediumChampagne => FromArgb(243, 229, 171);
-    public static RGBColor MediumOrchid => FromArgb(186, 85, 211);
-    public static RGBColor MediumPurple => FromArgb(147, 112, 219);
-    public static RGBColor MediumSeaGreen => FromArgb(60, 179, 113);
-    public static RGBColor MediumSlateBlue => FromArgb(123, 104, 238);
-    public static RGBColor MediumSpringGreen => FromArgb(0, 250, 154);
-    public static RGBColor MediumTurquoise => FromArgb(72, 209, 204);
-    public static RGBColor MediumVioletRed => FromArgb(199, 21, 133);
-    public static RGBColor MellowApricot => FromArgb(248, 184, 120);
-    public static RGBColor MellowYellow => FromArgb(248, 222, 126);
-    public static RGBColor Melon => FromArgb(253, 188, 180);
-    public static RGBColor MetallicSeaweed => FromArgb(10, 126, 140);
-    public static RGBColor MetallicSunburst => FromArgb(156, 124, 56);
-    public static RGBColor MexicanPink => FromArgb(228, 0, 124);
-    public static RGBColor MiddleBlue => FromArgb(126, 212, 230);
-    public static RGBColor MiddleBlueGreen => FromArgb(141, 217, 204);
-    public static RGBColor MiddleBluePurple => FromArgb(139, 134, 201);
-    public static RGBColor MiddleGrey => FromArgb(139, 134, 128);
-    public static RGBColor MiddleGreen => FromArgb(91, 165, 96);
-    public static RGBColor MiddleGreenYellow => FromArgb(172, 191, 105);
-    public static RGBColor MiddlePurple => FromArgb(217, 130, 181);
-    public static RGBColor MiddleRed => FromArgb(229, 142, 115);
-    public static RGBColor MiddleRedPurple => FromArgb(165, 83, 83);
-    public static RGBColor MiddleYellow => FromArgb(255, 235, 0);
-    public static RGBColor MiddleYellowRed => FromArgb(236, 177, 118);
-    public static RGBColor MidnightBlue => FromArgb(25, 25, 112);
-    public static RGBColor MidnightGreen => FromArgb(0, 73, 83);
-    public static RGBColor MikadoYellow => FromArgb(255, 196, 12);
-    public static RGBColor MilkChocolate => FromArgb(132, 86, 60);
-    public static RGBColor MintCream => FromArgb(245, 255, 250);
-    public static RGBColor MistyRose => FromArgb(255, 228, 225);
-    public static RGBColor Moccasin => FromArgb(250, 235, 215);
-    public static RGBColor ModeBeige => FromArgb(150, 113, 23);
-    public static RGBColor MoonstoneBlue => FromArgb(115, 169, 194);
-    public static RGBColor MordantRed19 => FromArgb(174, 12, 0);
-    public static RGBColor MossGreen => FromArgb(138, 154, 91);
-    public static RGBColor MountainMeadow => FromArgb(48, 186, 143);
-    public static RGBColor MountbattenPink => FromArgb(153, 122, 141);
-    public static RGBColor MSUGreen => FromArgb(24, 69, 59);
-    public static RGBColor Mulberry => FromArgb(197, 75, 140);
-    public static RGBColor Mustard => FromArgb(255, 219, 88);
-    public static RGBColor MyrtleGreen => FromArgb(49, 120, 115);
-    public static RGBColor Mystic => FromArgb(214, 82, 130);
-    public static RGBColor MysticMaroon => FromArgb(173, 67, 121);
-    public static RGBColor NadeshikoPink => FromArgb(246, 173, 198);
-    public static RGBColor NapierGreen => FromArgb(42, 128, 0);
-    public static RGBColor NaplesYellow => FromArgb(250, 218, 94);
-    public static RGBColor NavajoWhite => FromArgb(255, 222, 173);
-    public static RGBColor NavyBlue => FromArgb(0, 0, 128);
-    public static RGBColor NeonCarrot => FromArgb(255, 163, 67);
-    public static RGBColor NeonFuchsia => FromArgb(254, 65, 100);
-    public static RGBColor NeonGreen => FromArgb(57, 255, 20);
-    public static RGBColor NewYorkPink => FromArgb(215, 131, 127);
-    public static RGBColor Nickel => FromArgb(114, 116, 114);
-    public static RGBColor NonPhotoBlue => FromArgb(164, 221, 237);
-    public static RGBColor NorthTexasGreen => FromArgb(5, 144, 51);
-    public static RGBColor Nyanza => FromArgb(233, 255, 219);
-    public static RGBColor OceanBlue => FromArgb(79, 66, 181);
-    public static RGBColor OceanGreen => FromArgb(72, 191, 145);
-    public static RGBColor Ochre => FromArgb(204, 119, 34);
-    public static RGBColor OfficeGreen => FromArgb(0, 128, 0);
-    public static RGBColor OldBurgundy => FromArgb(67, 48, 46);
-    public static RGBColor OldGold => FromArgb(207, 181, 59);
-    public static RGBColor OldHeliotrope => FromArgb(86, 60, 92);
-    public static RGBColor OldLace => FromArgb(253, 245, 230);
-    public static RGBColor OldLavender => FromArgb(121, 104, 120);
-    public static RGBColor OldMauve => FromArgb(103, 49, 71);
-    public static RGBColor OldMossGreen => FromArgb(134, 126, 54);
-    public static RGBColor OldRose => FromArgb(192, 128, 129);
-    public static RGBColor OldSilver => FromArgb(132, 132, 130);
-    public static RGBColor Olive => FromArgb(128, 128, 0);
-    public static RGBColor OliveDrab7 => FromArgb(60, 52, 31);
-    public static RGBColor OliveGreen => FromArgb(181, 179, 92);
-    public static RGBColor Olivine => FromArgb(154, 185, 115);
-    public static RGBColor Onyx => FromArgb(53, 56, 57);
-    public static RGBColor OperaMauve => FromArgb(183, 132, 167);
-    public static RGBColor Orange => FromArgb(255, 165, 0);
-    public static RGBColor OrangePeel => FromArgb(255, 159, 0);
-    public static RGBColor OrangeRed => FromArgb(255, 69, 0);
-    public static RGBColor OrangeYellow => FromArgb(245, 189, 31);
-    public static RGBColor Orchid => FromArgb(218, 112, 214);
-    public static RGBColor OrchidPink => FromArgb(242, 189, 205);
-    public static RGBColor OriolesOrange => FromArgb(251, 79, 20);
-    public static RGBColor OtterBrown => FromArgb(101, 67, 33);
-    public static RGBColor OuterSpace => FromArgb(65, 74, 76);
-    public static RGBColor OutrageousOrange => FromArgb(255, 110, 74);
-    public static RGBColor OxfordBlue => FromArgb(0, 33, 71);
-    public static RGBColor OUcrimsonRed => FromArgb(153, 0, 0);
-    public static RGBColor PacificBlue => FromArgb(28, 169, 201);
-    public static RGBColor PakistanGreen => FromArgb(0, 102, 0);
-    public static RGBColor PalatinateBlue => FromArgb(39, 59, 226);
-    public static RGBColor PalatinatePurple => FromArgb(104, 40, 96);
-    public static RGBColor PaleAqua => FromArgb(188, 212, 230);
-    public static RGBColor PaleBlue => FromArgb(175, 238, 238);
-    public static RGBColor PaleBrown => FromArgb(152, 118, 84);
-    public static RGBColor PaleCarmine => FromArgb(175, 64, 53);
-    public static RGBColor PaleCerulean => FromArgb(155, 196, 226);
-    public static RGBColor PaleChestnut => FromArgb(221, 173, 175);
-    public static RGBColor PaleCopper => FromArgb(218, 138, 103);
-    public static RGBColor PaleCornflowerBlue => FromArgb(171, 205, 239);
-    public static RGBColor PaleCyan => FromArgb(135, 211, 248);
-    public static RGBColor PaleGold => FromArgb(230, 190, 138);
-    public static RGBColor PaleGoldenrod => FromArgb(238, 232, 170);
-    public static RGBColor PaleGreen => FromArgb(152, 251, 152);
-    public static RGBColor PaleLavender => FromArgb(220, 208, 255);
-    public static RGBColor PaleMagenta => FromArgb(249, 132, 229);
-    public static RGBColor PaleMagentaPink => FromArgb(255, 153, 204);
-    public static RGBColor PalePink => FromArgb(250, 218, 221);
-    public static RGBColor PalePlum => FromArgb(221, 160, 221);
-    public static RGBColor PaleRedViolet => FromArgb(219, 112, 147);
-    public static RGBColor PaleRobinEggBlue => FromArgb(150, 222, 209);
-    public static RGBColor PaleSilver => FromArgb(201, 192, 187);
-    public static RGBColor PaleSpringBud => FromArgb(236, 235, 189);
-    public static RGBColor PaleTaupe => FromArgb(188, 152, 126);
-    public static RGBColor PaleTurquoise => FromArgb(175, 238, 238);
-    public static RGBColor PaleViolet => FromArgb(204, 153, 255);
-    public static RGBColor PaleVioletRed => FromArgb(219, 112, 147);
-    public static RGBColor PalmLeaf => FromArgb(25, 51, 14);
-    public static RGBColor PansyPurple => FromArgb(120, 24, 74);
-    public static RGBColor PaoloVeroneseGreen => FromArgb(0, 155, 125);
-    public static RGBColor PapayaWhip => FromArgb(255, 239, 213);
-    public static RGBColor ParadisePink => FromArgb(230, 62, 98);
-    public static RGBColor ParisGreen => FromArgb(80, 200, 120);
-    public static RGBColor PastelBlue => FromArgb(174, 198, 207);
-    public static RGBColor PastelBrown => FromArgb(131, 105, 83);
-    public static RGBColor PastelGray => FromArgb(207, 207, 196);
-    public static RGBColor PastelGreen => FromArgb(119, 221, 119);
-    public static RGBColor PastelMagenta => FromArgb(244, 154, 194);
-    public static RGBColor PastelOrange => FromArgb(255, 179, 71);
-    public static RGBColor PastelPink => FromArgb(222, 165, 164);
-    public static RGBColor PastelPurple => FromArgb(179, 158, 181);
-    public static RGBColor PastelRed => FromArgb(255, 105, 97);
-    public static RGBColor PastelViolet => FromArgb(203, 153, 201);
-    public static RGBColor PastelYellow => FromArgb(253, 253, 150);
-    public static RGBColor Patriarch => FromArgb(128, 0, 128);
-    public static RGBColor PayneGrey => FromArgb(83, 104, 120);
-    public static RGBColor Peach => FromArgb(255, 229, 180);
-    public static RGBColor PeachOrange => FromArgb(255, 204, 153);
-    public static RGBColor PeachPuff => FromArgb(255, 218, 185);
-    public static RGBColor PeachYellow => FromArgb(250, 223, 173);
-    public static RGBColor Pear => FromArgb(209, 226, 49);
-    public static RGBColor Pearl => FromArgb(234, 224, 200);
-    public static RGBColor PearlAqua => FromArgb(136, 216, 192);
-    public static RGBColor PearlyPurple => FromArgb(183, 104, 162);
-    public static RGBColor Peridot => FromArgb(230, 226, 0);
-    public static RGBColor Periwinkle => FromArgb(204, 204, 255);
-    public static RGBColor PersianBlue => FromArgb(28, 57, 187);
-    public static RGBColor PersianGreen => FromArgb(0, 166, 147);
-    public static RGBColor PersianIndigo => FromArgb(50, 18, 122);
-    public static RGBColor PersianOrange => FromArgb(217, 144, 88);
-    public static RGBColor PersianPink => FromArgb(247, 127, 190);
-    public static RGBColor PersianPlum => FromArgb(112, 28, 28);
-    public static RGBColor PersianRed => FromArgb(204, 51, 51);
-    public static RGBColor PersianRose => FromArgb(254, 40, 162);
-    public static RGBColor Persimmon => FromArgb(236, 88, 0);
-    public static RGBColor Peru => FromArgb(205, 133, 63);
-    public static RGBColor Phlox => FromArgb(223, 0, 255);
-    public static RGBColor PhthaloBlue => FromArgb(0, 15, 137);
-    public static RGBColor PhthaloGreen => FromArgb(18, 53, 36);
-    public static RGBColor PictonBlue => FromArgb(69, 177, 232);
-    public static RGBColor PictorialCarmine => FromArgb(195, 11, 78);
-    public static RGBColor PiggyPink => FromArgb(253, 221, 230);
-    public static RGBColor PineGreen => FromArgb(1, 121, 111);
-    public static RGBColor Pineapple => FromArgb(86, 60, 13);
-    public static RGBColor Pink => FromArgb(255, 192, 203);
-    public static RGBColor PinkLace => FromArgb(255, 221, 244);
-    public static RGBColor PinkLavender => FromArgb(216, 178, 209);
-    public static RGBColor PinkPearl => FromArgb(231, 172, 207);
-    public static RGBColor PinkRaspberry => FromArgb(152, 0, 54);
-    public static RGBColor PinkSherbet => FromArgb(247, 143, 167);
-    public static RGBColor Pistachio => FromArgb(147, 197, 114);
-    public static RGBColor Platinum => FromArgb(229, 228, 226);
-    public static RGBColor Plum => FromArgb(142, 69, 133);
-    public static RGBColor PlumWeb => FromArgb(221, 160, 221);
-    public static RGBColor PompAndPower => FromArgb(134, 96, 142);
-    public static RGBColor Popstar => FromArgb(190, 79, 98);
-    public static RGBColor PortlandOrange => FromArgb(255, 90, 54);
-    public static RGBColor PowderBlue => FromArgb(176, 224, 230);
-    public static RGBColor PrincetonOrange => FromArgb(245, 128, 37);
-    public static RGBColor Prune => FromArgb(112, 28, 28);
-    public static RGBColor PrussianBlue => FromArgb(0, 49, 83);
-    public static RGBColor PsychedelicPurple => FromArgb(223, 0, 255);
-    public static RGBColor Puce => FromArgb(204, 136, 153);
-    public static RGBColor PuceRed => FromArgb(114, 47, 55);
-    public static RGBColor PullmanBrown => FromArgb(100, 65, 23);
-    public static RGBColor PullmanGreen => FromArgb(59, 51, 28);
-    public static RGBColor Pumpkin => FromArgb(255, 117, 24);
-    public static RGBColor Purple => FromArgb(128, 0, 128);
-    public static RGBColor PurpleHeart => FromArgb(105, 53, 156);
-    public static RGBColor PurpleMountainMajesty => FromArgb(150, 120, 182);
-    public static RGBColor PurpleNavy => FromArgb(78, 81, 128);
-    public static RGBColor PurplePizzazz => FromArgb(254, 78, 218);
-    public static RGBColor PurpleTaupe => FromArgb(80, 64, 77);
-    public static RGBColor Purpureus => FromArgb(154, 78, 174);
-    public static RGBColor Quartz => FromArgb(81, 72, 79);
-    public static RGBColor QueenBlue => FromArgb(67, 107, 149);
-    public static RGBColor QueenPink => FromArgb(232, 204, 215);
-    public static RGBColor QuickSilver => FromArgb(166, 166, 166);
-    public static RGBColor RadicalRed => FromArgb(255, 53, 94);
-    public static RGBColor RaisinBlack => FromArgb(36, 33, 36);
-    public static RGBColor Rajah => FromArgb(251, 171, 96);
-    public static RGBColor Raspberry => FromArgb(227, 11, 93);
-    public static RGBColor RaspberryPink => FromArgb(226, 80, 152);
-    public static RGBColor RawSienna => FromArgb(214, 138, 89);
-    public static RGBColor RazzleDazzleRose => FromArgb(255, 51, 204);
-    public static RGBColor Razzmatazz => FromArgb(227, 37, 107);
-    public static RGBColor RazzmicBerry => FromArgb(141, 78, 133);
-    public static RGBColor RebeccaPurple => FromArgb(102, 52, 153);
-    public static RGBColor Red => FromArgb(255, 0, 0);
-    public static RGBColor RedDevil => FromArgb(134, 1, 17);
-    public static RGBColor RedOrange => FromArgb(255, 83, 73);
-    public static RGBColor RedPurple => FromArgb(228, 0, 120);
-    public static RGBColor RedSalsa => FromArgb(253, 58, 74);
-    public static RGBColor RedViolet => FromArgb(199, 21, 133);
-    public static RGBColor Redwood => FromArgb(164, 90, 82);
-    public static RGBColor Regalia => FromArgb(82, 45, 128);
-    public static RGBColor ResolutionBlue => FromArgb(0, 35, 135);
-    public static RGBColor Rhythm => FromArgb(119, 118, 150);
-    public static RGBColor RichBlack => FromArgb(0, 64, 64);
-    public static RGBColor RichBrilliantLavender => FromArgb(241, 167, 254);
-    public static RGBColor RichCarmine => FromArgb(215, 0, 64);
-    public static RGBColor RichElectricBlue => FromArgb(8, 146, 208);
-    public static RGBColor RichLavender => FromArgb(167, 107, 207);
-    public static RGBColor RichLilac => FromArgb(182, 102, 210);
-    public static RGBColor RichMaroon => FromArgb(176, 48, 96);
-    public static RGBColor RifleGreen => FromArgb(68, 76, 56);
-    public static RGBColor RoastCoffee => FromArgb(112, 66, 65);
-    public static RGBColor RobinEggBlue => FromArgb(0, 204, 204);
-    public static RGBColor RocketMetallic => FromArgb(138, 127, 128);
-    public static RGBColor RomanSilver => FromArgb(131, 137, 150);
-    public static RGBColor Rose => FromArgb(255, 0, 127);
-    public static RGBColor RoseBonbon => FromArgb(249, 66, 158);
-    public static RGBColor RoseDust => FromArgb(158, 94, 111);
-    public static RGBColor RoseEbony => FromArgb(103, 72, 70);
-    public static RGBColor RoseGold => FromArgb(183, 110, 121);
-    public static RGBColor RoseMadder => FromArgb(227, 38, 54);
-    public static RGBColor RosePink => FromArgb(255, 102, 204);
-    public static RGBColor RoseQuartz => FromArgb(170, 152, 169);
-    public static RGBColor RoseRed => FromArgb(194, 30, 86);
-    public static RGBColor RoseTaupe => FromArgb(144, 93, 93);
-    public static RGBColor RoseVale => FromArgb(171, 78, 82);
-    public static RGBColor Rosewood => FromArgb(101, 0, 11);
-    public static RGBColor RossoCorsa => FromArgb(212, 0, 0);
-    public static RGBColor RosyBrown => FromArgb(188, 143, 143);
-    public static RGBColor RoyalAzure => FromArgb(0, 56, 168);
-    public static RGBColor RoyalBlue => FromArgb(0, 35, 102);
-    public static RGBColor RoyalFuchsia => FromArgb(202, 44, 146);
-    public static RGBColor RoyalPurple => FromArgb(120, 81, 169);
-    public static RGBColor RoyalYellow => FromArgb(250, 218, 94);
-    public static RGBColor Ruber => FromArgb(206, 70, 118);
-    public static RGBColor RubineRed => FromArgb(209, 0, 86);
-    public static RGBColor Ruby => FromArgb(224, 17, 95);
-    public static RGBColor RubyRed => FromArgb(155, 17, 30);
-    public static RGBColor Ruddy => FromArgb(255, 0, 40);
-    public static RGBColor RuddyBrown => FromArgb(187, 101, 40);
-    public static RGBColor RuddyPink => FromArgb(225, 142, 150);
-    public static RGBColor Rufous => FromArgb(168, 28, 7);
-    public static RGBColor Russet => FromArgb(128, 70, 27);
-    public static RGBColor RussianGreen => FromArgb(103, 146, 103);
-    public static RGBColor RussianViolet => FromArgb(50, 23, 77);
-    public static RGBColor Rust => FromArgb(183, 65, 14);
-    public static RGBColor RustyRed => FromArgb(218, 44, 67);
-    public static RGBColor SacramentoStateGreen => FromArgb(0, 86, 63);
-    public static RGBColor SaddleBrown => FromArgb(139, 69, 19);
-    public static RGBColor SafetyOrange => FromArgb(255, 103, 0);
-    public static RGBColor SafetyYellow => FromArgb(238, 210, 2);
-    public static RGBColor Saffron => FromArgb(244, 196, 48);
-    public static RGBColor Sage => FromArgb(188, 184, 138);
-    public static RGBColor StPatricksBlue => FromArgb(35, 41, 122);
-    public static RGBColor Salmon => FromArgb(250, 128, 114);
-    public static RGBColor SalmonPink => FromArgb(255, 145, 164);
-    public static RGBColor Sand => FromArgb(194, 178, 128);
-    public static RGBColor SandDune => FromArgb(150, 113, 23);
-    public static RGBColor Sandstorm => FromArgb(236, 213, 64);
-    public static RGBColor SandyBrown => FromArgb(244, 164, 96);
-    public static RGBColor SandyTan => FromArgb(253, 217, 181);
-    public static RGBColor SandyTaupe => FromArgb(150, 113, 23);
-    public static RGBColor Sangria => FromArgb(146, 0, 10);
-    public static RGBColor SapGreen => FromArgb(80, 125, 42);
-    public static RGBColor Sapphire => FromArgb(15, 82, 186);
-    public static RGBColor SapphireBlue => FromArgb(0, 103, 165);
-    public static RGBColor SatinSheenGold => FromArgb(203, 161, 53);
-    public static RGBColor Scarlet => FromArgb(255, 36, 0);
-    public static RGBColor SchaussPink => FromArgb(255, 145, 175);
-    public static RGBColor SchoolBusYellow => FromArgb(255, 216, 0);
-    public static RGBColor ScreaminGreen => FromArgb(118, 255, 122);
-    public static RGBColor SeaBlue => FromArgb(0, 105, 148);
-    public static RGBColor SeaGreen => FromArgb(46, 139, 87);
-    public static RGBColor SealBrown => FromArgb(50, 20, 20);
-    public static RGBColor Seashell => FromArgb(255, 245, 238);
-    public static RGBColor SelectiveYellow => FromArgb(255, 186, 0);
-    public static RGBColor Sepia => FromArgb(112, 66, 20);
-    public static RGBColor Shadow => FromArgb(138, 121, 93);
-    public static RGBColor ShadowBlue => FromArgb(119, 139, 165);
-    public static RGBColor Shampoo => FromArgb(255, 207, 241);
-    public static RGBColor ShamrockGreen => FromArgb(0, 158, 96);
-    public static RGBColor SheenGreen => FromArgb(143, 212, 0);
-    public static RGBColor ShimmeringBlush => FromArgb(217, 134, 149);
-    public static RGBColor ShinyShamrock => FromArgb(95, 167, 120);
-    public static RGBColor ShockingPink => FromArgb(252, 15, 192);
-    public static RGBColor Sienna => FromArgb(136, 45, 23);
-    public static RGBColor Silver => FromArgb(192, 192, 192);
-    public static RGBColor SilverChalice => FromArgb(172, 172, 172);
-    public static RGBColor SilverLakeBlue => FromArgb(93, 137, 186);
-    public static RGBColor SilverPink => FromArgb(196, 174, 173);
-    public static RGBColor SilverSand => FromArgb(191, 193, 194);
-    public static RGBColor Sinopia => FromArgb(203, 65, 11);
-    public static RGBColor SizzlingRed => FromArgb(255, 56, 85);
-    public static RGBColor SizzlingSunrise => FromArgb(255, 219, 0);
-    public static RGBColor Skobeloff => FromArgb(0, 116, 116);
-    public static RGBColor SkyBlue => FromArgb(135, 206, 235);
-    public static RGBColor SkyMagenta => FromArgb(207, 113, 175);
-    public static RGBColor SlateBlue => FromArgb(106, 90, 205);
-    public static RGBColor SlateGray => FromArgb(112, 128, 144);
-    public static RGBColor Smalt => FromArgb(0, 51, 153);
-    public static RGBColor SmashedPumpkin => FromArgb(255, 109, 58);
-    public static RGBColor Smitten => FromArgb(200, 65, 134);
-    public static RGBColor Smoke => FromArgb(115, 130, 118);
-    public static RGBColor SmokeyTopaz => FromArgb(147, 61, 65);
-    public static RGBColor Snow => FromArgb(255, 250, 250);
-    public static RGBColor Soap => FromArgb(206, 200, 239);
-    public static RGBColor SolidPink => FromArgb(137, 56, 67);
-    public static RGBColor SonicSilver => FromArgb(117, 117, 117);
-    public static RGBColor SpartanCrimson => FromArgb(158, 19, 22);
-    public static RGBColor SpaceCadet => FromArgb(29, 41, 81);
-    public static RGBColor SpanishBistre => FromArgb(128, 117, 50);
-    public static RGBColor SpanishBlue => FromArgb(0, 112, 184);
-    public static RGBColor SpanishCarmine => FromArgb(209, 0, 71);
-    public static RGBColor SpanishGray => FromArgb(152, 152, 152);
-    public static RGBColor SpanishGreen => FromArgb(0, 145, 80);
-    public static RGBColor SpanishOrange => FromArgb(232, 97, 0);
-    public static RGBColor SpanishPink => FromArgb(247, 191, 190);
-    public static RGBColor SpanishRed => FromArgb(230, 0, 38);
-    public static RGBColor SpanishSkyBlue => FromArgb(0, 255, 255);
-    public static RGBColor SpanishViolet => FromArgb(76, 40, 130);
-    public static RGBColor SpanishViridian => FromArgb(0, 127, 92);
-    public static RGBColor SpectralBlue => FromArgb(46, 88, 148);
-    public static RGBColor SpectralGreen => FromArgb(0, 158, 96);
-    public static RGBColor SpectralRed => FromArgb(191, 0, 38);
-    public static RGBColor Spice => FromArgb(106, 68, 46);
-    public static RGBColor SpicyMix => FromArgb(139, 95, 77);
-    public static RGBColor SpiroDiscoBall => FromArgb(15, 192, 252);
-    public static RGBColor SpringBud => FromArgb(167, 252, 0);
-    public static RGBColor SpringFrost => FromArgb(135, 255, 42);
-    public static RGBColor SpringGreen => FromArgb(0, 255, 127);
-    public static RGBColor StarCommandBlue => FromArgb(0, 123, 184);
-    public static RGBColor SteelBlue => FromArgb(70, 130, 180);
-    public static RGBColor SteelPink => FromArgb(204, 51, 204);
-    public static RGBColor SteelTeal => FromArgb(95, 138, 139);
-    public static RGBColor StilDeGrainYellow => FromArgb(250, 218, 94);
-    public static RGBColor Stizza => FromArgb(153, 0, 0);
-    public static RGBColor Stormcloud => FromArgb(79, 102, 106);
-    public static RGBColor Straw => FromArgb(228, 217, 111);
-    public static RGBColor Strawberry => FromArgb(252, 90, 141);
-    public static RGBColor SugarPlum => FromArgb(145, 78, 117);
-    public static RGBColor SunburntCyclops => FromArgb(255, 64, 76);
-    public static RGBColor Sunglow => FromArgb(255, 204, 51);
-    public static RGBColor Sunny => FromArgb(242, 242, 122);
-    public static RGBColor Sunray => FromArgb(227, 171, 87);
-    public static RGBColor Sunset => FromArgb(250, 214, 165);
-    public static RGBColor SunsetOrange => FromArgb(253, 94, 83);
-    public static RGBColor SuperPink => FromArgb(207, 107, 169);
-    public static RGBColor SweetBrown => FromArgb(168, 55, 49);
-    public static RGBColor Tan => FromArgb(210, 180, 140);
-    public static RGBColor Tangelo => FromArgb(249, 77, 0);
-    public static RGBColor Tangerine => FromArgb(242, 133, 0);
-    public static RGBColor TangerineYellow => FromArgb(255, 204, 0);
-    public static RGBColor TangoPink => FromArgb(228, 113, 122);
-    public static RGBColor TartOrange => FromArgb(251, 77, 70);
-    public static RGBColor Taupe => FromArgb(72, 60, 50);
-    public static RGBColor TaupeGray => FromArgb(139, 133, 137);
-    public static RGBColor TeaGreen => FromArgb(208, 240, 192);
-    public static RGBColor TeaRose => FromArgb(244, 194, 194);
-    public static RGBColor Teal => FromArgb(0, 128, 128);
-    public static RGBColor TealBlue => FromArgb(54, 117, 136);
-    public static RGBColor TealDeer => FromArgb(153, 230, 179);
-    public static RGBColor TealGreen => FromArgb(0, 130, 127);
-    public static RGBColor Telemagenta => FromArgb(207, 52, 118);
-    public static RGBColor TerraCotta => FromArgb(226, 114, 91);
-    public static RGBColor Thistle => FromArgb(216, 191, 216);
-    public static RGBColor ThulianPink => FromArgb(222, 111, 161);
-    public static RGBColor TickleMePink => FromArgb(252, 137, 172);
-    public static RGBColor TiffanyBlue => FromArgb(10, 186, 181);
-    public static RGBColor TigersEye => FromArgb(224, 141, 60);
-    public static RGBColor Timberwolf => FromArgb(219, 215, 210);
-    public static RGBColor TitaniumYellow => FromArgb(238, 230, 0);
-    public static RGBColor Tomato => FromArgb(255, 99, 71);
-    public static RGBColor Toolbox => FromArgb(116, 108, 192);
-    public static RGBColor Topaz => FromArgb(255, 200, 124);
-    public static RGBColor TractorRed => FromArgb(253, 14, 53);
-    public static RGBColor TrolleyGrey => FromArgb(128, 128, 128);
-    public static RGBColor TropicalRainForest => FromArgb(0, 117, 94);
-    public static RGBColor TrueBlue => FromArgb(0, 115, 207);
-    public static RGBColor TuftsBlue => FromArgb(65, 125, 193);
-    public static RGBColor Tulip => FromArgb(255, 135, 141);
-    public static RGBColor Tumbleweed => FromArgb(222, 170, 136);
-    public static RGBColor TurkishRose => FromArgb(181, 114, 129);
-    public static RGBColor Turquoise => FromArgb(48, 213, 200);
-    public static RGBColor TurquoiseBlue => FromArgb(0, 255, 239);
-    public static RGBColor TurquoiseGreen => FromArgb(160, 214, 180);
-    public static RGBColor TurquoiseSurf => FromArgb(0, 197, 205);
-    public static RGBColor TurtleGreen => FromArgb(138, 154, 91);
-    public static RGBColor Tuscan => FromArgb(250, 214, 165);
-    public static RGBColor TuscanBrown => FromArgb(111, 78, 55);
-    public static RGBColor TuscanRed => FromArgb(124, 72, 72);
-    public static RGBColor TuscanTan => FromArgb(166, 123, 91);
-    public static RGBColor Tuscany => FromArgb(192, 153, 153);
-    public static RGBColor TwilightLavender => FromArgb(138, 73, 107);
-    public static RGBColor TyrianPurple => FromArgb(102, 2, 60);
-    public static RGBColor UAblue => FromArgb(0, 51, 170);
-    public static RGBColor UARed => FromArgb(217, 0, 76);
-    public static RGBColor Ube => FromArgb(136, 120, 195);
-    public static RGBColor UCLAblue => FromArgb(83, 104, 149);
-    public static RGBColor UFOGreen => FromArgb(60, 208, 112);
-    public static RGBColor Ultramarine => FromArgb(18, 10, 143);
-    public static RGBColor UltramarineBlue => FromArgb(65, 102, 245);
-    public static RGBColor UltraPink => FromArgb(255, 111, 255);
-    public static RGBColor UltraRed => FromArgb(252, 108, 133);
-    public static RGBColor Umber => FromArgb(99, 81, 71);
-    public static RGBColor UnbleachedSilk => FromArgb(255, 221, 202);
-    public static RGBColor UnitedNationsBlue => FromArgb(91, 146, 229);
-    public static RGBColor UniversityOfCaliforniaGold => FromArgb(183, 135, 39);
-    public static RGBColor UnmellowYellow => FromArgb(255, 255, 102);
-    public static RGBColor UPForestGreen => FromArgb(1, 68, 33);
-    public static RGBColor UPMaroon => FromArgb(123, 17, 19);
-    public static RGBColor UpsdellRed => FromArgb(174, 32, 41);
-    public static RGBColor Urobilin => FromArgb(225, 173, 33);
-    public static RGBColor USAFABlue => FromArgb(0, 79, 152);
-    public static RGBColor UtahCrimson => FromArgb(211, 0, 63);
-    public static RGBColor Vanilla => FromArgb(243, 229, 171);
-    public static RGBColor VanillaIce => FromArgb(243, 143, 169);
-    public static RGBColor VegasGold => FromArgb(197, 179, 88);
-    public static RGBColor VenetianRed => FromArgb(200, 8, 21);
-    public static RGBColor Verdigris => FromArgb(67, 179, 174);
-    public static RGBColor Vermilion => FromArgb(227, 66, 52);
-    public static RGBColor Veronica => FromArgb(160, 32, 240);
-    public static RGBColor VeryLightAzure => FromArgb(116, 187, 251);
-    public static RGBColor VeryLightBlue => FromArgb(102, 102, 255);
-    public static RGBColor VeryLightMalachiteGreen => FromArgb(100, 233, 134);
-    public static RGBColor VeryLightTangelo => FromArgb(255, 176, 119);
-    public static RGBColor VeryPaleOrange => FromArgb(255, 223, 191);
-    public static RGBColor VeryPaleYellow => FromArgb(255, 255, 191);
-    public static RGBColor Violet => FromArgb(127, 0, 255);
-    public static RGBColor VioletBlue => FromArgb(50, 74, 178);
-    public static RGBColor VioletRed => FromArgb(247, 83, 148);
-    public static RGBColor Viridian => FromArgb(64, 130, 109);
-    public static RGBColor ViridianGreen => FromArgb(0, 150, 152);
-    public static RGBColor VistaBlue => FromArgb(124, 158, 217);
-    public static RGBColor VividAuburn => FromArgb(146, 39, 36);
-    public static RGBColor VividBurgundy => FromArgb(159, 29, 53);
-    public static RGBColor VividCerise => FromArgb(218, 29, 129);
-    public static RGBColor VividTangerine => FromArgb(255, 160, 137);
-    public static RGBColor VividViolet => FromArgb(159, 0, 255);
-    public static RGBColor WarmBlack => FromArgb(0, 66, 66);
-    public static RGBColor Waterspout => FromArgb(164, 244, 249);
-    public static RGBColor Wenge => FromArgb(100, 84, 82);
-    public static RGBColor Wheat => FromArgb(245, 222, 179);
-    public static RGBColor White => FromArgb(255, 255, 255);
-    public static RGBColor WhiteSmoke => FromArgb(245, 245, 245);
-    public static RGBColor WildBlueYonder => FromArgb(162, 173, 208);
-    public static RGBColor WildStrawberry => FromArgb(255, 67, 164);
-    public static RGBColor WildWatermelon => FromArgb(252, 108, 133);
-    public static RGBColor Wine => FromArgb(114, 47, 55);
-    public static RGBColor WinterSky => FromArgb(255, 0, 124);
-    public static RGBColor WinterWizard => FromArgb(160, 230, 255);
-    public static RGBColor Wisteria => FromArgb(201, 160, 220);
-    public static RGBColor Xanadu => FromArgb(115, 134, 120);
-    public static RGBColor YaleBlue => FromArgb(15, 77, 146);
-    public static RGBColor Yellow => FromArgb(255, 255, 0);
-    public static RGBColor YellowGreen => FromArgb(154, 205, 50);
-    public static RGBColor YellowOrange => FromArgb(255, 174, 66);
-    public static RGBColor YellowRose => FromArgb(255, 240, 0);
-    public static RGBColor Zaffre => FromArgb(0, 20, 168);
-    public static RGBColor ZinnwalditeBrown => FromArgb(44, 22, 8);
-    public static RGBColor Zomp => FromArgb(57, 167, 142);
+﻿namespace HtmlForgeX;
+
+/// <summary>
+/// Predefined colors (potential for autogeneration)
+/// </summary>
+public partial class RGBColor {
+    /// <summary>
+    /// Gets the None color.
+    /// </summary>
+    public static RGBColor None => FromArgb(0, 0, 0);
+    /// <summary>
+    /// Gets the AirForceBlue color.
+    /// </summary>
+    public static RGBColor AirForceBlue => FromArgb(93, 138, 168);
+    /// <summary>
+    /// Gets the Akaroa color.
+    /// </summary>
+    public static RGBColor Akaroa => FromArgb(195, 176, 145);
+    /// <summary>
+    /// Gets the AlbescentWhite color.
+    /// </summary>
+    public static RGBColor AlbescentWhite => FromArgb(227, 218, 201);
+    /// <summary>
+    /// Gets the AliceBlue color.
+    /// </summary>
+    public static RGBColor AliceBlue => FromArgb(240, 248, 255);
+    /// <summary>
+    /// Gets the Alizarin color.
+    /// </summary>
+    public static RGBColor Alizarin => FromArgb(227, 38, 54);
+    /// <summary>
+    /// Gets the Allports color.
+    /// </summary>
+    public static RGBColor Allports => FromArgb(18, 97, 128);
+    /// <summary>
+    /// Gets the Amaranth color.
+    /// </summary>
+    public static RGBColor Amaranth => FromArgb(229, 43, 80);
+    /// <summary>
+    /// Gets the Amazon color.
+    /// </summary>
+    public static RGBColor Amazon => FromArgb(59, 122, 87);
+    /// <summary>
+    /// Gets the Amber color.
+    /// </summary>
+    public static RGBColor Amber => FromArgb(255, 191, 0);
+    /// <summary>
+    /// Gets the Amethyst color.
+    /// </summary>
+    public static RGBColor Amethyst => FromArgb(153, 102, 204);
+    /// <summary>
+    /// Gets the AmethystSmoke color.
+    /// </summary>
+    public static RGBColor AmethystSmoke => FromArgb(156, 138, 164);
+    /// <summary>
+    /// Gets the AntiqueWhite color.
+    /// </summary>
+    public static RGBColor AntiqueWhite => FromArgb(250, 235, 215);
+    /// <summary>
+    /// Gets the Apple color.
+    /// </summary>
+    public static RGBColor Apple => FromArgb(102, 180, 71);
+    /// <summary>
+    /// Gets the AppleBlossom color.
+    /// </summary>
+    public static RGBColor AppleBlossom => FromArgb(176, 92, 82);
+    /// <summary>
+    /// Gets the Apricot color.
+    /// </summary>
+    public static RGBColor Apricot => FromArgb(251, 206, 177);
+    /// <summary>
+    /// Gets the Aqua color.
+    /// </summary>
+    public static RGBColor Aqua => FromArgb(0, 255, 255);
+    /// <summary>
+    /// Gets the Aquamarine color.
+    /// </summary>
+    public static RGBColor Aquamarine => FromArgb(127, 255, 212);
+    /// <summary>
+    /// Gets the Armygreen color.
+    /// </summary>
+    public static RGBColor Armygreen => FromArgb(75, 83, 32);
+    /// <summary>
+    /// Gets the Arsenic color.
+    /// </summary>
+    public static RGBColor Arsenic => FromArgb(59, 68, 75);
+    /// <summary>
+    /// Gets the Astral color.
+    /// </summary>
+    public static RGBColor Astral => FromArgb(54, 117, 136);
+    /// <summary>
+    /// Gets the Atlantis color.
+    /// </summary>
+    public static RGBColor Atlantis => FromArgb(164, 198, 57);
+    /// <summary>
+    /// Gets the Atomic color.
+    /// </summary>
+    public static RGBColor Atomic => FromArgb(65, 74, 76);
+    /// <summary>
+    /// Gets the AtomicTangerine color.
+    /// </summary>
+    public static RGBColor AtomicTangerine => FromArgb(255, 153, 102);
+    /// <summary>
+    /// Gets the Axolotl color.
+    /// </summary>
+    public static RGBColor Axolotl => FromArgb(99, 119, 91);
+    /// <summary>
+    /// Gets the Azure color.
+    /// </summary>
+    public static RGBColor Azure => FromArgb(240, 255, 255);
+    /// <summary>
+    /// Gets the Bahia color.
+    /// </summary>
+    public static RGBColor Bahia => FromArgb(176, 191, 26);
+    /// <summary>
+    /// Gets the BakersChocolate color.
+    /// </summary>
+    public static RGBColor BakersChocolate => FromArgb(93, 58, 26);
+    /// <summary>
+    /// Gets the BaliHai color.
+    /// </summary>
+    public static RGBColor BaliHai => FromArgb(124, 152, 171);
+    /// <summary>
+    /// Gets the BananaMania color.
+    /// </summary>
+    public static RGBColor BananaMania => FromArgb(250, 231, 181);
+    /// <summary>
+    /// Gets the BattleshipGrey color.
+    /// </summary>
+    public static RGBColor BattleshipGrey => FromArgb(85, 93, 80);
+    /// <summary>
+    /// Gets the BayOfMany color.
+    /// </summary>
+    public static RGBColor BayOfMany => FromArgb(35, 48, 103);
+    /// <summary>
+    /// Gets the Beige color.
+    /// </summary>
+    public static RGBColor Beige => FromArgb(245, 245, 220);
+    /// <summary>
+    /// Gets the Bermuda color.
+    /// </summary>
+    public static RGBColor Bermuda => FromArgb(136, 216, 192);
+    /// <summary>
+    /// Gets the Bilbao color.
+    /// </summary>
+    public static RGBColor Bilbao => FromArgb(42, 128, 0);
+    /// <summary>
+    /// Gets the BilobaFlower color.
+    /// </summary>
+    public static RGBColor BilobaFlower => FromArgb(181, 126, 220);
+    /// <summary>
+    /// Gets the Bismark color.
+    /// </summary>
+    public static RGBColor Bismark => FromArgb(83, 104, 114);
+    /// <summary>
+    /// Gets the Bisque color.
+    /// </summary>
+    public static RGBColor Bisque => FromArgb(255, 228, 196);
+    /// <summary>
+    /// Gets the Bistre color.
+    /// </summary>
+    public static RGBColor Bistre => FromArgb(61, 43, 31);
+    /// <summary>
+    /// Gets the Bittersweet color.
+    /// </summary>
+    public static RGBColor Bittersweet => FromArgb(254, 111, 94);
+    /// <summary>
+    /// Gets the Black color.
+    /// </summary>
+    public static RGBColor Black => FromArgb(0, 0, 0);
+    /// <summary>
+    /// Gets the BlackPearl color.
+    /// </summary>
+    public static RGBColor BlackPearl => FromArgb(31, 38, 42);
+    /// <summary>
+    /// Gets the BlackRose color.
+    /// </summary>
+    public static RGBColor BlackRose => FromArgb(85, 31, 47);
+    /// <summary>
+    /// Gets the BlackRussian color.
+    /// </summary>
+    public static RGBColor BlackRussian => FromArgb(23, 24, 43);
+    /// <summary>
+    /// Gets the BlanchedAlmond color.
+    /// </summary>
+    public static RGBColor BlanchedAlmond => FromArgb(255, 235, 205);
+    /// <summary>
+    /// Gets the BlizzardBlue color.
+    /// </summary>
+    public static RGBColor BlizzardBlue => FromArgb(172, 229, 238);
+    /// <summary>
+    /// Gets the Blue color.
+    /// </summary>
+    public static RGBColor Blue => FromArgb(0, 0, 255);
+    /// <summary>
+    /// Gets the BlueDiamond color.
+    /// </summary>
+    public static RGBColor BlueDiamond => FromArgb(77, 26, 127);
+    /// <summary>
+    /// Gets the BlueMarguerite color.
+    /// </summary>
+    public static RGBColor BlueMarguerite => FromArgb(115, 102, 189);
+    /// <summary>
+    /// Gets the BlueSmoke color.
+    /// </summary>
+    public static RGBColor BlueSmoke => FromArgb(115, 130, 118);
+    /// <summary>
+    /// Gets the BlueViolet color.
+    /// </summary>
+    public static RGBColor BlueViolet => FromArgb(138, 43, 226);
+    /// <summary>
+    /// Gets the Blush color.
+    /// </summary>
+    public static RGBColor Blush => FromArgb(169, 92, 104);
+    /// <summary>
+    /// Gets the BokaraGrey color.
+    /// </summary>
+    public static RGBColor BokaraGrey => FromArgb(22, 17, 13);
+    /// <summary>
+    /// Gets the Bole color.
+    /// </summary>
+    public static RGBColor Bole => FromArgb(121, 68, 59);
+    /// <summary>
+    /// Gets the BondiBlue color.
+    /// </summary>
+    public static RGBColor BondiBlue => FromArgb(0, 147, 175);
+    /// <summary>
+    /// Gets the Bordeaux color.
+    /// </summary>
+    public static RGBColor Bordeaux => FromArgb(88, 17, 26);
+    /// <summary>
+    /// Gets the Bossanova color.
+    /// </summary>
+    public static RGBColor Bossanova => FromArgb(86, 60, 92);
+    /// <summary>
+    /// Gets the Boulder color.
+    /// </summary>
+    public static RGBColor Boulder => FromArgb(114, 116, 114);
+    /// <summary>
+    /// Gets the Bouquet color.
+    /// </summary>
+    public static RGBColor Bouquet => FromArgb(183, 132, 167);
+    /// <summary>
+    /// Gets the Bourbon color.
+    /// </summary>
+    public static RGBColor Bourbon => FromArgb(170, 108, 57);
+    /// <summary>
+    /// Gets the Brass color.
+    /// </summary>
+    public static RGBColor Brass => FromArgb(181, 166, 66);
+    /// <summary>
+    /// Gets the BrickRed color.
+    /// </summary>
+    public static RGBColor BrickRed => FromArgb(199, 44, 72);
+    /// <summary>
+    /// Gets the BrightGreen color.
+    /// </summary>
+    public static RGBColor BrightGreen => FromArgb(102, 255, 0);
+    /// <summary>
+    /// Gets the BrightRed color.
+    /// </summary>
+    public static RGBColor BrightRed => FromArgb(146, 43, 62);
+    /// <summary>
+    /// Gets the BrightTurquoise color.
+    /// </summary>
+    public static RGBColor BrightTurquoise => FromArgb(8, 232, 222);
+    /// <summary>
+    /// Gets the BrilliantRose color.
+    /// </summary>
+    public static RGBColor BrilliantRose => FromArgb(243, 100, 162);
+    /// <summary>
+    /// Gets the BrinkPink color.
+    /// </summary>
+    public static RGBColor BrinkPink => FromArgb(250, 110, 121);
+    /// <summary>
+    /// Gets the BritishRacingGreen color.
+    /// </summary>
+    public static RGBColor BritishRacingGreen => FromArgb(0, 66, 37);
+    /// <summary>
+    /// Gets the Bronze color.
+    /// </summary>
+    public static RGBColor Bronze => FromArgb(205, 127, 50);
+    /// <summary>
+    /// Gets the Brown color.
+    /// </summary>
+    public static RGBColor Brown => FromArgb(165, 42, 42);
+    /// <summary>
+    /// Gets the BrownPod color.
+    /// </summary>
+    public static RGBColor BrownPod => FromArgb(57, 24, 2);
+    /// <summary>
+    /// Gets the BuddhaGold color.
+    /// </summary>
+    public static RGBColor BuddhaGold => FromArgb(202, 169, 6);
+    /// <summary>
+    /// Gets the Buff color.
+    /// </summary>
+    public static RGBColor Buff => FromArgb(240, 220, 130);
+    /// <summary>
+    /// Gets the Burgundy color.
+    /// </summary>
+    public static RGBColor Burgundy => FromArgb(128, 0, 32);
+    /// <summary>
+    /// Gets the BurlyWood color.
+    /// </summary>
+    public static RGBColor BurlyWood => FromArgb(222, 184, 135);
+    /// <summary>
+    /// Gets the BurntOrange color.
+    /// </summary>
+    public static RGBColor BurntOrange => FromArgb(255, 117, 56);
+    /// <summary>
+    /// Gets the BurntSienna color.
+    /// </summary>
+    public static RGBColor BurntSienna => FromArgb(233, 116, 81);
+    /// <summary>
+    /// Gets the BurntUmber color.
+    /// </summary>
+    public static RGBColor BurntUmber => FromArgb(138, 51, 36);
+    /// <summary>
+    /// Gets the ButteredRum color.
+    /// </summary>
+    public static RGBColor ButteredRum => FromArgb(156, 124, 56);
+    /// <summary>
+    /// Gets the CadetBlue color.
+    /// </summary>
+    public static RGBColor CadetBlue => FromArgb(95, 158, 160);
+    /// <summary>
+    /// Gets the California color.
+    /// </summary>
+    public static RGBColor California => FromArgb(224, 141, 60);
+    /// <summary>
+    /// Gets the CamouflageGreen color.
+    /// </summary>
+    public static RGBColor CamouflageGreen => FromArgb(120, 134, 107);
+    /// <summary>
+    /// Gets the Canary color.
+    /// </summary>
+    public static RGBColor Canary => FromArgb(255, 255, 153);
+    /// <summary>
+    /// Gets the CandyPink color.
+    /// </summary>
+    public static RGBColor CandyPink => FromArgb(255, 103, 149);
+    /// <summary>
+    /// Gets the Capri color.
+    /// </summary>
+    public static RGBColor Capri => FromArgb(0, 191, 255);
+    /// <summary>
+    /// Gets the Cardinal color.
+    /// </summary>
+    public static RGBColor Cardinal => FromArgb(196, 30, 58);
+    /// <summary>
+    /// Gets the Carmine color.
+    /// </summary>
+    public static RGBColor Carmine => FromArgb(150, 0, 24);
+    /// <summary>
+    /// Gets the Carnation color.
+    /// </summary>
+    public static RGBColor Carnation => FromArgb(255, 166, 201);
+    /// <summary>
+    /// Gets the CarnationPink color.
+    /// </summary>
+    public static RGBColor CarnationPink => FromArgb(255, 166, 201);
+    /// <summary>
+    /// Gets the CarrotOrange color.
+    /// </summary>
+    public static RGBColor CarrotOrange => FromArgb(237, 145, 33);
+    /// <summary>
+    /// Gets the Casablanca color.
+    /// </summary>
+    public static RGBColor Casablanca => FromArgb(248, 184, 83);
+    /// <summary>
+    /// Gets the Cascade color.
+    /// </summary>
+    public static RGBColor Cascade => FromArgb(139, 169, 165);
+    /// <summary>
+    /// Gets the Cashmere color.
+    /// </summary>
+    public static RGBColor Cashmere => FromArgb(236, 200, 176);
+    /// <summary>
+    /// Gets the CastletonGreen color.
+    /// </summary>
+    public static RGBColor CastletonGreen => FromArgb(0, 86, 63);
+    /// <summary>
+    /// Gets the CatalinaBlue color.
+    /// </summary>
+    public static RGBColor CatalinaBlue => FromArgb(6, 42, 120);
+    /// <summary>
+    /// Gets the Catawba color.
+    /// </summary>
+    public static RGBColor Catawba => FromArgb(112, 54, 66);
+    /// <summary>
+    /// Gets the Cedar color.
+    /// </summary>
+    public static RGBColor Cedar => FromArgb(62, 28, 20);
+    /// <summary>
+    /// Gets the Celadon color.
+    /// </summary>
+    public static RGBColor Celadon => FromArgb(172, 225, 175);
+    /// <summary>
+    /// Gets the CeladonBlue color.
+    /// </summary>
+    public static RGBColor CeladonBlue => FromArgb(0, 123, 167);
+    /// <summary>
+    /// Gets the CeladonGreen color.
+    /// </summary>
+    public static RGBColor CeladonGreen => FromArgb(47, 132, 124);
+    /// <summary>
+    /// Gets the Celeste color.
+    /// </summary>
+    public static RGBColor Celeste => FromArgb(178, 255, 255);
+    /// <summary>
+    /// Gets the CelestialBlue color.
+    /// </summary>
+    public static RGBColor CelestialBlue => FromArgb(73, 151, 208);
+    /// <summary>
+    /// Gets the Cerise color.
+    /// </summary>
+    public static RGBColor Cerise => FromArgb(222, 49, 99);
+    /// <summary>
+    /// Gets the CerisePink color.
+    /// </summary>
+    public static RGBColor CerisePink => FromArgb(236, 59, 131);
+    /// <summary>
+    /// Gets the Cerulean color.
+    /// </summary>
+    public static RGBColor Cerulean => FromArgb(0, 123, 167);
+    /// <summary>
+    /// Gets the CeruleanBlue color.
+    /// </summary>
+    public static RGBColor CeruleanBlue => FromArgb(42, 82, 190);
+    /// <summary>
+    /// Gets the CeruleanFrost color.
+    /// </summary>
+    public static RGBColor CeruleanFrost => FromArgb(109, 155, 195);
+    /// <summary>
+    /// Gets the Chamoisee color.
+    /// </summary>
+    public static RGBColor Chamoisee => FromArgb(160, 120, 90);
+    /// <summary>
+    /// Gets the Champagne color.
+    /// </summary>
+    public static RGBColor Champagne => FromArgb(250, 214, 165);
+    /// <summary>
+    /// Gets the Charcoal color.
+    /// </summary>
+    public static RGBColor Charcoal => FromArgb(54, 69, 79);
+    /// <summary>
+    /// Gets the Charm color.
+    /// </summary>
+    public static RGBColor Charm => FromArgb(208, 116, 139);
+    /// <summary>
+    /// Gets the Chartreuse color.
+    /// </summary>
+    public static RGBColor Chartreuse => FromArgb(127, 255, 0);
+    /// <summary>
+    /// Gets the Cherry color.
+    /// </summary>
+    public static RGBColor Cherry => FromArgb(222, 49, 99);
+    /// <summary>
+    /// Gets the CherryBlossomPink color.
+    /// </summary>
+    public static RGBColor CherryBlossomPink => FromArgb(255, 183, 197);
+    /// <summary>
+    /// Gets the Chestnut color.
+    /// </summary>
+    public static RGBColor Chestnut => FromArgb(149, 69, 53);
+    /// <summary>
+    /// Gets the ChinaPink color.
+    /// </summary>
+    public static RGBColor ChinaPink => FromArgb(222, 111, 161);
+    /// <summary>
+    /// Gets the ChinaRose color.
+    /// </summary>
+    public static RGBColor ChinaRose => FromArgb(168, 81, 110);
+    /// <summary>
+    /// Gets the ChineseRed color.
+    /// </summary>
+    public static RGBColor ChineseRed => FromArgb(170, 56, 30);
+    /// <summary>
+    /// Gets the ChineseViolet color.
+    /// </summary>
+    public static RGBColor ChineseViolet => FromArgb(133, 96, 136);
+    /// <summary>
+    /// Gets the ChlorophyllGreen color.
+    /// </summary>
+    public static RGBColor ChlorophyllGreen => FromArgb(74, 255, 0);
+    /// <summary>
+    /// Gets the Chocolate color.
+    /// </summary>
+    public static RGBColor Chocolate => FromArgb(210, 105, 30);
+    /// <summary>
+    /// Gets the ChromeYellow color.
+    /// </summary>
+    public static RGBColor ChromeYellow => FromArgb(255, 167, 0);
+    /// <summary>
+    /// Gets the Cinereous color.
+    /// </summary>
+    public static RGBColor Cinereous => FromArgb(152, 129, 123);
+    /// <summary>
+    /// Gets the Cinnabar color.
+    /// </summary>
+    public static RGBColor Cinnabar => FromArgb(227, 66, 52);
+    /// <summary>
+    /// Gets the CinnamonSatin color.
+    /// </summary>
+    public static RGBColor CinnamonSatin => FromArgb(205, 96, 126);
+    /// <summary>
+    /// Gets the Citrine color.
+    /// </summary>
+    public static RGBColor Citrine => FromArgb(228, 208, 10);
+    /// <summary>
+    /// Gets the Citron color.
+    /// </summary>
+    public static RGBColor Citron => FromArgb(158, 169, 31);
+    /// <summary>
+    /// Gets the Claret color.
+    /// </summary>
+    public static RGBColor Claret => FromArgb(127, 23, 52);
+    /// <summary>
+    /// Gets the ClassicRose color.
+    /// </summary>
+    public static RGBColor ClassicRose => FromArgb(251, 204, 231);
+    /// <summary>
+    /// Gets the CobaltBlue color.
+    /// </summary>
+    public static RGBColor CobaltBlue => FromArgb(0, 71, 171);
+    /// <summary>
+    /// Gets the CocoaBrown color.
+    /// </summary>
+    public static RGBColor CocoaBrown => FromArgb(210, 105, 30);
+    /// <summary>
+    /// Gets the Coconut color.
+    /// </summary>
+    public static RGBColor Coconut => FromArgb(150, 90, 62);
+    /// <summary>
+    /// Gets the Coffee color.
+    /// </summary>
+    public static RGBColor Coffee => FromArgb(111, 78, 55);
+    /// <summary>
+    /// Gets the ColumbiaBlue color.
+    /// </summary>
+    public static RGBColor ColumbiaBlue => FromArgb(196, 216, 226);
+    /// <summary>
+    /// Gets the CongoPink color.
+    /// </summary>
+    public static RGBColor CongoPink => FromArgb(248, 131, 121);
+    /// <summary>
+    /// Gets the CoolBlack color.
+    /// </summary>
+    public static RGBColor CoolBlack => FromArgb(0, 46, 99);
+    /// <summary>
+    /// Gets the CoolGrey color.
+    /// </summary>
+    public static RGBColor CoolGrey => FromArgb(140, 146, 172);
+    /// <summary>
+    /// Gets the Copper color.
+    /// </summary>
+    public static RGBColor Copper => FromArgb(184, 115, 51);
+    /// <summary>
+    /// Gets the CopperPenny color.
+    /// </summary>
+    public static RGBColor CopperPenny => FromArgb(173, 111, 105);
+    /// <summary>
+    /// Gets the CopperRed color.
+    /// </summary>
+    public static RGBColor CopperRed => FromArgb(203, 109, 81);
+    /// <summary>
+    /// Gets the CopperRose color.
+    /// </summary>
+    public static RGBColor CopperRose => FromArgb(153, 102, 102);
+    /// <summary>
+    /// Gets the Coquelicot color.
+    /// </summary>
+    public static RGBColor Coquelicot => FromArgb(255, 56, 0);
+    /// <summary>
+    /// Gets the Coral color.
+    /// </summary>
+    public static RGBColor Coral => FromArgb(255, 127, 80);
+    /// <summary>
+    /// Gets the CoralPink color.
+    /// </summary>
+    public static RGBColor CoralPink => FromArgb(248, 131, 121);
+    /// <summary>
+    /// Gets the CoralRed color.
+    /// </summary>
+    public static RGBColor CoralRed => FromArgb(255, 64, 64);
+    /// <summary>
+    /// Gets the Cordovan color.
+    /// </summary>
+    public static RGBColor Cordovan => FromArgb(137, 63, 69);
+    /// <summary>
+    /// Gets the Corn color.
+    /// </summary>
+    public static RGBColor Corn => FromArgb(251, 236, 93);
+    /// <summary>
+    /// Gets the CornellRed color.
+    /// </summary>
+    public static RGBColor CornellRed => FromArgb(179, 27, 27);
+    /// <summary>
+    /// Gets the CornflowerBlue color.
+    /// </summary>
+    public static RGBColor CornflowerBlue => FromArgb(100, 149, 237);
+    /// <summary>
+    /// Gets the Cornsilk color.
+    /// </summary>
+    public static RGBColor Cornsilk => FromArgb(255, 248, 220);
+    /// <summary>
+    /// Gets the CosmicCobalt color.
+    /// </summary>
+    public static RGBColor CosmicCobalt => FromArgb(46, 45, 136);
+    /// <summary>
+    /// Gets the CosmicLatte color.
+    /// </summary>
+    public static RGBColor CosmicLatte => FromArgb(255, 248, 231);
+    /// <summary>
+    /// Gets the CoyoteBrown color.
+    /// </summary>
+    public static RGBColor CoyoteBrown => FromArgb(129, 97, 60);
+    /// <summary>
+    /// Gets the CottonCandy color.
+    /// </summary>
+    public static RGBColor CottonCandy => FromArgb(255, 188, 217);
+    /// <summary>
+    /// Gets the Cream color.
+    /// </summary>
+    public static RGBColor Cream => FromArgb(255, 253, 208);
+    /// <summary>
+    /// Gets the Crimson color.
+    /// </summary>
+    public static RGBColor Crimson => FromArgb(220, 20, 60);
+    /// <summary>
+    /// Gets the CrimsonGlory color.
+    /// </summary>
+    public static RGBColor CrimsonGlory => FromArgb(190, 0, 50);
+    /// <summary>
+    /// Gets the Cyan color.
+    /// </summary>
+    public static RGBColor Cyan => FromArgb(0, 255, 255);
+    /// <summary>
+    /// Gets the CyanAzure color.
+    /// </summary>
+    public static RGBColor CyanAzure => FromArgb(78, 130, 180);
+    /// <summary>
+    /// Gets the CyanBlueAzure color.
+    /// </summary>
+    public static RGBColor CyanBlueAzure => FromArgb(70, 130, 191);
+    /// <summary>
+    /// Gets the CyanCobaltBlue color.
+    /// </summary>
+    public static RGBColor CyanCobaltBlue => FromArgb(40, 88, 156);
+    /// <summary>
+    /// Gets the CyanCornflowerBlue color.
+    /// </summary>
+    public static RGBColor CyanCornflowerBlue => FromArgb(24, 139, 194);
+    /// <summary>
+    /// Gets the CyanProcess color.
+    /// </summary>
+    public static RGBColor CyanProcess => FromArgb(0, 183, 235);
+    /// <summary>
+    /// Gets the CyberGrape color.
+    /// </summary>
+    public static RGBColor CyberGrape => FromArgb(88, 66, 124);
+    /// <summary>
+    /// Gets the CyberYellow color.
+    /// </summary>
+    public static RGBColor CyberYellow => FromArgb(255, 211, 0);
+    /// <summary>
+    /// Gets the Daffodil color.
+    /// </summary>
+    public static RGBColor Daffodil => FromArgb(255, 255, 49);
+    /// <summary>
+    /// Gets the Dandelion color.
+    /// </summary>
+    public static RGBColor Dandelion => FromArgb(240, 225, 48);
+    /// <summary>
+    /// Gets the DarkBlue color.
+    /// </summary>
+    public static RGBColor DarkBlue => FromArgb(0, 0, 139);
+    /// <summary>
+    /// Gets the DarkBrown color.
+    /// </summary>
+    public static RGBColor DarkBrown => FromArgb(101, 67, 33);
+    /// <summary>
+    /// Gets the DarkByzantium color.
+    /// </summary>
+    public static RGBColor DarkByzantium => FromArgb(93, 57, 84);
+    /// <summary>
+    /// Gets the DarkCandyAppleRed color.
+    /// </summary>
+    public static RGBColor DarkCandyAppleRed => FromArgb(164, 0, 0);
+    /// <summary>
+    /// Gets the DarkCerulean color.
+    /// </summary>
+    public static RGBColor DarkCerulean => FromArgb(8, 69, 126);
+    /// <summary>
+    /// Gets the DarkChestnut color.
+    /// </summary>
+    public static RGBColor DarkChestnut => FromArgb(152, 105, 96);
+    /// <summary>
+    /// Gets the DarkCoral color.
+    /// </summary>
+    public static RGBColor DarkCoral => FromArgb(205, 91, 69);
+    /// <summary>
+    /// Gets the DarkCyan color.
+    /// </summary>
+    public static RGBColor DarkCyan => FromArgb(0, 139, 139);
+    /// <summary>
+    /// Gets the DarkElectricBlue color.
+    /// </summary>
+    public static RGBColor DarkElectricBlue => FromArgb(83, 104, 120);
+    /// <summary>
+    /// Gets the DarkGoldenrod color.
+    /// </summary>
+    public static RGBColor DarkGoldenrod => FromArgb(184, 134, 11);
+    /// <summary>
+    /// Gets the DarkGray color.
+    /// </summary>
+    public static RGBColor DarkGray => FromArgb(169, 169, 169);
+    /// <summary>
+    /// Gets the DarkGreen color.
+    /// </summary>
+    public static RGBColor DarkGreen => FromArgb(1, 50, 32);
+    /// <summary>
+    /// Gets the DarkImperialBlue color.
+    /// </summary>
+    public static RGBColor DarkImperialBlue => FromArgb(0, 65, 106);
+    /// <summary>
+    /// Gets the DarkJungleGreen color.
+    /// </summary>
+    public static RGBColor DarkJungleGreen => FromArgb(26, 36, 33);
+    /// <summary>
+    /// Gets the DarkKhaki color.
+    /// </summary>
+    public static RGBColor DarkKhaki => FromArgb(189, 183, 107);
+    /// <summary>
+    /// Gets the DarkLava color.
+    /// </summary>
+    public static RGBColor DarkLava => FromArgb(72, 60, 50);
+    /// <summary>
+    /// Gets the DarkLavender color.
+    /// </summary>
+    public static RGBColor DarkLavender => FromArgb(115, 79, 150);
+    /// <summary>
+    /// Gets the DarkLiver color.
+    /// </summary>
+    public static RGBColor DarkLiver => FromArgb(83, 75, 79);
+    /// <summary>
+    /// Gets the DarkMagenta color.
+    /// </summary>
+    public static RGBColor DarkMagenta => FromArgb(139, 0, 139);
+    /// <summary>
+    /// Gets the DarkMediumGray color.
+    /// </summary>
+    public static RGBColor DarkMediumGray => FromArgb(169, 169, 169);
+    /// <summary>
+    /// Gets the DarkMidnightBlue color.
+    /// </summary>
+    public static RGBColor DarkMidnightBlue => FromArgb(0, 51, 102);
+    /// <summary>
+    /// Gets the DarkMossGreen color.
+    /// </summary>
+    public static RGBColor DarkMossGreen => FromArgb(74, 93, 35);
+    /// <summary>
+    /// Gets the DarkOliveGreen color.
+    /// </summary>
+    public static RGBColor DarkOliveGreen => FromArgb(85, 107, 47);
+    /// <summary>
+    /// Gets the DarkOrange color.
+    /// </summary>
+    public static RGBColor DarkOrange => FromArgb(255, 140, 0);
+    /// <summary>
+    /// Gets the DarkOrchid color.
+    /// </summary>
+    public static RGBColor DarkOrchid => FromArgb(153, 50, 204);
+    /// <summary>
+    /// Gets the DarkPastelBlue color.
+    /// </summary>
+    public static RGBColor DarkPastelBlue => FromArgb(119, 158, 203);
+    /// <summary>
+    /// Gets the DarkPastelGreen color.
+    /// </summary>
+    public static RGBColor DarkPastelGreen => FromArgb(3, 192, 60);
+    /// <summary>
+    /// Gets the DarkPastelPurple color.
+    /// </summary>
+    public static RGBColor DarkPastelPurple => FromArgb(150, 111, 214);
+    /// <summary>
+    /// Gets the DarkPastelRed color.
+    /// </summary>
+    public static RGBColor DarkPastelRed => FromArgb(194, 59, 34);
+    /// <summary>
+    /// Gets the DarkPink color.
+    /// </summary>
+    public static RGBColor DarkPink => FromArgb(231, 84, 128);
+    /// <summary>
+    /// Gets the DarkPowderBlue color.
+    /// </summary>
+    public static RGBColor DarkPowderBlue => FromArgb(0, 51, 153);
+    /// <summary>
+    /// Gets the DarkPuce color.
+    /// </summary>
+    public static RGBColor DarkPuce => FromArgb(79, 58, 60);
+    /// <summary>
+    /// Gets the DarkPurple color.
+    /// </summary>
+    public static RGBColor DarkPurple => FromArgb(48, 25, 52);
+    /// <summary>
+    /// Gets the DarkRaspberry color.
+    /// </summary>
+    public static RGBColor DarkRaspberry => FromArgb(135, 38, 87);
+    /// <summary>
+    /// Gets the DarkRed color.
+    /// </summary>
+    public static RGBColor DarkRed => FromArgb(139, 0, 0);
+    /// <summary>
+    /// Gets the DarkSalmon color.
+    /// </summary>
+    public static RGBColor DarkSalmon => FromArgb(233, 150, 122);
+    /// <summary>
+    /// Gets the DarkScarlet color.
+    /// </summary>
+    public static RGBColor DarkScarlet => FromArgb(86, 3, 25);
+    /// <summary>
+    /// Gets the DarkSeaGreen color.
+    /// </summary>
+    public static RGBColor DarkSeaGreen => FromArgb(143, 188, 143);
+    /// <summary>
+    /// Gets the DarkSienna color.
+    /// </summary>
+    public static RGBColor DarkSienna => FromArgb(60, 20, 20);
+    /// <summary>
+    /// Gets the DarkSkyBlue color.
+    /// </summary>
+    public static RGBColor DarkSkyBlue => FromArgb(140, 190, 214);
+    /// <summary>
+    /// Gets the DarkSlateBlue color.
+    /// </summary>
+    public static RGBColor DarkSlateBlue => FromArgb(72, 61, 139);
+    /// <summary>
+    /// Gets the DarkSlateGray color.
+    /// </summary>
+    public static RGBColor DarkSlateGray => FromArgb(47, 79, 79);
+    /// <summary>
+    /// Gets the DarkSpringGreen color.
+    /// </summary>
+    public static RGBColor DarkSpringGreen => FromArgb(23, 114, 69);
+    /// <summary>
+    /// Gets the DarkTan color.
+    /// </summary>
+    public static RGBColor DarkTan => FromArgb(145, 129, 81);
+    /// <summary>
+    /// Gets the DarkTangerine color.
+    /// </summary>
+    public static RGBColor DarkTangerine => FromArgb(255, 168, 18);
+    /// <summary>
+    /// Gets the DarkTaupe color.
+    /// </summary>
+    public static RGBColor DarkTaupe => FromArgb(72, 60, 50);
+    /// <summary>
+    /// Gets the DarkTerraCotta color.
+    /// </summary>
+    public static RGBColor DarkTerraCotta => FromArgb(204, 78, 92);
+    /// <summary>
+    /// Gets the DarkTurquoise color.
+    /// </summary>
+    public static RGBColor DarkTurquoise => FromArgb(0, 206, 209);
+    /// <summary>
+    /// Gets the DarkVanilla color.
+    /// </summary>
+    public static RGBColor DarkVanilla => FromArgb(209, 190, 168);
+    /// <summary>
+    /// Gets the DarkViolet color.
+    /// </summary>
+    public static RGBColor DarkViolet => FromArgb(148, 0, 211);
+    /// <summary>
+    /// Gets the DarkYellow color.
+    /// </summary>
+    public static RGBColor DarkYellow => FromArgb(155, 135, 12);
+    /// <summary>
+    /// Gets the DartmouthGreen color.
+    /// </summary>
+    public static RGBColor DartmouthGreen => FromArgb(0, 112, 60);
+    /// <summary>
+    /// Gets the DavysGrey color.
+    /// </summary>
+    public static RGBColor DavysGrey => FromArgb(85, 85, 85);
+    /// <summary>
+    /// Gets the DebianRed color.
+    /// </summary>
+    public static RGBColor DebianRed => FromArgb(215, 10, 83);
+    /// <summary>
+    /// Gets the DeepAquamarine color.
+    /// </summary>
+    public static RGBColor DeepAquamarine => FromArgb(64, 130, 109);
+    /// <summary>
+    /// Gets the DeepCarmine color.
+    /// </summary>
+    public static RGBColor DeepCarmine => FromArgb(169, 32, 62);
+    /// <summary>
+    /// Gets the DeepCarminePink color.
+    /// </summary>
+    public static RGBColor DeepCarminePink => FromArgb(239, 48, 56);
+    /// <summary>
+    /// Gets the DeepCarrotOrange color.
+    /// </summary>
+    public static RGBColor DeepCarrotOrange => FromArgb(233, 105, 44);
+    /// <summary>
+    /// Gets the DeepCerise color.
+    /// </summary>
+    public static RGBColor DeepCerise => FromArgb(218, 50, 135);
+    /// <summary>
+    /// Gets the DeepChampagne color.
+    /// </summary>
+    public static RGBColor DeepChampagne => FromArgb(250, 214, 165);
+    /// <summary>
+    /// Gets the DeepChestnut color.
+    /// </summary>
+    public static RGBColor DeepChestnut => FromArgb(185, 78, 72);
+    /// <summary>
+    /// Gets the DeepCoffee color.
+    /// </summary>
+    public static RGBColor DeepCoffee => FromArgb(112, 66, 65);
+    /// <summary>
+    /// Gets the DeepFuchsia color.
+    /// </summary>
+    public static RGBColor DeepFuchsia => FromArgb(193, 84, 193);
+    /// <summary>
+    /// Gets the DeepGreen color.
+    /// </summary>
+    public static RGBColor DeepGreen => FromArgb(5, 102, 8);
+    /// <summary>
+    /// Gets the DeepGreenCyanTurquoise color.
+    /// </summary>
+    public static RGBColor DeepGreenCyanTurquoise => FromArgb(14, 124, 97);
+    /// <summary>
+    /// Gets the DeepJungleGreen color.
+    /// </summary>
+    public static RGBColor DeepJungleGreen => FromArgb(0, 75, 73);
+    /// <summary>
+    /// Gets the DeepKoamaru color.
+    /// </summary>
+    public static RGBColor DeepKoamaru => FromArgb(51, 51, 153);
+    /// <summary>
+    /// Gets the DeepLemon color.
+    /// </summary>
+    public static RGBColor DeepLemon => FromArgb(245, 199, 26);
+    /// <summary>
+    /// Gets the DeepLilac color.
+    /// </summary>
+    public static RGBColor DeepLilac => FromArgb(153, 85, 187);
+    /// <summary>
+    /// Gets the DeepMaroon color.
+    /// </summary>
+    public static RGBColor DeepMaroon => FromArgb(130, 0, 0);
+    /// <summary>
+    /// Gets the DeepMauve color.
+    /// </summary>
+    public static RGBColor DeepMauve => FromArgb(212, 115, 212);
+    /// <summary>
+    /// Gets the DeepMossGreen color.
+    /// </summary>
+    public static RGBColor DeepMossGreen => FromArgb(53, 94, 59);
+    /// <summary>
+    /// Gets the DeepPeach color.
+    /// </summary>
+    public static RGBColor DeepPeach => FromArgb(255, 203, 164);
+    /// <summary>
+    /// Gets the DeepPink color.
+    /// </summary>
+    public static RGBColor DeepPink => FromArgb(255, 20, 147);
+    /// <summary>
+    /// Gets the DeepPuce color.
+    /// </summary>
+    public static RGBColor DeepPuce => FromArgb(169, 92, 104);
+    /// <summary>
+    /// Gets the DeepRed color.
+    /// </summary>
+    public static RGBColor DeepRed => FromArgb(133, 1, 1);
+    /// <summary>
+    /// Gets the DeepRuby color.
+    /// </summary>
+    public static RGBColor DeepRuby => FromArgb(132, 63, 91);
+    /// <summary>
+    /// Gets the DeepSaffron color.
+    /// </summary>
+    public static RGBColor DeepSaffron => FromArgb(255, 153, 51);
+    /// <summary>
+    /// Gets the DeepSkyBlue color.
+    /// </summary>
+    public static RGBColor DeepSkyBlue => FromArgb(0, 191, 255);
+    /// <summary>
+    /// Gets the DeepSpaceSparkle color.
+    /// </summary>
+    public static RGBColor DeepSpaceSparkle => FromArgb(74, 100, 108);
+    /// <summary>
+    /// Gets the DeepSpringBud color.
+    /// </summary>
+    public static RGBColor DeepSpringBud => FromArgb(85, 107, 47);
+    /// <summary>
+    /// Gets the DeepTaupe color.
+    /// </summary>
+    public static RGBColor DeepTaupe => FromArgb(126, 94, 96);
+    /// <summary>
+    /// Gets the DeepTuscanRed color.
+    /// </summary>
+    public static RGBColor DeepTuscanRed => FromArgb(102, 66, 77);
+    /// <summary>
+    /// Gets the DeepViolet color.
+    /// </summary>
+    public static RGBColor DeepViolet => FromArgb(51, 51, 153);
+    /// <summary>
+    /// Gets the Deer color.
+    /// </summary>
+    public static RGBColor Deer => FromArgb(186, 135, 89);
+    /// <summary>
+    /// Gets the Denim color.
+    /// </summary>
+    public static RGBColor Denim => FromArgb(21, 96, 189);
+    /// <summary>
+    /// Gets the DenimBlue color.
+    /// </summary>
+    public static RGBColor DenimBlue => FromArgb(34, 67, 182);
+    /// <summary>
+    /// Gets the DesaturatedCyan color.
+    /// </summary>
+    public static RGBColor DesaturatedCyan => FromArgb(102, 153, 153);
+    /// <summary>
+    /// Gets the Desert color.
+    /// </summary>
+    public static RGBColor Desert => FromArgb(193, 154, 107);
+    /// <summary>
+    /// Gets the DesertSand color.
+    /// </summary>
+    public static RGBColor DesertSand => FromArgb(237, 201, 175);
+    /// <summary>
+    /// Gets the Desire color.
+    /// </summary>
+    public static RGBColor Desire => FromArgb(234, 60, 83);
+    /// <summary>
+    /// Gets the Diamond color.
+    /// </summary>
+    public static RGBColor Diamond => FromArgb(185, 242, 255);
+    /// <summary>
+    /// Gets the DimGray color.
+    /// </summary>
+    public static RGBColor DimGray => FromArgb(105, 105, 105);
+    /// <summary>
+    /// Gets the DingyDungeon color.
+    /// </summary>
+    public static RGBColor DingyDungeon => FromArgb(197, 49, 81);
+    /// <summary>
+    /// Gets the Dirt color.
+    /// </summary>
+    public static RGBColor Dirt => FromArgb(155, 118, 83);
+    /// <summary>
+    /// Gets the DodgerBlue color.
+    /// </summary>
+    public static RGBColor DodgerBlue => FromArgb(30, 144, 255);
+    /// <summary>
+    /// Gets the DogwoodRose color.
+    /// </summary>
+    public static RGBColor DogwoodRose => FromArgb(215, 24, 104);
+    /// <summary>
+    /// Gets the DollarBill color.
+    /// </summary>
+    public static RGBColor DollarBill => FromArgb(133, 187, 101);
+    /// <summary>
+    /// Gets the DolphinGray color.
+    /// </summary>
+    public static RGBColor DolphinGray => FromArgb(130, 142, 132);
+    /// <summary>
+    /// Gets the DonkeyBrown color.
+    /// </summary>
+    public static RGBColor DonkeyBrown => FromArgb(102, 76, 40);
+    /// <summary>
+    /// Gets the Drab color.
+    /// </summary>
+    public static RGBColor Drab => FromArgb(150, 113, 23);
+    /// <summary>
+    /// Gets the DukeBlue color.
+    /// </summary>
+    public static RGBColor DukeBlue => FromArgb(0, 0, 156);
+    /// <summary>
+    /// Gets the DustStorm color.
+    /// </summary>
+    public static RGBColor DustStorm => FromArgb(229, 204, 201);
+    /// <summary>
+    /// Gets the DutchWhite color.
+    /// </summary>
+    public static RGBColor DutchWhite => FromArgb(239, 223, 187);
+    /// <summary>
+    /// Gets the EarthYellow color.
+    /// </summary>
+    public static RGBColor EarthYellow => FromArgb(225, 169, 95);
+    /// <summary>
+    /// Gets the Ebony color.
+    /// </summary>
+    public static RGBColor Ebony => FromArgb(85, 93, 80);
+    /// <summary>
+    /// Gets the Ecru color.
+    /// </summary>
+    public static RGBColor Ecru => FromArgb(194, 178, 128);
+    /// <summary>
+    /// Gets the EerieBlack color.
+    /// </summary>
+    public static RGBColor EerieBlack => FromArgb(27, 27, 27);
+    /// <summary>
+    /// Gets the Eggplant color.
+    /// </summary>
+    public static RGBColor Eggplant => FromArgb(97, 64, 81);
+    /// <summary>
+    /// Gets the Eggshell color.
+    /// </summary>
+    public static RGBColor Eggshell => FromArgb(240, 234, 214);
+    /// <summary>
+    /// Gets the EgyptianBlue color.
+    /// </summary>
+    public static RGBColor EgyptianBlue => FromArgb(16, 52, 166);
+    /// <summary>
+    /// Gets the ElectricBlue color.
+    /// </summary>
+    public static RGBColor ElectricBlue => FromArgb(125, 249, 255);
+    /// <summary>
+    /// Gets the ElectricCrimson color.
+    /// </summary>
+    public static RGBColor ElectricCrimson => FromArgb(255, 0, 63);
+    /// <summary>
+    /// Gets the ElectricCyan color.
+    /// </summary>
+    public static RGBColor ElectricCyan => FromArgb(0, 255, 255);
+    /// <summary>
+    /// Gets the ElectricGreen color.
+    /// </summary>
+    public static RGBColor ElectricGreen => FromArgb(0, 255, 0);
+    /// <summary>
+    /// Gets the ElectricIndigo color.
+    /// </summary>
+    public static RGBColor ElectricIndigo => FromArgb(111, 0, 255);
+    /// <summary>
+    /// Gets the ElectricLavender color.
+    /// </summary>
+    public static RGBColor ElectricLavender => FromArgb(244, 187, 255);
+    /// <summary>
+    /// Gets the ElectricLime color.
+    /// </summary>
+    public static RGBColor ElectricLime => FromArgb(204, 255, 0);
+    /// <summary>
+    /// Gets the ElectricPurple color.
+    /// </summary>
+    public static RGBColor ElectricPurple => FromArgb(191, 0, 255);
+    /// <summary>
+    /// Gets the ElectricUltramarine color.
+    /// </summary>
+    public static RGBColor ElectricUltramarine => FromArgb(63, 0, 255);
+    /// <summary>
+    /// Gets the ElectricViolet color.
+    /// </summary>
+    public static RGBColor ElectricViolet => FromArgb(143, 0, 255);
+    /// <summary>
+    /// Gets the ElectricYellow color.
+    /// </summary>
+    public static RGBColor ElectricYellow => FromArgb(255, 255, 0);
+    /// <summary>
+    /// Gets the Emerald color.
+    /// </summary>
+    public static RGBColor Emerald => FromArgb(80, 200, 120);
+    /// <summary>
+    /// Gets the Eminence color.
+    /// </summary>
+    public static RGBColor Eminence => FromArgb(108, 48, 130);
+    /// <summary>
+    /// Gets the EnglishGreen color.
+    /// </summary>
+    public static RGBColor EnglishGreen => FromArgb(27, 77, 62);
+    /// <summary>
+    /// Gets the EnglishLavender color.
+    /// </summary>
+    public static RGBColor EnglishLavender => FromArgb(180, 131, 149);
+    /// <summary>
+    /// Gets the EnglishRed color.
+    /// </summary>
+    public static RGBColor EnglishRed => FromArgb(171, 75, 82);
+    /// <summary>
+    /// Gets the EnglishViolet color.
+    /// </summary>
+    public static RGBColor EnglishViolet => FromArgb(86, 60, 92);
+    /// <summary>
+    /// Gets the EtonBlue color.
+    /// </summary>
+    public static RGBColor EtonBlue => FromArgb(150, 200, 162);
+    /// <summary>
+    /// Gets the Eucalyptus color.
+    /// </summary>
+    public static RGBColor Eucalyptus => FromArgb(38, 115, 77);
+    /// <summary>
+    /// Gets the Fallow color.
+    /// </summary>
+    public static RGBColor Fallow => FromArgb(193, 154, 107);
+    /// <summary>
+    /// Gets the FaluRed color.
+    /// </summary>
+    public static RGBColor FaluRed => FromArgb(128, 24, 24);
+    /// <summary>
+    /// Gets the Fandango color.
+    /// </summary>
+    public static RGBColor Fandango => FromArgb(181, 51, 137);
+    /// <summary>
+    /// Gets the FandangoPink color.
+    /// </summary>
+    public static RGBColor FandangoPink => FromArgb(222, 82, 133);
+    /// <summary>
+    /// Gets the FashionFuchsia color.
+    /// </summary>
+    public static RGBColor FashionFuchsia => FromArgb(244, 0, 161);
+    /// <summary>
+    /// Gets the Fawn color.
+    /// </summary>
+    public static RGBColor Fawn => FromArgb(229, 170, 112);
+    /// <summary>
+    /// Gets the Feldgrau color.
+    /// </summary>
+    public static RGBColor Feldgrau => FromArgb(77, 93, 83);
+    /// <summary>
+    /// Gets the Feldspar color.
+    /// </summary>
+    public static RGBColor Feldspar => FromArgb(253, 213, 177);
+    /// <summary>
+    /// Gets the FernGreen color.
+    /// </summary>
+    public static RGBColor FernGreen => FromArgb(79, 121, 66);
+    /// <summary>
+    /// Gets the FerrariRed color.
+    /// </summary>
+    public static RGBColor FerrariRed => FromArgb(255, 40, 0);
+    /// <summary>
+    /// Gets the FieldDrab color.
+    /// </summary>
+    public static RGBColor FieldDrab => FromArgb(108, 84, 30);
+    /// <summary>
+    /// Gets the FieryRose color.
+    /// </summary>
+    public static RGBColor FieryRose => FromArgb(255, 84, 112);
+    /// <summary>
+    /// Gets the FireEngineRed color.
+    /// </summary>
+    public static RGBColor FireEngineRed => FromArgb(206, 32, 41);
+    /// <summary>
+    /// Gets the Firebrick color.
+    /// </summary>
+    public static RGBColor Firebrick => FromArgb(178, 34, 34);
+    /// <summary>
+    /// Gets the Flame color.
+    /// </summary>
+    public static RGBColor Flame => FromArgb(226, 88, 34);
+    /// <summary>
+    /// Gets the Flamingo color.
+    /// </summary>
+    public static RGBColor Flamingo => FromArgb(242, 85, 42);
+    /// <summary>
+    /// Gets the Flax color.
+    /// </summary>
+    public static RGBColor Flax => FromArgb(238, 220, 130);
+    /// <summary>
+    /// Gets the Flirt color.
+    /// </summary>
+    public static RGBColor Flirt => FromArgb(162, 0, 109);
+    /// <summary>
+    /// Gets the FloralWhite color.
+    /// </summary>
+    public static RGBColor FloralWhite => FromArgb(255, 250, 240);
+    /// <summary>
+    /// Gets the Foam color.
+    /// </summary>
+    public static RGBColor Foam => FromArgb(216, 252, 250);
+    /// <summary>
+    /// Gets the Fog color.
+    /// </summary>
+    public static RGBColor Fog => FromArgb(215, 208, 255);
+    /// <summary>
+    /// Gets the FoggyGray color.
+    /// </summary>
+    public static RGBColor FoggyGray => FromArgb(204, 204, 204);
+    /// <summary>
+    /// Gets the ForestGreen color.
+    /// </summary>
+    public static RGBColor ForestGreen => FromArgb(34, 139, 34);
+    /// <summary>
+    /// Gets the ForgetMeNot color.
+    /// </summary>
+    public static RGBColor ForgetMeNot => FromArgb(255, 241, 238);
+    /// <summary>
+    /// Gets the FountainBlue color.
+    /// </summary>
+    public static RGBColor FountainBlue => FromArgb(86, 180, 190);
+    /// <summary>
+    /// Gets the Frangipani color.
+    /// </summary>
+    public static RGBColor Frangipani => FromArgb(255, 222, 179);
+    /// <summary>
+    /// Gets the FrenchGray color.
+    /// </summary>
+    public static RGBColor FrenchGray => FromArgb(189, 189, 198);
+    /// <summary>
+    /// Gets the FrenchLilac color.
+    /// </summary>
+    public static RGBColor FrenchLilac => FromArgb(134, 96, 142);
+    /// <summary>
+    /// Gets the FrenchRose color.
+    /// </summary>
+    public static RGBColor FrenchRose => FromArgb(246, 74, 138);
+    /// <summary>
+    /// Gets the FreshEggplant color.
+    /// </summary>
+    public static RGBColor FreshEggplant => FromArgb(105, 45, 84);
+    /// <summary>
+    /// Gets the Frost color.
+    /// </summary>
+    public static RGBColor Frost => FromArgb(237, 245, 255);
+    /// <summary>
+    /// Gets the FrostedMint color.
+    /// </summary>
+    public static RGBColor FrostedMint => FromArgb(210, 255, 188);
+    /// <summary>
+    /// Gets the Frostee color.
+    /// </summary>
+    public static RGBColor Frostee => FromArgb(219, 255, 248);
+    /// <summary>
+    /// Gets the FruitSalad color.
+    /// </summary>
+    public static RGBColor FruitSalad => FromArgb(79, 157, 93);
+    /// <summary>
+    /// Gets the Fuchsia color.
+    /// </summary>
+    public static RGBColor Fuchsia => FromArgb(255, 0, 255);
+    /// <summary>
+    /// Gets the FuchsiaPink color.
+    /// </summary>
+    public static RGBColor FuchsiaPink => FromArgb(255, 119, 255);
+    /// <summary>
+    /// Gets the Fuego color.
+    /// </summary>
+    public static RGBColor Fuego => FromArgb(190, 222, 13);
+    /// <summary>
+    /// Gets the FujiGreen color.
+    /// </summary>
+    public static RGBColor FujiGreen => FromArgb(125, 176, 93);
+    /// <summary>
+    /// Gets the FuscousGray color.
+    /// </summary>
+    public static RGBColor FuscousGray => FromArgb(84, 83, 77);
+    /// <summary>
+    /// Gets the FuzzyWuzzyBrown color.
+    /// </summary>
+    public static RGBColor FuzzyWuzzyBrown => FromArgb(204, 102, 102);
+    /// <summary>
+    /// Gets the GableGreen color.
+    /// </summary>
+    public static RGBColor GableGreen => FromArgb(22, 53, 49);
+    /// <summary>
+    /// Gets the Gallery color.
+    /// </summary>
+    public static RGBColor Gallery => FromArgb(238, 238, 238);
+    /// <summary>
+    /// Gets the Galliano color.
+    /// </summary>
+    public static RGBColor Galliano => FromArgb(220, 178, 12);
+    /// <summary>
+    /// Gets the Gamboge color.
+    /// </summary>
+    public static RGBColor Gamboge => FromArgb(228, 155, 15);
+    /// <summary>
+    /// Gets the GargoyleGas color.
+    /// </summary>
+    public static RGBColor GargoyleGas => FromArgb(255, 223, 70);
+    /// <summary>
+    /// Gets the Geebung color.
+    /// </summary>
+    public static RGBColor Geebung => FromArgb(209, 143, 27);
+    /// <summary>
+    /// Gets the Genoa color.
+    /// </summary>
+    public static RGBColor Genoa => FromArgb(21, 115, 107);
+    /// <summary>
+    /// Gets the Geraldine color.
+    /// </summary>
+    public static RGBColor Geraldine => FromArgb(251, 137, 137);
+    /// <summary>
+    /// Gets the Geyser color.
+    /// </summary>
+    public static RGBColor Geyser => FromArgb(212, 223, 226);
+    /// <summary>
+    /// Gets the Ghost color.
+    /// </summary>
+    public static RGBColor Ghost => FromArgb(199, 201, 213);
+    /// <summary>
+    /// Gets the GhostWhite color.
+    /// </summary>
+    public static RGBColor GhostWhite => FromArgb(248, 248, 255);
+    /// <summary>
+    /// Gets the Gigas color.
+    /// </summary>
+    public static RGBColor Gigas => FromArgb(82, 60, 148);
+    /// <summary>
+    /// Gets the Gimblet color.
+    /// </summary>
+    public static RGBColor Gimblet => FromArgb(184, 181, 106);
+    /// <summary>
+    /// Gets the Gin color.
+    /// </summary>
+    public static RGBColor Gin => FromArgb(216, 252, 250);
+    /// <summary>
+    /// Gets the GinFizz color.
+    /// </summary>
+    public static RGBColor GinFizz => FromArgb(255, 249, 226);
+    /// <summary>
+    /// Gets the Givry color.
+    /// </summary>
+    public static RGBColor Givry => FromArgb(248, 228, 191);
+    /// <summary>
+    /// Gets the Glacier color.
+    /// </summary>
+    public static RGBColor Glacier => FromArgb(128, 179, 196);
+    /// <summary>
+    /// Gets the GladeGreen color.
+    /// </summary>
+    public static RGBColor GladeGreen => FromArgb(97, 132, 95);
+    /// <summary>
+    /// Gets the GoBen color.
+    /// </summary>
+    public static RGBColor GoBen => FromArgb(120, 107, 79);
+    /// <summary>
+    /// Gets the Gondola color.
+    /// </summary>
+    public static RGBColor Gondola => FromArgb(38, 20, 20);
+    /// <summary>
+    /// Gets the GoodSamaritan color.
+    /// </summary>
+    public static RGBColor GoodSamaritan => FromArgb(60, 100, 126);
+    /// <summary>
+    /// Gets the Gorse color.
+    /// </summary>
+    public static RGBColor Gorse => FromArgb(255, 233, 21);
+    /// <summary>
+    /// Gets the Gothic color.
+    /// </summary>
+    public static RGBColor Gothic => FromArgb(106, 120, 123);
+    /// <summary>
+    /// Gets the GovernorBay color.
+    /// </summary>
+    public static RGBColor GovernorBay => FromArgb(47, 60, 179);
+    /// <summary>
+    /// Gets the GrainBrown color.
+    /// </summary>
+    public static RGBColor GrainBrown => FromArgb(228, 213, 183);
+    /// <summary>
+    /// Gets the Grandis color.
+    /// </summary>
+    public static RGBColor Grandis => FromArgb(255, 211, 140);
+    /// <summary>
+    /// Gets the GraniteGreen color.
+    /// </summary>
+    public static RGBColor GraniteGreen => FromArgb(141, 137, 116);
+    /// <summary>
+    /// Gets the GrannyApple color.
+    /// </summary>
+    public static RGBColor GrannyApple => FromArgb(213, 246, 227);
+    /// <summary>
+    /// Gets the GrannySmith color.
+    /// </summary>
+    public static RGBColor GrannySmith => FromArgb(132, 160, 160);
+    /// <summary>
+    /// Gets the GrannySmithApple color.
+    /// </summary>
+    public static RGBColor GrannySmithApple => FromArgb(157, 224, 147);
+    /// <summary>
+    /// Gets the Grape color.
+    /// </summary>
+    public static RGBColor Grape => FromArgb(56, 26, 81);
+    /// <summary>
+    /// Gets the Graphite color.
+    /// </summary>
+    public static RGBColor Graphite => FromArgb(37, 22, 7);
+    /// <summary>
+    /// Gets the GrassHopper color.
+    /// </summary>
+    public static RGBColor GrassHopper => FromArgb(124, 118, 49);
+    /// <summary>
+    /// Gets the Gravel color.
+    /// </summary>
+    public static RGBColor Gravel => FromArgb(74, 68, 75);
+    /// <summary>
+    /// Gets the Gray color.
+    /// </summary>
+    public static RGBColor Gray => FromArgb(128, 128, 128);
+    /// <summary>
+    /// Gets the GrayAsparagus color.
+    /// </summary>
+    public static RGBColor GrayAsparagus => FromArgb(70, 89, 69);
+    /// <summary>
+    /// Gets the GrayChateau color.
+    /// </summary>
+    public static RGBColor GrayChateau => FromArgb(163, 164, 165);
+    /// <summary>
+    /// Gets the GrayNickel color.
+    /// </summary>
+    public static RGBColor GrayNickel => FromArgb(195, 195, 189);
+    /// <summary>
+    /// Gets the GrayNurse color.
+    /// </summary>
+    public static RGBColor GrayNurse => FromArgb(231, 236, 230);
+    /// <summary>
+    /// Gets the GrayOlive color.
+    /// </summary>
+    public static RGBColor GrayOlive => FromArgb(113, 107, 86);
+    /// <summary>
+    /// Gets the GraySuit color.
+    /// </summary>
+    public static RGBColor GraySuit => FromArgb(193, 190, 205);
+    /// <summary>
+    /// Gets the Green color.
+    /// </summary>
+    public static RGBColor Green => FromArgb(0, 128, 0);
+    /// <summary>
+    /// Gets the GreenBlue color.
+    /// </summary>
+    public static RGBColor GreenBlue => FromArgb(17, 100, 180);
+    /// <summary>
+    /// Gets the GreenCyan color.
+    /// </summary>
+    public static RGBColor GreenCyan => FromArgb(0, 153, 102);
+    /// <summary>
+    /// Gets the GreenHaze color.
+    /// </summary>
+    public static RGBColor GreenHaze => FromArgb(1, 170, 122);
+    /// <summary>
+    /// Gets the GreenHouse color.
+    /// </summary>
+    public static RGBColor GreenHouse => FromArgb(36, 80, 15);
+    /// <summary>
+    /// Gets the GreenKelp color.
+    /// </summary>
+    public static RGBColor GreenKelp => FromArgb(37, 49, 28);
+    /// <summary>
+    /// Gets the GreenLeaf color.
+    /// </summary>
+    public static RGBColor GreenLeaf => FromArgb(37, 49, 20);
+    /// <summary>
+    /// Gets the GreenMist color.
+    /// </summary>
+    public static RGBColor GreenMist => FromArgb(203, 211, 176);
+    /// <summary>
+    /// Gets the GreenPea color.
+    /// </summary>
+    public static RGBColor GreenPea => FromArgb(29, 97, 66);
+    /// <summary>
+    /// Gets the GreenSmoke color.
+    /// </summary>
+    public static RGBColor GreenSmoke => FromArgb(164, 175, 110);
+    /// <summary>
+    /// Gets the GreenSpring color.
+    /// </summary>
+    public static RGBColor GreenSpring => FromArgb(184, 193, 162);
+    /// <summary>
+    /// Gets the GreenVogue color.
+    /// </summary>
+    public static RGBColor GreenVogue => FromArgb(3, 43, 82);
+    /// <summary>
+    /// Gets the GreenWaterloo color.
+    /// </summary>
+    public static RGBColor GreenWaterloo => FromArgb(16, 20, 5);
+    /// <summary>
+    /// Gets the GreenWhite color.
+    /// </summary>
+    public static RGBColor GreenWhite => FromArgb(232, 235, 224);
+    /// <summary>
+    /// Gets the GreenYellow color.
+    /// </summary>
+    public static RGBColor GreenYellow => FromArgb(173, 255, 47);
+    /// <summary>
+    /// Gets the Grenadier color.
+    /// </summary>
+    public static RGBColor Grenadier => FromArgb(213, 70, 0);
+    /// <summary>
+    /// Gets the Grey color.
+    /// </summary>
+    public static RGBColor Grey => FromArgb(128, 128, 128);
+    /// <summary>
+    /// Gets the GreyChateau color.
+    /// </summary>
+    public static RGBColor GreyChateau => FromArgb(162, 170, 179);
+    /// <summary>
+    /// Gets the GreyGreen color.
+    /// </summary>
+    public static RGBColor GreyGreen => FromArgb(69, 73, 54);
+    /// <summary>
+    /// Gets the GreyNurse color.
+    /// </summary>
+    public static RGBColor GreyNurse => FromArgb(231, 236, 230);
+    /// <summary>
+    /// Gets the GreyOlive color.
+    /// </summary>
+    public static RGBColor GreyOlive => FromArgb(169, 164, 145);
+    /// <summary>
+    /// Gets the GreySuit color.
+    /// </summary>
+    public static RGBColor GreySuit => FromArgb(193, 190, 205);
+    /// <summary>
+    /// Gets the GuardsmanRed color.
+    /// </summary>
+    public static RGBColor GuardsmanRed => FromArgb(186, 12, 47);
+    /// <summary>
+    /// Gets the GulfBlue color.
+    /// </summary>
+    public static RGBColor GulfBlue => FromArgb(5, 22, 87);
+    /// <summary>
+    /// Gets the GulfStream color.
+    /// </summary>
+    public static RGBColor GulfStream => FromArgb(128, 179, 174);
+    /// <summary>
+    /// Gets the GullGray color.
+    /// </summary>
+    public static RGBColor GullGray => FromArgb(157, 172, 183);
+    /// <summary>
+    /// Gets the GumLeaf color.
+    /// </summary>
+    public static RGBColor GumLeaf => FromArgb(182, 211, 191);
+    /// <summary>
+    /// Gets the Gumboot color.
+    /// </summary>
+    public static RGBColor Gumboot => FromArgb(60, 31, 31);
+    /// <summary>
+    /// Gets the GunPowder color.
+    /// </summary>
+    public static RGBColor GunPowder => FromArgb(130, 134, 133);
+    /// <summary>
+    /// Gets the Gunmetal color.
+    /// </summary>
+    public static RGBColor Gunmetal => FromArgb(42, 52, 57);
+    /// <summary>
+    /// Gets the Gunsmoke color.
+    /// </summary>
+    public static RGBColor Gunsmoke => FromArgb(130, 134, 133);
+    /// <summary>
+    /// Gets the GypsyQueen color.
+    /// </summary>
+    public static RGBColor GypsyQueen => FromArgb(105, 155, 176);
+    /// <summary>
+    /// Gets the Hacienda color.
+    /// </summary>
+    public static RGBColor Hacienda => FromArgb(152, 129, 27);
+    /// <summary>
+    /// Gets the HairyHeath color.
+    /// </summary>
+    public static RGBColor HairyHeath => FromArgb(107, 42, 20);
+    /// <summary>
+    /// Gets the Haiti color.
+    /// </summary>
+    public static RGBColor Haiti => FromArgb(27, 16, 53);
+    /// <summary>
+    /// Gets the HalfBaked color.
+    /// </summary>
+    public static RGBColor HalfBaked => FromArgb(133, 196, 204);
+    /// <summary>
+    /// Gets the HalfColonialWhite color.
+    /// </summary>
+    public static RGBColor HalfColonialWhite => FromArgb(253, 246, 211);
+    /// <summary>
+    /// Gets the HalfDutchWhite color.
+    /// </summary>
+    public static RGBColor HalfDutchWhite => FromArgb(254, 247, 222);
+    /// <summary>
+    /// Gets the HalfSpanishWhite color.
+    /// </summary>
+    public static RGBColor HalfSpanishWhite => FromArgb(254, 244, 219);
+    /// <summary>
+    /// Gets the HalfAndHalf color.
+    /// </summary>
+    public static RGBColor HalfAndHalf => FromArgb(255, 254, 225);
+    /// <summary>
+    /// Gets the Hampton color.
+    /// </summary>
+    public static RGBColor Hampton => FromArgb(230, 242, 234);
+    /// <summary>
+    /// Gets the Harlequin color.
+    /// </summary>
+    public static RGBColor Harlequin => FromArgb(63, 255, 0);
+    /// <summary>
+    /// Gets the Harp color.
+    /// </summary>
+    public static RGBColor Harp => FromArgb(230, 242, 234);
+    /// <summary>
+    /// Gets the HarvestGold color.
+    /// </summary>
+    public static RGBColor HarvestGold => FromArgb(224, 170, 15);
+    /// <summary>
+    /// Gets the HavelockBlue color.
+    /// </summary>
+    public static RGBColor HavelockBlue => FromArgb(85, 144, 217);
+    /// <summary>
+    /// Gets the HawaiianTan color.
+    /// </summary>
+    public static RGBColor HawaiianTan => FromArgb(157, 86, 22);
+    /// <summary>
+    /// Gets the HawkesBlue color.
+    /// </summary>
+    public static RGBColor HawkesBlue => FromArgb(212, 226, 252);
+    /// <summary>
+    /// Gets the Haystack color.
+    /// </summary>
+    public static RGBColor Haystack => FromArgb(224, 185, 117);
+    /// <summary>
+    /// Gets the Hazel color.
+    /// </summary>
+    public static RGBColor Hazel => FromArgb(142, 118, 24);
+    /// <summary>
+    /// Gets the Hazelnut color.
+    /// </summary>
+    public static RGBColor Hazelnut => FromArgb(218, 157, 118);
+    /// <summary>
+    /// Gets the Heirloom color.
+    /// </summary>
+    public static RGBColor Heirloom => FromArgb(96, 26, 20);
+    /// <summary>
+    /// Gets the Hemp color.
+    /// </summary>
+    public static RGBColor Hemp => FromArgb(144, 120, 116);
+    /// <summary>
+    /// Gets the Hibiscus color.
+    /// </summary>
+    public static RGBColor Hibiscus => FromArgb(182, 49, 108);
+    /// <summary>
+    /// Gets the Highball color.
+    /// </summary>
+    public static RGBColor Highball => FromArgb(144, 141, 57);
+    /// <summary>
+    /// Gets the Highland color.
+    /// </summary>
+    public static RGBColor Highland => FromArgb(111, 142, 99);
+    /// <summary>
+    /// Gets the Hillary color.
+    /// </summary>
+    public static RGBColor Hillary => FromArgb(172, 165, 134);
+    /// <summary>
+    /// Gets the HollywoodCerise color.
+    /// </summary>
+    public static RGBColor HollywoodCerise => FromArgb(244, 0, 161);
+    /// <summary>
+    /// Gets the Honeydew color.
+    /// </summary>
+    public static RGBColor Honeydew => FromArgb(240, 255, 240);
+    /// <summary>
+    /// Gets the HonoluluBlue color.
+    /// </summary>
+    public static RGBColor HonoluluBlue => FromArgb(0, 127, 191);
+    /// <summary>
+    /// Gets the HookersGreen color.
+    /// </summary>
+    public static RGBColor HookersGreen => FromArgb(73, 121, 107);
+    /// <summary>
+    /// Gets the HotMagenta color.
+    /// </summary>
+    public static RGBColor HotMagenta => FromArgb(255, 29, 206);
+    /// <summary>
+    /// Gets the HotPink color.
+    /// </summary>
+    public static RGBColor HotPink => FromArgb(255, 105, 180);
+    /// <summary>
+    /// Gets the HunterGreen color.
+    /// </summary>
+    public static RGBColor HunterGreen => FromArgb(53, 94, 59);
+    /// <summary>
+    /// Gets the Iceberg color.
+    /// </summary>
+    public static RGBColor Iceberg => FromArgb(113, 166, 210);
+    /// <summary>
+    /// Gets the Icterine color.
+    /// </summary>
+    public static RGBColor Icterine => FromArgb(252, 247, 94);
+    /// <summary>
+    /// Gets the IlluminatingEmerald color.
+    /// </summary>
+    public static RGBColor IlluminatingEmerald => FromArgb(49, 145, 119);
+    /// <summary>
+    /// Gets the Imperial color.
+    /// </summary>
+    public static RGBColor Imperial => FromArgb(96, 47, 107);
+    /// <summary>
+    /// Gets the ImperialBlue color.
+    /// </summary>
+    public static RGBColor ImperialBlue => FromArgb(0, 35, 149);
+    /// <summary>
+    /// Gets the ImperialPurple color.
+    /// </summary>
+    public static RGBColor ImperialPurple => FromArgb(102, 2, 60);
+    /// <summary>
+    /// Gets the ImperialRed color.
+    /// </summary>
+    public static RGBColor ImperialRed => FromArgb(237, 41, 57);
+    /// <summary>
+    /// Gets the Inchworm color.
+    /// </summary>
+    public static RGBColor Inchworm => FromArgb(178, 236, 93);
+    /// <summary>
+    /// Gets the Independence color.
+    /// </summary>
+    public static RGBColor Independence => FromArgb(76, 81, 109);
+    /// <summary>
+    /// Gets the IndiaGreen color.
+    /// </summary>
+    public static RGBColor IndiaGreen => FromArgb(19, 136, 8);
+    /// <summary>
+    /// Gets the IndianRed color.
+    /// </summary>
+    public static RGBColor IndianRed => FromArgb(205, 92, 92);
+    /// <summary>
+    /// Gets the IndianYellow color.
+    /// </summary>
+    public static RGBColor IndianYellow => FromArgb(227, 168, 87);
+    /// <summary>
+    /// Gets the Indigo color.
+    /// </summary>
+    public static RGBColor Indigo => FromArgb(75, 0, 130);
+    /// <summary>
+    /// Gets the IndigoDye color.
+    /// </summary>
+    public static RGBColor IndigoDye => FromArgb(0, 65, 106);
+    /// <summary>
+    /// Gets the IndigoRainbow color.
+    /// </summary>
+    public static RGBColor IndigoRainbow => FromArgb(35, 64, 86);
+    /// <summary>
+    /// Gets the InfraRed color.
+    /// </summary>
+    public static RGBColor InfraRed => FromArgb(255, 73, 108);
+    /// <summary>
+    /// Gets the InterdimensionalBlue color.
+    /// </summary>
+    public static RGBColor InterdimensionalBlue => FromArgb(54, 12, 204);
+    /// <summary>
+    /// Gets the InternationalKleinBlue color.
+    /// </summary>
+    public static RGBColor InternationalKleinBlue => FromArgb(0, 47, 167);
+    /// <summary>
+    /// Gets the InternationalOrange color.
+    /// </summary>
+    public static RGBColor InternationalOrange => FromArgb(255, 79, 0);
+    /// <summary>
+    /// Gets the Iris color.
+    /// </summary>
+    public static RGBColor Iris => FromArgb(90, 79, 207);
+    /// <summary>
+    /// Gets the Irresistible color.
+    /// </summary>
+    public static RGBColor Irresistible => FromArgb(179, 68, 108);
+    /// <summary>
+    /// Gets the Isabelline color.
+    /// </summary>
+    public static RGBColor Isabelline => FromArgb(244, 240, 236);
+    /// <summary>
+    /// Gets the IslamicGreen color.
+    /// </summary>
+    public static RGBColor IslamicGreen => FromArgb(0, 144, 0);
+    /// <summary>
+    /// Gets the ItalianSkyBlue color.
+    /// </summary>
+    public static RGBColor ItalianSkyBlue => FromArgb(178, 255, 255);
+    /// <summary>
+    /// Gets the Ivory color.
+    /// </summary>
+    public static RGBColor Ivory => FromArgb(255, 255, 240);
+    /// <summary>
+    /// Gets the Jade color.
+    /// </summary>
+    public static RGBColor Jade => FromArgb(0, 168, 107);
+    /// <summary>
+    /// Gets the JapaneseCarmine color.
+    /// </summary>
+    public static RGBColor JapaneseCarmine => FromArgb(157, 41, 51);
+    /// <summary>
+    /// Gets the JapaneseViolet color.
+    /// </summary>
+    public static RGBColor JapaneseViolet => FromArgb(91, 50, 86);
+    /// <summary>
+    /// Gets the Jasmine color.
+    /// </summary>
+    public static RGBColor Jasmine => FromArgb(248, 222, 126);
+    /// <summary>
+    /// Gets the Jasper color.
+    /// </summary>
+    public static RGBColor Jasper => FromArgb(215, 59, 62);
+    /// <summary>
+    /// Gets the JazzberryJam color.
+    /// </summary>
+    public static RGBColor JazzberryJam => FromArgb(165, 11, 94);
+    /// <summary>
+    /// Gets the JellyBean color.
+    /// </summary>
+    public static RGBColor JellyBean => FromArgb(218, 97, 78);
+    /// <summary>
+    /// Gets the Jet color.
+    /// </summary>
+    public static RGBColor Jet => FromArgb(52, 52, 52);
+    /// <summary>
+    /// Gets the Jonquil color.
+    /// </summary>
+    public static RGBColor Jonquil => FromArgb(250, 218, 94);
+    /// <summary>
+    /// Gets the JordyBlue color.
+    /// </summary>
+    public static RGBColor JordyBlue => FromArgb(138, 185, 241);
+    /// <summary>
+    /// Gets the JuneBud color.
+    /// </summary>
+    public static RGBColor JuneBud => FromArgb(189, 218, 87);
+    /// <summary>
+    /// Gets the JungleGreen color.
+    /// </summary>
+    public static RGBColor JungleGreen => FromArgb(41, 171, 135);
+    /// <summary>
+    /// Gets the KellyGreen color.
+    /// </summary>
+    public static RGBColor KellyGreen => FromArgb(76, 187, 23);
+    /// <summary>
+    /// Gets the KenyanCopper color.
+    /// </summary>
+    public static RGBColor KenyanCopper => FromArgb(124, 28, 5);
+    /// <summary>
+    /// Gets the Keppel color.
+    /// </summary>
+    public static RGBColor Keppel => FromArgb(58, 176, 158);
+    /// <summary>
+    /// Gets the KeyLime color.
+    /// </summary>
+    public static RGBColor KeyLime => FromArgb(232, 244, 140);
+    /// <summary>
+    /// Gets the Khaki color.
+    /// </summary>
+    public static RGBColor Khaki => FromArgb(195, 176, 145);
+    /// <summary>
+    /// Gets the Kiwi color.
+    /// </summary>
+    public static RGBColor Kiwi => FromArgb(142, 229, 63);
+    /// <summary>
+    /// Gets the Kobe color.
+    /// </summary>
+    public static RGBColor Kobe => FromArgb(136, 45, 23);
+    /// <summary>
+    /// Gets the Kobi color.
+    /// </summary>
+    public static RGBColor Kobi => FromArgb(231, 159, 196);
+    /// <summary>
+    /// Gets the Kobicha color.
+    /// </summary>
+    public static RGBColor Kobicha => FromArgb(107, 68, 35);
+    /// <summary>
+    /// Gets the KombuGreen color.
+    /// </summary>
+    public static RGBColor KombuGreen => FromArgb(53, 66, 48);
+    /// <summary>
+    /// Gets the KSUPurple color.
+    /// </summary>
+    public static RGBColor KSUPurple => FromArgb(81, 40, 136);
+    /// <summary>
+    /// Gets the KUCrimson color.
+    /// </summary>
+    public static RGBColor KUCrimson => FromArgb(232, 0, 13);
+    /// <summary>
+    /// Gets the LaSalleGreen color.
+    /// </summary>
+    public static RGBColor LaSalleGreen => FromArgb(8, 120, 48);
+    /// <summary>
+    /// Gets the LanguidLavender color.
+    /// </summary>
+    public static RGBColor LanguidLavender => FromArgb(214, 202, 221);
+    /// <summary>
+    /// Gets the LapisLazuli color.
+    /// </summary>
+    public static RGBColor LapisLazuli => FromArgb(38, 97, 156);
+    /// <summary>
+    /// Gets the LaserLemon color.
+    /// </summary>
+    public static RGBColor LaserLemon => FromArgb(254, 254, 34);
+    /// <summary>
+    /// Gets the LaurelGreen color.
+    /// </summary>
+    public static RGBColor LaurelGreen => FromArgb(169, 186, 157);
+    /// <summary>
+    /// Gets the Lava color.
+    /// </summary>
+    public static RGBColor Lava => FromArgb(207, 16, 32);
+    /// <summary>
+    /// Gets the Lavender color.
+    /// </summary>
+    public static RGBColor Lavender => FromArgb(230, 230, 250);
+    /// <summary>
+    /// Gets the LavenderBlue color.
+    /// </summary>
+    public static RGBColor LavenderBlue => FromArgb(204, 204, 255);
+    /// <summary>
+    /// Gets the LavenderBlush color.
+    /// </summary>
+    public static RGBColor LavenderBlush => FromArgb(255, 240, 245);
+    /// <summary>
+    /// Gets the LavenderGray color.
+    /// </summary>
+    public static RGBColor LavenderGray => FromArgb(196, 195, 208);
+    /// <summary>
+    /// Gets the LavenderIndigo color.
+    /// </summary>
+    public static RGBColor LavenderIndigo => FromArgb(148, 87, 235);
+    /// <summary>
+    /// Gets the LavenderMagenta color.
+    /// </summary>
+    public static RGBColor LavenderMagenta => FromArgb(238, 130, 238);
+    /// <summary>
+    /// Gets the LavenderMist color.
+    /// </summary>
+    public static RGBColor LavenderMist => FromArgb(230, 230, 250);
+    /// <summary>
+    /// Gets the LavenderPink color.
+    /// </summary>
+    public static RGBColor LavenderPink => FromArgb(251, 174, 210);
+    /// <summary>
+    /// Gets the LavenderPurple color.
+    /// </summary>
+    public static RGBColor LavenderPurple => FromArgb(150, 123, 182);
+    /// <summary>
+    /// Gets the LavenderRose color.
+    /// </summary>
+    public static RGBColor LavenderRose => FromArgb(251, 160, 227);
+    /// <summary>
+    /// Gets the LawnGreen color.
+    /// </summary>
+    public static RGBColor LawnGreen => FromArgb(124, 252, 0);
+    /// <summary>
+    /// Gets the Lemon color.
+    /// </summary>
+    public static RGBColor Lemon => FromArgb(255, 247, 0);
+    /// <summary>
+    /// Gets the LemonChiffon color.
+    /// </summary>
+    public static RGBColor LemonChiffon => FromArgb(255, 250, 205);
+    /// <summary>
+    /// Gets the LemonCurry color.
+    /// </summary>
+    public static RGBColor LemonCurry => FromArgb(204, 160, 29);
+    /// <summary>
+    /// Gets the LemonGlacier color.
+    /// </summary>
+    public static RGBColor LemonGlacier => FromArgb(253, 255, 0);
+    /// <summary>
+    /// Gets the LemonLime color.
+    /// </summary>
+    public static RGBColor LemonLime => FromArgb(227, 255, 0);
+    /// <summary>
+    /// Gets the LemonMeringue color.
+    /// </summary>
+    public static RGBColor LemonMeringue => FromArgb(246, 234, 190);
+    /// <summary>
+    /// Gets the LemonYellow color.
+    /// </summary>
+    public static RGBColor LemonYellow => FromArgb(255, 244, 79);
+    /// <summary>
+    /// Gets the LemonYellowCrayola color.
+    /// </summary>
+    public static RGBColor LemonYellowCrayola => FromArgb(255, 255, 159);
+    /// <summary>
+    /// Gets the Liberty color.
+    /// </summary>
+    public static RGBColor Liberty => FromArgb(84, 90, 167);
+    /// <summary>
+    /// Gets the Licorice color.
+    /// </summary>
+    public static RGBColor Licorice => FromArgb(26, 17, 16);
+    /// <summary>
+    /// Gets the LightApricot color.
+    /// </summary>
+    public static RGBColor LightApricot => FromArgb(253, 213, 177);
+    /// <summary>
+    /// Gets the LightBlue color.
+    /// </summary>
+    public static RGBColor LightBlue => FromArgb(173, 216, 230);
+    /// <summary>
+    /// Gets the LightBrown color.
+    /// </summary>
+    public static RGBColor LightBrown => FromArgb(181, 101, 29);
+    /// <summary>
+    /// Gets the LightCarminePink color.
+    /// </summary>
+    public static RGBColor LightCarminePink => FromArgb(230, 103, 113);
+    /// <summary>
+    /// Gets the LightCobaltBlue color.
+    /// </summary>
+    public static RGBColor LightCobaltBlue => FromArgb(136, 172, 224);
+    /// <summary>
+    /// Gets the LightCoral color.
+    /// </summary>
+    public static RGBColor LightCoral => FromArgb(240, 128, 128);
+    /// <summary>
+    /// Gets the LightCornflowerBlue color.
+    /// </summary>
+    public static RGBColor LightCornflowerBlue => FromArgb(147, 204, 234);
+    /// <summary>
+    /// Gets the LightCrimson color.
+    /// </summary>
+    public static RGBColor LightCrimson => FromArgb(245, 105, 145);
+    /// <summary>
+    /// Gets the LightCyan color.
+    /// </summary>
+    public static RGBColor LightCyan => FromArgb(224, 255, 255);
+    /// <summary>
+    /// Gets the LightDeepPink color.
+    /// </summary>
+    public static RGBColor LightDeepPink => FromArgb(255, 92, 205);
+    /// <summary>
+    /// Gets the LightFrenchBeige color.
+    /// </summary>
+    public static RGBColor LightFrenchBeige => FromArgb(200, 173, 127);
+    /// <summary>
+    /// Gets the LightFuchsiaPink color.
+    /// </summary>
+    public static RGBColor LightFuchsiaPink => FromArgb(249, 132, 239);
+    /// <summary>
+    /// Gets the LightGold color.
+    /// </summary>
+    public static RGBColor LightGold => FromArgb(230, 190, 138);
+    /// <summary>
+    /// Gets the LightGoldenrodYellow color.
+    /// </summary>
+    public static RGBColor LightGoldenrodYellow => FromArgb(250, 250, 210);
+    /// <summary>
+    /// Gets the LightGray color.
+    /// </summary>
+    public static RGBColor LightGray => FromArgb(211, 211, 211);
+    /// <summary>
+    /// Gets the LightGreen color.
+    /// </summary>
+    public static RGBColor LightGreen => FromArgb(144, 238, 144);
+    /// <summary>
+    /// Gets the LightHotPink color.
+    /// </summary>
+    public static RGBColor LightHotPink => FromArgb(255, 179, 222);
+    /// <summary>
+    /// Gets the LightKhaki color.
+    /// </summary>
+    public static RGBColor LightKhaki => FromArgb(240, 230, 140);
+    /// <summary>
+    /// Gets the LightMediumOrchid color.
+    /// </summary>
+    public static RGBColor LightMediumOrchid => FromArgb(211, 155, 203);
+    /// <summary>
+    /// Gets the LightMossGreen color.
+    /// </summary>
+    public static RGBColor LightMossGreen => FromArgb(173, 223, 173);
+    /// <summary>
+    /// Gets the LightOrchid color.
+    /// </summary>
+    public static RGBColor LightOrchid => FromArgb(230, 168, 215);
+    /// <summary>
+    /// Gets the LightPastelPurple color.
+    /// </summary>
+    public static RGBColor LightPastelPurple => FromArgb(177, 156, 217);
+    /// <summary>
+    /// Gets the LightPink color.
+    /// </summary>
+    public static RGBColor LightPink => FromArgb(255, 182, 193);
+    /// <summary>
+    /// Gets the LightRedOchre color.
+    /// </summary>
+    public static RGBColor LightRedOchre => FromArgb(233, 116, 81);
+    /// <summary>
+    /// Gets the LightSalmon color.
+    /// </summary>
+    public static RGBColor LightSalmon => FromArgb(255, 160, 122);
+    /// <summary>
+    /// Gets the LightSalmonPink color.
+    /// </summary>
+    public static RGBColor LightSalmonPink => FromArgb(255, 153, 153);
+    /// <summary>
+    /// Gets the LightSeaGreen color.
+    /// </summary>
+    public static RGBColor LightSeaGreen => FromArgb(32, 178, 170);
+    /// <summary>
+    /// Gets the LightSkyBlue color.
+    /// </summary>
+    public static RGBColor LightSkyBlue => FromArgb(135, 206, 250);
+    /// <summary>
+    /// Gets the LightSlateGray color.
+    /// </summary>
+    public static RGBColor LightSlateGray => FromArgb(119, 136, 153);
+    /// <summary>
+    /// Gets the LightSteelBlue color.
+    /// </summary>
+    public static RGBColor LightSteelBlue => FromArgb(176, 196, 222);
+    /// <summary>
+    /// Gets the LightTaupe color.
+    /// </summary>
+    public static RGBColor LightTaupe => FromArgb(179, 139, 109);
+    /// <summary>
+    /// Gets the LightThulianPink color.
+    /// </summary>
+    public static RGBColor LightThulianPink => FromArgb(230, 143, 172);
+    /// <summary>
+    /// Gets the LightYellow color.
+    /// </summary>
+    public static RGBColor LightYellow => FromArgb(255, 255, 224);
+    /// <summary>
+    /// Gets the Lilac color.
+    /// </summary>
+    public static RGBColor Lilac => FromArgb(200, 162, 200);
+    /// <summary>
+    /// Gets the LilacLuster color.
+    /// </summary>
+    public static RGBColor LilacLuster => FromArgb(174, 152, 170);
+    /// <summary>
+    /// Gets the Lime color.
+    /// </summary>
+    public static RGBColor Lime => FromArgb(0, 255, 0);
+    /// <summary>
+    /// Gets the LimeGreen color.
+    /// </summary>
+    public static RGBColor LimeGreen => FromArgb(50, 205, 50);
+    /// <summary>
+    /// Gets the Limerick color.
+    /// </summary>
+    public static RGBColor Limerick => FromArgb(157, 194, 9);
+    /// <summary>
+    /// Gets the LincolnGreen color.
+    /// </summary>
+    public static RGBColor LincolnGreen => FromArgb(25, 89, 5);
+    /// <summary>
+    /// Gets the Linen color.
+    /// </summary>
+    public static RGBColor Linen => FromArgb(250, 240, 230);
+    /// <summary>
+    /// Gets the Lion color.
+    /// </summary>
+    public static RGBColor Lion => FromArgb(193, 154, 107);
+    /// <summary>
+    /// Gets the LiseranPurple color.
+    /// </summary>
+    public static RGBColor LiseranPurple => FromArgb(222, 111, 161);
+    /// <summary>
+    /// Gets the LittleBoyBlue color.
+    /// </summary>
+    public static RGBColor LittleBoyBlue => FromArgb(108, 160, 220);
+    /// <summary>
+    /// Gets the Liver color.
+    /// </summary>
+    public static RGBColor Liver => FromArgb(103, 76, 71);
+    /// <summary>
+    /// Gets the LiverChestnut color.
+    /// </summary>
+    public static RGBColor LiverChestnut => FromArgb(152, 116, 86);
+    /// <summary>
+    /// Gets the LiverOrgan color.
+    /// </summary>
+    public static RGBColor LiverOrgan => FromArgb(108, 46, 31);
+    /// <summary>
+    /// Gets the LiverDogs color.
+    /// </summary>
+    public static RGBColor LiverDogs => FromArgb(184, 109, 41);
+    /// <summary>
+    /// Gets the LustyGallant color.
+    /// </summary>
+    public static RGBColor LustyGallant => FromArgb(102, 56, 84);
+    /// <summary>
+    /// Gets the MacaroniAndCheese color.
+    /// </summary>
+    public static RGBColor MacaroniAndCheese => FromArgb(255, 189, 136);
+
+    /// <summary>
+    /// Gets the MadderLake color.
+    /// </summary>
+    public static RGBColor MadderLake => FromArgb(204, 51, 54);
+    /// <summary>
+    /// Gets the Magenta color.
+    /// </summary>
+    public static RGBColor Magenta => FromArgb(255, 0, 255);
+    /// <summary>
+    /// Gets the MagentaCrayola color.
+    /// </summary>
+    public static RGBColor MagentaCrayola => FromArgb(246, 83, 166);
+    /// <summary>
+    /// Gets the MagentaDye color.
+    /// </summary>
+    public static RGBColor MagentaDye => FromArgb(202, 31, 123);
+    /// <summary>
+    /// Gets the MagentaPantone color.
+    /// </summary>
+    public static RGBColor MagentaPantone => FromArgb(208, 65, 126);
+    /// <summary>
+    /// Gets the MagentaProcess color.
+    /// </summary>
+    public static RGBColor MagentaProcess => FromArgb(255, 0, 144);
+    /// <summary>
+    /// Gets the MagentaHaze color.
+    /// </summary>
+    public static RGBColor MagentaHaze => FromArgb(159, 69, 118);
+    /// <summary>
+    /// Gets the MagicMint color.
+    /// </summary>
+    public static RGBColor MagicMint => FromArgb(170, 240, 209);
+    /// <summary>
+    /// Gets the Magnolia color.
+    /// </summary>
+    public static RGBColor Magnolia => FromArgb(248, 244, 255);
+    /// <summary>
+    /// Gets the Mahogany color.
+    /// </summary>
+    public static RGBColor Mahogany => FromArgb(192, 64, 0);
+    /// <summary>
+    /// Gets the Maize color.
+    /// </summary>
+    public static RGBColor Maize => FromArgb(251, 236, 93);
+    /// <summary>
+    /// Gets the Malachite color.
+    /// </summary>
+    public static RGBColor Malachite => FromArgb(11, 218, 81);
+    /// <summary>
+    /// Gets the Manatee color.
+    /// </summary>
+    public static RGBColor Manatee => FromArgb(151, 154, 170);
+    /// <summary>
+    /// Gets the Mandarin color.
+    /// </summary>
+    public static RGBColor Mandarin => FromArgb(243, 122, 72);
+    /// <summary>
+    /// Gets the MangoTango color.
+    /// </summary>
+    public static RGBColor MangoTango => FromArgb(255, 130, 67);
+    /// <summary>
+    /// Gets the Mantis color.
+    /// </summary>
+    public static RGBColor Mantis => FromArgb(116, 195, 101);
+    /// <summary>
+    /// Gets the MardiGras color.
+    /// </summary>
+    public static RGBColor MardiGras => FromArgb(136, 0, 133);
+    /// <summary>
+    /// Gets the Marigold color.
+    /// </summary>
+    public static RGBColor Marigold => FromArgb(234, 162, 33);
+    /// <summary>
+    /// Gets the Maroon color.
+    /// </summary>
+    public static RGBColor Maroon => FromArgb(128, 0, 0);
+    /// <summary>
+    /// Gets the Mauve color.
+    /// </summary>
+    public static RGBColor Mauve => FromArgb(224, 176, 255);
+    /// <summary>
+    /// Gets the MauveTaupe color.
+    /// </summary>
+    public static RGBColor MauveTaupe => FromArgb(145, 95, 109);
+    /// <summary>
+    /// Gets the Mauvelous color.
+    /// </summary>
+    public static RGBColor Mauvelous => FromArgb(239, 152, 170);
+    /// <summary>
+    /// Gets the MaximumBlue color.
+    /// </summary>
+    public static RGBColor MaximumBlue => FromArgb(71, 171, 204);
+    /// <summary>
+    /// Gets the MaximumBlueGreen color.
+    /// </summary>
+    public static RGBColor MaximumBlueGreen => FromArgb(48, 191, 191);
+    /// <summary>
+    /// Gets the MaximumBluePurple color.
+    /// </summary>
+    public static RGBColor MaximumBluePurple => FromArgb(172, 172, 230);
+    /// <summary>
+    /// Gets the MaximumGreen color.
+    /// </summary>
+    public static RGBColor MaximumGreen => FromArgb(94, 140, 49);
+    /// <summary>
+    /// Gets the MaximumGreenYellow color.
+    /// </summary>
+    public static RGBColor MaximumGreenYellow => FromArgb(217, 230, 80);
+    /// <summary>
+    /// Gets the MaximumPurple color.
+    /// </summary>
+    public static RGBColor MaximumPurple => FromArgb(115, 51, 128);
+    /// <summary>
+    /// Gets the MaximumRed color.
+    /// </summary>
+    public static RGBColor MaximumRed => FromArgb(217, 33, 33);
+    /// <summary>
+    /// Gets the MaximumRedPurple color.
+    /// </summary>
+    public static RGBColor MaximumRedPurple => FromArgb(166, 58, 121);
+    /// <summary>
+    /// Gets the MaximumYellow color.
+    /// </summary>
+    public static RGBColor MaximumYellow => FromArgb(250, 250, 55);
+    /// <summary>
+    /// Gets the MaximumYellowRed color.
+    /// </summary>
+    public static RGBColor MaximumYellowRed => FromArgb(242, 186, 73);
+    /// <summary>
+    /// Gets the MayGreen color.
+    /// </summary>
+    public static RGBColor MayGreen => FromArgb(76, 145, 65);
+    /// <summary>
+    /// Gets the MayaBlue color.
+    /// </summary>
+    public static RGBColor MayaBlue => FromArgb(115, 194, 251);
+    /// <summary>
+    /// Gets the MediumAquamarine color.
+    /// </summary>
+    public static RGBColor MediumAquamarine => FromArgb(102, 221, 170);
+    /// <summary>
+    /// Gets the MediumBlue color.
+    /// </summary>
+    public static RGBColor MediumBlue => FromArgb(0, 0, 205);
+    /// <summary>
+    /// Gets the MediumCandyAppleRed color.
+    /// </summary>
+    public static RGBColor MediumCandyAppleRed => FromArgb(226, 6, 44);
+    /// <summary>
+    /// Gets the MediumCarmine color.
+    /// </summary>
+    public static RGBColor MediumCarmine => FromArgb(175, 64, 53);
+    /// <summary>
+    /// Gets the MediumChampagne color.
+    /// </summary>
+    public static RGBColor MediumChampagne => FromArgb(243, 229, 171);
+    /// <summary>
+    /// Gets the MediumOrchid color.
+    /// </summary>
+    public static RGBColor MediumOrchid => FromArgb(186, 85, 211);
+    /// <summary>
+    /// Gets the MediumPurple color.
+    /// </summary>
+    public static RGBColor MediumPurple => FromArgb(147, 112, 219);
+    /// <summary>
+    /// Gets the MediumSeaGreen color.
+    /// </summary>
+    public static RGBColor MediumSeaGreen => FromArgb(60, 179, 113);
+    /// <summary>
+    /// Gets the MediumSlateBlue color.
+    /// </summary>
+    public static RGBColor MediumSlateBlue => FromArgb(123, 104, 238);
+    /// <summary>
+    /// Gets the MediumSpringGreen color.
+    /// </summary>
+    public static RGBColor MediumSpringGreen => FromArgb(0, 250, 154);
+    /// <summary>
+    /// Gets the MediumTurquoise color.
+    /// </summary>
+    public static RGBColor MediumTurquoise => FromArgb(72, 209, 204);
+    /// <summary>
+    /// Gets the MediumVioletRed color.
+    /// </summary>
+    public static RGBColor MediumVioletRed => FromArgb(199, 21, 133);
+    /// <summary>
+    /// Gets the MellowApricot color.
+    /// </summary>
+    public static RGBColor MellowApricot => FromArgb(248, 184, 120);
+    /// <summary>
+    /// Gets the MellowYellow color.
+    /// </summary>
+    public static RGBColor MellowYellow => FromArgb(248, 222, 126);
+    /// <summary>
+    /// Gets the Melon color.
+    /// </summary>
+    public static RGBColor Melon => FromArgb(253, 188, 180);
+    /// <summary>
+    /// Gets the MetallicSeaweed color.
+    /// </summary>
+    public static RGBColor MetallicSeaweed => FromArgb(10, 126, 140);
+    /// <summary>
+    /// Gets the MetallicSunburst color.
+    /// </summary>
+    public static RGBColor MetallicSunburst => FromArgb(156, 124, 56);
+    /// <summary>
+    /// Gets the MexicanPink color.
+    /// </summary>
+    public static RGBColor MexicanPink => FromArgb(228, 0, 124);
+    /// <summary>
+    /// Gets the MiddleBlue color.
+    /// </summary>
+    public static RGBColor MiddleBlue => FromArgb(126, 212, 230);
+    /// <summary>
+    /// Gets the MiddleBlueGreen color.
+    /// </summary>
+    public static RGBColor MiddleBlueGreen => FromArgb(141, 217, 204);
+    /// <summary>
+    /// Gets the MiddleBluePurple color.
+    /// </summary>
+    public static RGBColor MiddleBluePurple => FromArgb(139, 134, 201);
+    /// <summary>
+    /// Gets the MiddleGrey color.
+    /// </summary>
+    public static RGBColor MiddleGrey => FromArgb(139, 134, 128);
+    /// <summary>
+    /// Gets the MiddleGreen color.
+    /// </summary>
+    public static RGBColor MiddleGreen => FromArgb(91, 165, 96);
+    /// <summary>
+    /// Gets the MiddleGreenYellow color.
+    /// </summary>
+    public static RGBColor MiddleGreenYellow => FromArgb(172, 191, 105);
+    /// <summary>
+    /// Gets the MiddlePurple color.
+    /// </summary>
+    public static RGBColor MiddlePurple => FromArgb(217, 130, 181);
+    /// <summary>
+    /// Gets the MiddleRed color.
+    /// </summary>
+    public static RGBColor MiddleRed => FromArgb(229, 142, 115);
+    /// <summary>
+    /// Gets the MiddleRedPurple color.
+    /// </summary>
+    public static RGBColor MiddleRedPurple => FromArgb(165, 83, 83);
+    /// <summary>
+    /// Gets the MiddleYellow color.
+    /// </summary>
+    public static RGBColor MiddleYellow => FromArgb(255, 235, 0);
+    /// <summary>
+    /// Gets the MiddleYellowRed color.
+    /// </summary>
+    public static RGBColor MiddleYellowRed => FromArgb(236, 177, 118);
+    /// <summary>
+    /// Gets the MidnightBlue color.
+    /// </summary>
+    public static RGBColor MidnightBlue => FromArgb(25, 25, 112);
+    /// <summary>
+    /// Gets the MidnightGreen color.
+    /// </summary>
+    public static RGBColor MidnightGreen => FromArgb(0, 73, 83);
+    /// <summary>
+    /// Gets the MikadoYellow color.
+    /// </summary>
+    public static RGBColor MikadoYellow => FromArgb(255, 196, 12);
+    /// <summary>
+    /// Gets the MilkChocolate color.
+    /// </summary>
+    public static RGBColor MilkChocolate => FromArgb(132, 86, 60);
+    /// <summary>
+    /// Gets the MintCream color.
+    /// </summary>
+    public static RGBColor MintCream => FromArgb(245, 255, 250);
+    /// <summary>
+    /// Gets the MistyRose color.
+    /// </summary>
+    public static RGBColor MistyRose => FromArgb(255, 228, 225);
+    /// <summary>
+    /// Gets the Moccasin color.
+    /// </summary>
+    public static RGBColor Moccasin => FromArgb(250, 235, 215);
+    /// <summary>
+    /// Gets the ModeBeige color.
+    /// </summary>
+    public static RGBColor ModeBeige => FromArgb(150, 113, 23);
+    /// <summary>
+    /// Gets the MoonstoneBlue color.
+    /// </summary>
+    public static RGBColor MoonstoneBlue => FromArgb(115, 169, 194);
+    /// <summary>
+    /// Gets the MordantRed19 color.
+    /// </summary>
+    public static RGBColor MordantRed19 => FromArgb(174, 12, 0);
+    /// <summary>
+    /// Gets the MossGreen color.
+    /// </summary>
+    public static RGBColor MossGreen => FromArgb(138, 154, 91);
+    /// <summary>
+    /// Gets the MountainMeadow color.
+    /// </summary>
+    public static RGBColor MountainMeadow => FromArgb(48, 186, 143);
+    /// <summary>
+    /// Gets the MountbattenPink color.
+    /// </summary>
+    public static RGBColor MountbattenPink => FromArgb(153, 122, 141);
+    /// <summary>
+    /// Gets the MSUGreen color.
+    /// </summary>
+    public static RGBColor MSUGreen => FromArgb(24, 69, 59);
+    /// <summary>
+    /// Gets the Mulberry color.
+    /// </summary>
+    public static RGBColor Mulberry => FromArgb(197, 75, 140);
+    /// <summary>
+    /// Gets the Mustard color.
+    /// </summary>
+    public static RGBColor Mustard => FromArgb(255, 219, 88);
+    /// <summary>
+    /// Gets the MyrtleGreen color.
+    /// </summary>
+    public static RGBColor MyrtleGreen => FromArgb(49, 120, 115);
+    /// <summary>
+    /// Gets the Mystic color.
+    /// </summary>
+    public static RGBColor Mystic => FromArgb(214, 82, 130);
+    /// <summary>
+    /// Gets the MysticMaroon color.
+    /// </summary>
+    public static RGBColor MysticMaroon => FromArgb(173, 67, 121);
+    /// <summary>
+    /// Gets the NadeshikoPink color.
+    /// </summary>
+    public static RGBColor NadeshikoPink => FromArgb(246, 173, 198);
+    /// <summary>
+    /// Gets the NapierGreen color.
+    /// </summary>
+    public static RGBColor NapierGreen => FromArgb(42, 128, 0);
+    /// <summary>
+    /// Gets the NaplesYellow color.
+    /// </summary>
+    public static RGBColor NaplesYellow => FromArgb(250, 218, 94);
+    /// <summary>
+    /// Gets the NavajoWhite color.
+    /// </summary>
+    public static RGBColor NavajoWhite => FromArgb(255, 222, 173);
+    /// <summary>
+    /// Gets the NavyBlue color.
+    /// </summary>
+    public static RGBColor NavyBlue => FromArgb(0, 0, 128);
+    /// <summary>
+    /// Gets the NeonCarrot color.
+    /// </summary>
+    public static RGBColor NeonCarrot => FromArgb(255, 163, 67);
+    /// <summary>
+    /// Gets the NeonFuchsia color.
+    /// </summary>
+    public static RGBColor NeonFuchsia => FromArgb(254, 65, 100);
+    /// <summary>
+    /// Gets the NeonGreen color.
+    /// </summary>
+    public static RGBColor NeonGreen => FromArgb(57, 255, 20);
+    /// <summary>
+    /// Gets the NewYorkPink color.
+    /// </summary>
+    public static RGBColor NewYorkPink => FromArgb(215, 131, 127);
+    /// <summary>
+    /// Gets the Nickel color.
+    /// </summary>
+    public static RGBColor Nickel => FromArgb(114, 116, 114);
+    /// <summary>
+    /// Gets the NonPhotoBlue color.
+    /// </summary>
+    public static RGBColor NonPhotoBlue => FromArgb(164, 221, 237);
+    /// <summary>
+    /// Gets the NorthTexasGreen color.
+    /// </summary>
+    public static RGBColor NorthTexasGreen => FromArgb(5, 144, 51);
+    /// <summary>
+    /// Gets the Nyanza color.
+    /// </summary>
+    public static RGBColor Nyanza => FromArgb(233, 255, 219);
+    /// <summary>
+    /// Gets the OceanBlue color.
+    /// </summary>
+    public static RGBColor OceanBlue => FromArgb(79, 66, 181);
+    /// <summary>
+    /// Gets the OceanGreen color.
+    /// </summary>
+    public static RGBColor OceanGreen => FromArgb(72, 191, 145);
+    /// <summary>
+    /// Gets the Ochre color.
+    /// </summary>
+    public static RGBColor Ochre => FromArgb(204, 119, 34);
+    /// <summary>
+    /// Gets the OfficeGreen color.
+    /// </summary>
+    public static RGBColor OfficeGreen => FromArgb(0, 128, 0);
+    /// <summary>
+    /// Gets the OldBurgundy color.
+    /// </summary>
+    public static RGBColor OldBurgundy => FromArgb(67, 48, 46);
+    /// <summary>
+    /// Gets the OldGold color.
+    /// </summary>
+    public static RGBColor OldGold => FromArgb(207, 181, 59);
+    /// <summary>
+    /// Gets the OldHeliotrope color.
+    /// </summary>
+    public static RGBColor OldHeliotrope => FromArgb(86, 60, 92);
+    /// <summary>
+    /// Gets the OldLace color.
+    /// </summary>
+    public static RGBColor OldLace => FromArgb(253, 245, 230);
+    /// <summary>
+    /// Gets the OldLavender color.
+    /// </summary>
+    public static RGBColor OldLavender => FromArgb(121, 104, 120);
+    /// <summary>
+    /// Gets the OldMauve color.
+    /// </summary>
+    public static RGBColor OldMauve => FromArgb(103, 49, 71);
+    /// <summary>
+    /// Gets the OldMossGreen color.
+    /// </summary>
+    public static RGBColor OldMossGreen => FromArgb(134, 126, 54);
+    /// <summary>
+    /// Gets the OldRose color.
+    /// </summary>
+    public static RGBColor OldRose => FromArgb(192, 128, 129);
+    /// <summary>
+    /// Gets the OldSilver color.
+    /// </summary>
+    public static RGBColor OldSilver => FromArgb(132, 132, 130);
+    /// <summary>
+    /// Gets the Olive color.
+    /// </summary>
+    public static RGBColor Olive => FromArgb(128, 128, 0);
+    /// <summary>
+    /// Gets the OliveDrab7 color.
+    /// </summary>
+    public static RGBColor OliveDrab7 => FromArgb(60, 52, 31);
+    /// <summary>
+    /// Gets the OliveGreen color.
+    /// </summary>
+    public static RGBColor OliveGreen => FromArgb(181, 179, 92);
+    /// <summary>
+    /// Gets the Olivine color.
+    /// </summary>
+    public static RGBColor Olivine => FromArgb(154, 185, 115);
+    /// <summary>
+    /// Gets the Onyx color.
+    /// </summary>
+    public static RGBColor Onyx => FromArgb(53, 56, 57);
+    /// <summary>
+    /// Gets the OperaMauve color.
+    /// </summary>
+    public static RGBColor OperaMauve => FromArgb(183, 132, 167);
+    /// <summary>
+    /// Gets the Orange color.
+    /// </summary>
+    public static RGBColor Orange => FromArgb(255, 165, 0);
+    /// <summary>
+    /// Gets the OrangePeel color.
+    /// </summary>
+    public static RGBColor OrangePeel => FromArgb(255, 159, 0);
+    /// <summary>
+    /// Gets the OrangeRed color.
+    /// </summary>
+    public static RGBColor OrangeRed => FromArgb(255, 69, 0);
+    /// <summary>
+    /// Gets the OrangeYellow color.
+    /// </summary>
+    public static RGBColor OrangeYellow => FromArgb(245, 189, 31);
+    /// <summary>
+    /// Gets the Orchid color.
+    /// </summary>
+    public static RGBColor Orchid => FromArgb(218, 112, 214);
+    /// <summary>
+    /// Gets the OrchidPink color.
+    /// </summary>
+    public static RGBColor OrchidPink => FromArgb(242, 189, 205);
+    /// <summary>
+    /// Gets the OriolesOrange color.
+    /// </summary>
+    public static RGBColor OriolesOrange => FromArgb(251, 79, 20);
+    /// <summary>
+    /// Gets the OtterBrown color.
+    /// </summary>
+    public static RGBColor OtterBrown => FromArgb(101, 67, 33);
+    /// <summary>
+    /// Gets the OuterSpace color.
+    /// </summary>
+    public static RGBColor OuterSpace => FromArgb(65, 74, 76);
+    /// <summary>
+    /// Gets the OutrageousOrange color.
+    /// </summary>
+    public static RGBColor OutrageousOrange => FromArgb(255, 110, 74);
+    /// <summary>
+    /// Gets the OxfordBlue color.
+    /// </summary>
+    public static RGBColor OxfordBlue => FromArgb(0, 33, 71);
+    /// <summary>
+    /// Gets the OUcrimsonRed color.
+    /// </summary>
+    public static RGBColor OUcrimsonRed => FromArgb(153, 0, 0);
+    /// <summary>
+    /// Gets the PacificBlue color.
+    /// </summary>
+    public static RGBColor PacificBlue => FromArgb(28, 169, 201);
+    /// <summary>
+    /// Gets the PakistanGreen color.
+    /// </summary>
+    public static RGBColor PakistanGreen => FromArgb(0, 102, 0);
+    /// <summary>
+    /// Gets the PalatinateBlue color.
+    /// </summary>
+    public static RGBColor PalatinateBlue => FromArgb(39, 59, 226);
+    /// <summary>
+    /// Gets the PalatinatePurple color.
+    /// </summary>
+    public static RGBColor PalatinatePurple => FromArgb(104, 40, 96);
+    /// <summary>
+    /// Gets the PaleAqua color.
+    /// </summary>
+    public static RGBColor PaleAqua => FromArgb(188, 212, 230);
+    /// <summary>
+    /// Gets the PaleBlue color.
+    /// </summary>
+    public static RGBColor PaleBlue => FromArgb(175, 238, 238);
+    /// <summary>
+    /// Gets the PaleBrown color.
+    /// </summary>
+    public static RGBColor PaleBrown => FromArgb(152, 118, 84);
+    /// <summary>
+    /// Gets the PaleCarmine color.
+    /// </summary>
+    public static RGBColor PaleCarmine => FromArgb(175, 64, 53);
+    /// <summary>
+    /// Gets the PaleCerulean color.
+    /// </summary>
+    public static RGBColor PaleCerulean => FromArgb(155, 196, 226);
+    /// <summary>
+    /// Gets the PaleChestnut color.
+    /// </summary>
+    public static RGBColor PaleChestnut => FromArgb(221, 173, 175);
+    /// <summary>
+    /// Gets the PaleCopper color.
+    /// </summary>
+    public static RGBColor PaleCopper => FromArgb(218, 138, 103);
+    /// <summary>
+    /// Gets the PaleCornflowerBlue color.
+    /// </summary>
+    public static RGBColor PaleCornflowerBlue => FromArgb(171, 205, 239);
+    /// <summary>
+    /// Gets the PaleCyan color.
+    /// </summary>
+    public static RGBColor PaleCyan => FromArgb(135, 211, 248);
+    /// <summary>
+    /// Gets the PaleGold color.
+    /// </summary>
+    public static RGBColor PaleGold => FromArgb(230, 190, 138);
+    /// <summary>
+    /// Gets the PaleGoldenrod color.
+    /// </summary>
+    public static RGBColor PaleGoldenrod => FromArgb(238, 232, 170);
+    /// <summary>
+    /// Gets the PaleGreen color.
+    /// </summary>
+    public static RGBColor PaleGreen => FromArgb(152, 251, 152);
+    /// <summary>
+    /// Gets the PaleLavender color.
+    /// </summary>
+    public static RGBColor PaleLavender => FromArgb(220, 208, 255);
+    /// <summary>
+    /// Gets the PaleMagenta color.
+    /// </summary>
+    public static RGBColor PaleMagenta => FromArgb(249, 132, 229);
+    /// <summary>
+    /// Gets the PaleMagentaPink color.
+    /// </summary>
+    public static RGBColor PaleMagentaPink => FromArgb(255, 153, 204);
+    /// <summary>
+    /// Gets the PalePink color.
+    /// </summary>
+    public static RGBColor PalePink => FromArgb(250, 218, 221);
+    /// <summary>
+    /// Gets the PalePlum color.
+    /// </summary>
+    public static RGBColor PalePlum => FromArgb(221, 160, 221);
+    /// <summary>
+    /// Gets the PaleRedViolet color.
+    /// </summary>
+    public static RGBColor PaleRedViolet => FromArgb(219, 112, 147);
+    /// <summary>
+    /// Gets the PaleRobinEggBlue color.
+    /// </summary>
+    public static RGBColor PaleRobinEggBlue => FromArgb(150, 222, 209);
+    /// <summary>
+    /// Gets the PaleSilver color.
+    /// </summary>
+    public static RGBColor PaleSilver => FromArgb(201, 192, 187);
+    /// <summary>
+    /// Gets the PaleSpringBud color.
+    /// </summary>
+    public static RGBColor PaleSpringBud => FromArgb(236, 235, 189);
+    /// <summary>
+    /// Gets the PaleTaupe color.
+    /// </summary>
+    public static RGBColor PaleTaupe => FromArgb(188, 152, 126);
+    /// <summary>
+    /// Gets the PaleTurquoise color.
+    /// </summary>
+    public static RGBColor PaleTurquoise => FromArgb(175, 238, 238);
+    /// <summary>
+    /// Gets the PaleViolet color.
+    /// </summary>
+    public static RGBColor PaleViolet => FromArgb(204, 153, 255);
+    /// <summary>
+    /// Gets the PaleVioletRed color.
+    /// </summary>
+    public static RGBColor PaleVioletRed => FromArgb(219, 112, 147);
+    /// <summary>
+    /// Gets the PalmLeaf color.
+    /// </summary>
+    public static RGBColor PalmLeaf => FromArgb(25, 51, 14);
+    /// <summary>
+    /// Gets the PansyPurple color.
+    /// </summary>
+    public static RGBColor PansyPurple => FromArgb(120, 24, 74);
+    /// <summary>
+    /// Gets the PaoloVeroneseGreen color.
+    /// </summary>
+    public static RGBColor PaoloVeroneseGreen => FromArgb(0, 155, 125);
+    /// <summary>
+    /// Gets the PapayaWhip color.
+    /// </summary>
+    public static RGBColor PapayaWhip => FromArgb(255, 239, 213);
+    /// <summary>
+    /// Gets the ParadisePink color.
+    /// </summary>
+    public static RGBColor ParadisePink => FromArgb(230, 62, 98);
+    /// <summary>
+    /// Gets the ParisGreen color.
+    /// </summary>
+    public static RGBColor ParisGreen => FromArgb(80, 200, 120);
+    /// <summary>
+    /// Gets the PastelBlue color.
+    /// </summary>
+    public static RGBColor PastelBlue => FromArgb(174, 198, 207);
+    /// <summary>
+    /// Gets the PastelBrown color.
+    /// </summary>
+    public static RGBColor PastelBrown => FromArgb(131, 105, 83);
+    /// <summary>
+    /// Gets the PastelGray color.
+    /// </summary>
+    public static RGBColor PastelGray => FromArgb(207, 207, 196);
+    /// <summary>
+    /// Gets the PastelGreen color.
+    /// </summary>
+    public static RGBColor PastelGreen => FromArgb(119, 221, 119);
+    /// <summary>
+    /// Gets the PastelMagenta color.
+    /// </summary>
+    public static RGBColor PastelMagenta => FromArgb(244, 154, 194);
+    /// <summary>
+    /// Gets the PastelOrange color.
+    /// </summary>
+    public static RGBColor PastelOrange => FromArgb(255, 179, 71);
+    /// <summary>
+    /// Gets the PastelPink color.
+    /// </summary>
+    public static RGBColor PastelPink => FromArgb(222, 165, 164);
+    /// <summary>
+    /// Gets the PastelPurple color.
+    /// </summary>
+    public static RGBColor PastelPurple => FromArgb(179, 158, 181);
+    /// <summary>
+    /// Gets the PastelRed color.
+    /// </summary>
+    public static RGBColor PastelRed => FromArgb(255, 105, 97);
+    /// <summary>
+    /// Gets the PastelViolet color.
+    /// </summary>
+    public static RGBColor PastelViolet => FromArgb(203, 153, 201);
+    /// <summary>
+    /// Gets the PastelYellow color.
+    /// </summary>
+    public static RGBColor PastelYellow => FromArgb(253, 253, 150);
+    /// <summary>
+    /// Gets the Patriarch color.
+    /// </summary>
+    public static RGBColor Patriarch => FromArgb(128, 0, 128);
+    /// <summary>
+    /// Gets the PayneGrey color.
+    /// </summary>
+    public static RGBColor PayneGrey => FromArgb(83, 104, 120);
+    /// <summary>
+    /// Gets the Peach color.
+    /// </summary>
+    public static RGBColor Peach => FromArgb(255, 229, 180);
+    /// <summary>
+    /// Gets the PeachOrange color.
+    /// </summary>
+    public static RGBColor PeachOrange => FromArgb(255, 204, 153);
+    /// <summary>
+    /// Gets the PeachPuff color.
+    /// </summary>
+    public static RGBColor PeachPuff => FromArgb(255, 218, 185);
+    /// <summary>
+    /// Gets the PeachYellow color.
+    /// </summary>
+    public static RGBColor PeachYellow => FromArgb(250, 223, 173);
+    /// <summary>
+    /// Gets the Pear color.
+    /// </summary>
+    public static RGBColor Pear => FromArgb(209, 226, 49);
+    /// <summary>
+    /// Gets the Pearl color.
+    /// </summary>
+    public static RGBColor Pearl => FromArgb(234, 224, 200);
+    /// <summary>
+    /// Gets the PearlAqua color.
+    /// </summary>
+    public static RGBColor PearlAqua => FromArgb(136, 216, 192);
+    /// <summary>
+    /// Gets the PearlyPurple color.
+    /// </summary>
+    public static RGBColor PearlyPurple => FromArgb(183, 104, 162);
+    /// <summary>
+    /// Gets the Peridot color.
+    /// </summary>
+    public static RGBColor Peridot => FromArgb(230, 226, 0);
+    /// <summary>
+    /// Gets the Periwinkle color.
+    /// </summary>
+    public static RGBColor Periwinkle => FromArgb(204, 204, 255);
+    /// <summary>
+    /// Gets the PersianBlue color.
+    /// </summary>
+    public static RGBColor PersianBlue => FromArgb(28, 57, 187);
+    /// <summary>
+    /// Gets the PersianGreen color.
+    /// </summary>
+    public static RGBColor PersianGreen => FromArgb(0, 166, 147);
+    /// <summary>
+    /// Gets the PersianIndigo color.
+    /// </summary>
+    public static RGBColor PersianIndigo => FromArgb(50, 18, 122);
+    /// <summary>
+    /// Gets the PersianOrange color.
+    /// </summary>
+    public static RGBColor PersianOrange => FromArgb(217, 144, 88);
+    /// <summary>
+    /// Gets the PersianPink color.
+    /// </summary>
+    public static RGBColor PersianPink => FromArgb(247, 127, 190);
+    /// <summary>
+    /// Gets the PersianPlum color.
+    /// </summary>
+    public static RGBColor PersianPlum => FromArgb(112, 28, 28);
+    /// <summary>
+    /// Gets the PersianRed color.
+    /// </summary>
+    public static RGBColor PersianRed => FromArgb(204, 51, 51);
+    /// <summary>
+    /// Gets the PersianRose color.
+    /// </summary>
+    public static RGBColor PersianRose => FromArgb(254, 40, 162);
+    /// <summary>
+    /// Gets the Persimmon color.
+    /// </summary>
+    public static RGBColor Persimmon => FromArgb(236, 88, 0);
+    /// <summary>
+    /// Gets the Peru color.
+    /// </summary>
+    public static RGBColor Peru => FromArgb(205, 133, 63);
+    /// <summary>
+    /// Gets the Phlox color.
+    /// </summary>
+    public static RGBColor Phlox => FromArgb(223, 0, 255);
+    /// <summary>
+    /// Gets the PhthaloBlue color.
+    /// </summary>
+    public static RGBColor PhthaloBlue => FromArgb(0, 15, 137);
+    /// <summary>
+    /// Gets the PhthaloGreen color.
+    /// </summary>
+    public static RGBColor PhthaloGreen => FromArgb(18, 53, 36);
+    /// <summary>
+    /// Gets the PictonBlue color.
+    /// </summary>
+    public static RGBColor PictonBlue => FromArgb(69, 177, 232);
+    /// <summary>
+    /// Gets the PictorialCarmine color.
+    /// </summary>
+    public static RGBColor PictorialCarmine => FromArgb(195, 11, 78);
+    /// <summary>
+    /// Gets the PiggyPink color.
+    /// </summary>
+    public static RGBColor PiggyPink => FromArgb(253, 221, 230);
+    /// <summary>
+    /// Gets the PineGreen color.
+    /// </summary>
+    public static RGBColor PineGreen => FromArgb(1, 121, 111);
+    /// <summary>
+    /// Gets the Pineapple color.
+    /// </summary>
+    public static RGBColor Pineapple => FromArgb(86, 60, 13);
+    /// <summary>
+    /// Gets the Pink color.
+    /// </summary>
+    public static RGBColor Pink => FromArgb(255, 192, 203);
+    /// <summary>
+    /// Gets the PinkLace color.
+    /// </summary>
+    public static RGBColor PinkLace => FromArgb(255, 221, 244);
+    /// <summary>
+    /// Gets the PinkLavender color.
+    /// </summary>
+    public static RGBColor PinkLavender => FromArgb(216, 178, 209);
+    /// <summary>
+    /// Gets the PinkPearl color.
+    /// </summary>
+    public static RGBColor PinkPearl => FromArgb(231, 172, 207);
+    /// <summary>
+    /// Gets the PinkRaspberry color.
+    /// </summary>
+    public static RGBColor PinkRaspberry => FromArgb(152, 0, 54);
+    /// <summary>
+    /// Gets the PinkSherbet color.
+    /// </summary>
+    public static RGBColor PinkSherbet => FromArgb(247, 143, 167);
+    /// <summary>
+    /// Gets the Pistachio color.
+    /// </summary>
+    public static RGBColor Pistachio => FromArgb(147, 197, 114);
+    /// <summary>
+    /// Gets the Platinum color.
+    /// </summary>
+    public static RGBColor Platinum => FromArgb(229, 228, 226);
+    /// <summary>
+    /// Gets the Plum color.
+    /// </summary>
+    public static RGBColor Plum => FromArgb(142, 69, 133);
+    /// <summary>
+    /// Gets the PlumWeb color.
+    /// </summary>
+    public static RGBColor PlumWeb => FromArgb(221, 160, 221);
+    /// <summary>
+    /// Gets the PompAndPower color.
+    /// </summary>
+    public static RGBColor PompAndPower => FromArgb(134, 96, 142);
+    /// <summary>
+    /// Gets the Popstar color.
+    /// </summary>
+    public static RGBColor Popstar => FromArgb(190, 79, 98);
+    /// <summary>
+    /// Gets the PortlandOrange color.
+    /// </summary>
+    public static RGBColor PortlandOrange => FromArgb(255, 90, 54);
+    /// <summary>
+    /// Gets the PowderBlue color.
+    /// </summary>
+    public static RGBColor PowderBlue => FromArgb(176, 224, 230);
+    /// <summary>
+    /// Gets the PrincetonOrange color.
+    /// </summary>
+    public static RGBColor PrincetonOrange => FromArgb(245, 128, 37);
+    /// <summary>
+    /// Gets the Prune color.
+    /// </summary>
+    public static RGBColor Prune => FromArgb(112, 28, 28);
+    /// <summary>
+    /// Gets the PrussianBlue color.
+    /// </summary>
+    public static RGBColor PrussianBlue => FromArgb(0, 49, 83);
+    /// <summary>
+    /// Gets the PsychedelicPurple color.
+    /// </summary>
+    public static RGBColor PsychedelicPurple => FromArgb(223, 0, 255);
+    /// <summary>
+    /// Gets the Puce color.
+    /// </summary>
+    public static RGBColor Puce => FromArgb(204, 136, 153);
+    /// <summary>
+    /// Gets the PuceRed color.
+    /// </summary>
+    public static RGBColor PuceRed => FromArgb(114, 47, 55);
+    /// <summary>
+    /// Gets the PullmanBrown color.
+    /// </summary>
+    public static RGBColor PullmanBrown => FromArgb(100, 65, 23);
+    /// <summary>
+    /// Gets the PullmanGreen color.
+    /// </summary>
+    public static RGBColor PullmanGreen => FromArgb(59, 51, 28);
+    /// <summary>
+    /// Gets the Pumpkin color.
+    /// </summary>
+    public static RGBColor Pumpkin => FromArgb(255, 117, 24);
+    /// <summary>
+    /// Gets the Purple color.
+    /// </summary>
+    public static RGBColor Purple => FromArgb(128, 0, 128);
+    /// <summary>
+    /// Gets the PurpleHeart color.
+    /// </summary>
+    public static RGBColor PurpleHeart => FromArgb(105, 53, 156);
+    /// <summary>
+    /// Gets the PurpleMountainMajesty color.
+    /// </summary>
+    public static RGBColor PurpleMountainMajesty => FromArgb(150, 120, 182);
+    /// <summary>
+    /// Gets the PurpleNavy color.
+    /// </summary>
+    public static RGBColor PurpleNavy => FromArgb(78, 81, 128);
+    /// <summary>
+    /// Gets the PurplePizzazz color.
+    /// </summary>
+    public static RGBColor PurplePizzazz => FromArgb(254, 78, 218);
+    /// <summary>
+    /// Gets the PurpleTaupe color.
+    /// </summary>
+    public static RGBColor PurpleTaupe => FromArgb(80, 64, 77);
+    /// <summary>
+    /// Gets the Purpureus color.
+    /// </summary>
+    public static RGBColor Purpureus => FromArgb(154, 78, 174);
+    /// <summary>
+    /// Gets the Quartz color.
+    /// </summary>
+    public static RGBColor Quartz => FromArgb(81, 72, 79);
+    /// <summary>
+    /// Gets the QueenBlue color.
+    /// </summary>
+    public static RGBColor QueenBlue => FromArgb(67, 107, 149);
+    /// <summary>
+    /// Gets the QueenPink color.
+    /// </summary>
+    public static RGBColor QueenPink => FromArgb(232, 204, 215);
+    /// <summary>
+    /// Gets the QuickSilver color.
+    /// </summary>
+    public static RGBColor QuickSilver => FromArgb(166, 166, 166);
+    /// <summary>
+    /// Gets the RadicalRed color.
+    /// </summary>
+    public static RGBColor RadicalRed => FromArgb(255, 53, 94);
+    /// <summary>
+    /// Gets the RaisinBlack color.
+    /// </summary>
+    public static RGBColor RaisinBlack => FromArgb(36, 33, 36);
+    /// <summary>
+    /// Gets the Rajah color.
+    /// </summary>
+    public static RGBColor Rajah => FromArgb(251, 171, 96);
+    /// <summary>
+    /// Gets the Raspberry color.
+    /// </summary>
+    public static RGBColor Raspberry => FromArgb(227, 11, 93);
+    /// <summary>
+    /// Gets the RaspberryPink color.
+    /// </summary>
+    public static RGBColor RaspberryPink => FromArgb(226, 80, 152);
+    /// <summary>
+    /// Gets the RawSienna color.
+    /// </summary>
+    public static RGBColor RawSienna => FromArgb(214, 138, 89);
+    /// <summary>
+    /// Gets the RazzleDazzleRose color.
+    /// </summary>
+    public static RGBColor RazzleDazzleRose => FromArgb(255, 51, 204);
+    /// <summary>
+    /// Gets the Razzmatazz color.
+    /// </summary>
+    public static RGBColor Razzmatazz => FromArgb(227, 37, 107);
+    /// <summary>
+    /// Gets the RazzmicBerry color.
+    /// </summary>
+    public static RGBColor RazzmicBerry => FromArgb(141, 78, 133);
+    /// <summary>
+    /// Gets the RebeccaPurple color.
+    /// </summary>
+    public static RGBColor RebeccaPurple => FromArgb(102, 52, 153);
+    /// <summary>
+    /// Gets the Red color.
+    /// </summary>
+    public static RGBColor Red => FromArgb(255, 0, 0);
+    /// <summary>
+    /// Gets the RedDevil color.
+    /// </summary>
+    public static RGBColor RedDevil => FromArgb(134, 1, 17);
+    /// <summary>
+    /// Gets the RedOrange color.
+    /// </summary>
+    public static RGBColor RedOrange => FromArgb(255, 83, 73);
+    /// <summary>
+    /// Gets the RedPurple color.
+    /// </summary>
+    public static RGBColor RedPurple => FromArgb(228, 0, 120);
+    /// <summary>
+    /// Gets the RedSalsa color.
+    /// </summary>
+    public static RGBColor RedSalsa => FromArgb(253, 58, 74);
+    /// <summary>
+    /// Gets the RedViolet color.
+    /// </summary>
+    public static RGBColor RedViolet => FromArgb(199, 21, 133);
+    /// <summary>
+    /// Gets the Redwood color.
+    /// </summary>
+    public static RGBColor Redwood => FromArgb(164, 90, 82);
+    /// <summary>
+    /// Gets the Regalia color.
+    /// </summary>
+    public static RGBColor Regalia => FromArgb(82, 45, 128);
+    /// <summary>
+    /// Gets the ResolutionBlue color.
+    /// </summary>
+    public static RGBColor ResolutionBlue => FromArgb(0, 35, 135);
+    /// <summary>
+    /// Gets the Rhythm color.
+    /// </summary>
+    public static RGBColor Rhythm => FromArgb(119, 118, 150);
+    /// <summary>
+    /// Gets the RichBlack color.
+    /// </summary>
+    public static RGBColor RichBlack => FromArgb(0, 64, 64);
+    /// <summary>
+    /// Gets the RichBrilliantLavender color.
+    /// </summary>
+    public static RGBColor RichBrilliantLavender => FromArgb(241, 167, 254);
+    /// <summary>
+    /// Gets the RichCarmine color.
+    /// </summary>
+    public static RGBColor RichCarmine => FromArgb(215, 0, 64);
+    /// <summary>
+    /// Gets the RichElectricBlue color.
+    /// </summary>
+    public static RGBColor RichElectricBlue => FromArgb(8, 146, 208);
+    /// <summary>
+    /// Gets the RichLavender color.
+    /// </summary>
+    public static RGBColor RichLavender => FromArgb(167, 107, 207);
+    /// <summary>
+    /// Gets the RichLilac color.
+    /// </summary>
+    public static RGBColor RichLilac => FromArgb(182, 102, 210);
+    /// <summary>
+    /// Gets the RichMaroon color.
+    /// </summary>
+    public static RGBColor RichMaroon => FromArgb(176, 48, 96);
+    /// <summary>
+    /// Gets the RifleGreen color.
+    /// </summary>
+    public static RGBColor RifleGreen => FromArgb(68, 76, 56);
+    /// <summary>
+    /// Gets the RoastCoffee color.
+    /// </summary>
+    public static RGBColor RoastCoffee => FromArgb(112, 66, 65);
+    /// <summary>
+    /// Gets the RobinEggBlue color.
+    /// </summary>
+    public static RGBColor RobinEggBlue => FromArgb(0, 204, 204);
+    /// <summary>
+    /// Gets the RocketMetallic color.
+    /// </summary>
+    public static RGBColor RocketMetallic => FromArgb(138, 127, 128);
+    /// <summary>
+    /// Gets the RomanSilver color.
+    /// </summary>
+    public static RGBColor RomanSilver => FromArgb(131, 137, 150);
+    /// <summary>
+    /// Gets the Rose color.
+    /// </summary>
+    public static RGBColor Rose => FromArgb(255, 0, 127);
+    /// <summary>
+    /// Gets the RoseBonbon color.
+    /// </summary>
+    public static RGBColor RoseBonbon => FromArgb(249, 66, 158);
+    /// <summary>
+    /// Gets the RoseDust color.
+    /// </summary>
+    public static RGBColor RoseDust => FromArgb(158, 94, 111);
+    /// <summary>
+    /// Gets the RoseEbony color.
+    /// </summary>
+    public static RGBColor RoseEbony => FromArgb(103, 72, 70);
+    /// <summary>
+    /// Gets the RoseGold color.
+    /// </summary>
+    public static RGBColor RoseGold => FromArgb(183, 110, 121);
+    /// <summary>
+    /// Gets the RoseMadder color.
+    /// </summary>
+    public static RGBColor RoseMadder => FromArgb(227, 38, 54);
+    /// <summary>
+    /// Gets the RosePink color.
+    /// </summary>
+    public static RGBColor RosePink => FromArgb(255, 102, 204);
+    /// <summary>
+    /// Gets the RoseQuartz color.
+    /// </summary>
+    public static RGBColor RoseQuartz => FromArgb(170, 152, 169);
+    /// <summary>
+    /// Gets the RoseRed color.
+    /// </summary>
+    public static RGBColor RoseRed => FromArgb(194, 30, 86);
+    /// <summary>
+    /// Gets the RoseTaupe color.
+    /// </summary>
+    public static RGBColor RoseTaupe => FromArgb(144, 93, 93);
+    /// <summary>
+    /// Gets the RoseVale color.
+    /// </summary>
+    public static RGBColor RoseVale => FromArgb(171, 78, 82);
+    /// <summary>
+    /// Gets the Rosewood color.
+    /// </summary>
+    public static RGBColor Rosewood => FromArgb(101, 0, 11);
+    /// <summary>
+    /// Gets the RossoCorsa color.
+    /// </summary>
+    public static RGBColor RossoCorsa => FromArgb(212, 0, 0);
+    /// <summary>
+    /// Gets the RosyBrown color.
+    /// </summary>
+    public static RGBColor RosyBrown => FromArgb(188, 143, 143);
+    /// <summary>
+    /// Gets the RoyalAzure color.
+    /// </summary>
+    public static RGBColor RoyalAzure => FromArgb(0, 56, 168);
+    /// <summary>
+    /// Gets the RoyalBlue color.
+    /// </summary>
+    public static RGBColor RoyalBlue => FromArgb(0, 35, 102);
+    /// <summary>
+    /// Gets the RoyalFuchsia color.
+    /// </summary>
+    public static RGBColor RoyalFuchsia => FromArgb(202, 44, 146);
+    /// <summary>
+    /// Gets the RoyalPurple color.
+    /// </summary>
+    public static RGBColor RoyalPurple => FromArgb(120, 81, 169);
+    /// <summary>
+    /// Gets the RoyalYellow color.
+    /// </summary>
+    public static RGBColor RoyalYellow => FromArgb(250, 218, 94);
+    /// <summary>
+    /// Gets the Ruber color.
+    /// </summary>
+    public static RGBColor Ruber => FromArgb(206, 70, 118);
+    /// <summary>
+    /// Gets the RubineRed color.
+    /// </summary>
+    public static RGBColor RubineRed => FromArgb(209, 0, 86);
+    /// <summary>
+    /// Gets the Ruby color.
+    /// </summary>
+    public static RGBColor Ruby => FromArgb(224, 17, 95);
+    /// <summary>
+    /// Gets the RubyRed color.
+    /// </summary>
+    public static RGBColor RubyRed => FromArgb(155, 17, 30);
+    /// <summary>
+    /// Gets the Ruddy color.
+    /// </summary>
+    public static RGBColor Ruddy => FromArgb(255, 0, 40);
+    /// <summary>
+    /// Gets the RuddyBrown color.
+    /// </summary>
+    public static RGBColor RuddyBrown => FromArgb(187, 101, 40);
+    /// <summary>
+    /// Gets the RuddyPink color.
+    /// </summary>
+    public static RGBColor RuddyPink => FromArgb(225, 142, 150);
+    /// <summary>
+    /// Gets the Rufous color.
+    /// </summary>
+    public static RGBColor Rufous => FromArgb(168, 28, 7);
+    /// <summary>
+    /// Gets the Russet color.
+    /// </summary>
+    public static RGBColor Russet => FromArgb(128, 70, 27);
+    /// <summary>
+    /// Gets the RussianGreen color.
+    /// </summary>
+    public static RGBColor RussianGreen => FromArgb(103, 146, 103);
+    /// <summary>
+    /// Gets the RussianViolet color.
+    /// </summary>
+    public static RGBColor RussianViolet => FromArgb(50, 23, 77);
+    /// <summary>
+    /// Gets the Rust color.
+    /// </summary>
+    public static RGBColor Rust => FromArgb(183, 65, 14);
+    /// <summary>
+    /// Gets the RustyRed color.
+    /// </summary>
+    public static RGBColor RustyRed => FromArgb(218, 44, 67);
+    /// <summary>
+    /// Gets the SacramentoStateGreen color.
+    /// </summary>
+    public static RGBColor SacramentoStateGreen => FromArgb(0, 86, 63);
+    /// <summary>
+    /// Gets the SaddleBrown color.
+    /// </summary>
+    public static RGBColor SaddleBrown => FromArgb(139, 69, 19);
+    /// <summary>
+    /// Gets the SafetyOrange color.
+    /// </summary>
+    public static RGBColor SafetyOrange => FromArgb(255, 103, 0);
+    /// <summary>
+    /// Gets the SafetyYellow color.
+    /// </summary>
+    public static RGBColor SafetyYellow => FromArgb(238, 210, 2);
+    /// <summary>
+    /// Gets the Saffron color.
+    /// </summary>
+    public static RGBColor Saffron => FromArgb(244, 196, 48);
+    /// <summary>
+    /// Gets the Sage color.
+    /// </summary>
+    public static RGBColor Sage => FromArgb(188, 184, 138);
+    /// <summary>
+    /// Gets the StPatricksBlue color.
+    /// </summary>
+    public static RGBColor StPatricksBlue => FromArgb(35, 41, 122);
+    /// <summary>
+    /// Gets the Salmon color.
+    /// </summary>
+    public static RGBColor Salmon => FromArgb(250, 128, 114);
+    /// <summary>
+    /// Gets the SalmonPink color.
+    /// </summary>
+    public static RGBColor SalmonPink => FromArgb(255, 145, 164);
+    /// <summary>
+    /// Gets the Sand color.
+    /// </summary>
+    public static RGBColor Sand => FromArgb(194, 178, 128);
+    /// <summary>
+    /// Gets the SandDune color.
+    /// </summary>
+    public static RGBColor SandDune => FromArgb(150, 113, 23);
+    /// <summary>
+    /// Gets the Sandstorm color.
+    /// </summary>
+    public static RGBColor Sandstorm => FromArgb(236, 213, 64);
+    /// <summary>
+    /// Gets the SandyBrown color.
+    /// </summary>
+    public static RGBColor SandyBrown => FromArgb(244, 164, 96);
+    /// <summary>
+    /// Gets the SandyTan color.
+    /// </summary>
+    public static RGBColor SandyTan => FromArgb(253, 217, 181);
+    /// <summary>
+    /// Gets the SandyTaupe color.
+    /// </summary>
+    public static RGBColor SandyTaupe => FromArgb(150, 113, 23);
+    /// <summary>
+    /// Gets the Sangria color.
+    /// </summary>
+    public static RGBColor Sangria => FromArgb(146, 0, 10);
+    /// <summary>
+    /// Gets the SapGreen color.
+    /// </summary>
+    public static RGBColor SapGreen => FromArgb(80, 125, 42);
+    /// <summary>
+    /// Gets the Sapphire color.
+    /// </summary>
+    public static RGBColor Sapphire => FromArgb(15, 82, 186);
+    /// <summary>
+    /// Gets the SapphireBlue color.
+    /// </summary>
+    public static RGBColor SapphireBlue => FromArgb(0, 103, 165);
+    /// <summary>
+    /// Gets the SatinSheenGold color.
+    /// </summary>
+    public static RGBColor SatinSheenGold => FromArgb(203, 161, 53);
+    /// <summary>
+    /// Gets the Scarlet color.
+    /// </summary>
+    public static RGBColor Scarlet => FromArgb(255, 36, 0);
+    /// <summary>
+    /// Gets the SchaussPink color.
+    /// </summary>
+    public static RGBColor SchaussPink => FromArgb(255, 145, 175);
+    /// <summary>
+    /// Gets the SchoolBusYellow color.
+    /// </summary>
+    public static RGBColor SchoolBusYellow => FromArgb(255, 216, 0);
+    /// <summary>
+    /// Gets the ScreaminGreen color.
+    /// </summary>
+    public static RGBColor ScreaminGreen => FromArgb(118, 255, 122);
+    /// <summary>
+    /// Gets the SeaBlue color.
+    /// </summary>
+    public static RGBColor SeaBlue => FromArgb(0, 105, 148);
+    /// <summary>
+    /// Gets the SeaGreen color.
+    /// </summary>
+    public static RGBColor SeaGreen => FromArgb(46, 139, 87);
+    /// <summary>
+    /// Gets the SealBrown color.
+    /// </summary>
+    public static RGBColor SealBrown => FromArgb(50, 20, 20);
+    /// <summary>
+    /// Gets the Seashell color.
+    /// </summary>
+    public static RGBColor Seashell => FromArgb(255, 245, 238);
+    /// <summary>
+    /// Gets the SelectiveYellow color.
+    /// </summary>
+    public static RGBColor SelectiveYellow => FromArgb(255, 186, 0);
+    /// <summary>
+    /// Gets the Sepia color.
+    /// </summary>
+    public static RGBColor Sepia => FromArgb(112, 66, 20);
+    /// <summary>
+    /// Gets the Shadow color.
+    /// </summary>
+    public static RGBColor Shadow => FromArgb(138, 121, 93);
+    /// <summary>
+    /// Gets the ShadowBlue color.
+    /// </summary>
+    public static RGBColor ShadowBlue => FromArgb(119, 139, 165);
+    /// <summary>
+    /// Gets the Shampoo color.
+    /// </summary>
+    public static RGBColor Shampoo => FromArgb(255, 207, 241);
+    /// <summary>
+    /// Gets the ShamrockGreen color.
+    /// </summary>
+    public static RGBColor ShamrockGreen => FromArgb(0, 158, 96);
+    /// <summary>
+    /// Gets the SheenGreen color.
+    /// </summary>
+    public static RGBColor SheenGreen => FromArgb(143, 212, 0);
+    /// <summary>
+    /// Gets the ShimmeringBlush color.
+    /// </summary>
+    public static RGBColor ShimmeringBlush => FromArgb(217, 134, 149);
+    /// <summary>
+    /// Gets the ShinyShamrock color.
+    /// </summary>
+    public static RGBColor ShinyShamrock => FromArgb(95, 167, 120);
+    /// <summary>
+    /// Gets the ShockingPink color.
+    /// </summary>
+    public static RGBColor ShockingPink => FromArgb(252, 15, 192);
+    /// <summary>
+    /// Gets the Sienna color.
+    /// </summary>
+    public static RGBColor Sienna => FromArgb(136, 45, 23);
+    /// <summary>
+    /// Gets the Silver color.
+    /// </summary>
+    public static RGBColor Silver => FromArgb(192, 192, 192);
+    /// <summary>
+    /// Gets the SilverChalice color.
+    /// </summary>
+    public static RGBColor SilverChalice => FromArgb(172, 172, 172);
+    /// <summary>
+    /// Gets the SilverLakeBlue color.
+    /// </summary>
+    public static RGBColor SilverLakeBlue => FromArgb(93, 137, 186);
+    /// <summary>
+    /// Gets the SilverPink color.
+    /// </summary>
+    public static RGBColor SilverPink => FromArgb(196, 174, 173);
+    /// <summary>
+    /// Gets the SilverSand color.
+    /// </summary>
+    public static RGBColor SilverSand => FromArgb(191, 193, 194);
+    /// <summary>
+    /// Gets the Sinopia color.
+    /// </summary>
+    public static RGBColor Sinopia => FromArgb(203, 65, 11);
+    /// <summary>
+    /// Gets the SizzlingRed color.
+    /// </summary>
+    public static RGBColor SizzlingRed => FromArgb(255, 56, 85);
+    /// <summary>
+    /// Gets the SizzlingSunrise color.
+    /// </summary>
+    public static RGBColor SizzlingSunrise => FromArgb(255, 219, 0);
+    /// <summary>
+    /// Gets the Skobeloff color.
+    /// </summary>
+    public static RGBColor Skobeloff => FromArgb(0, 116, 116);
+    /// <summary>
+    /// Gets the SkyBlue color.
+    /// </summary>
+    public static RGBColor SkyBlue => FromArgb(135, 206, 235);
+    /// <summary>
+    /// Gets the SkyMagenta color.
+    /// </summary>
+    public static RGBColor SkyMagenta => FromArgb(207, 113, 175);
+    /// <summary>
+    /// Gets the SlateBlue color.
+    /// </summary>
+    public static RGBColor SlateBlue => FromArgb(106, 90, 205);
+    /// <summary>
+    /// Gets the SlateGray color.
+    /// </summary>
+    public static RGBColor SlateGray => FromArgb(112, 128, 144);
+    /// <summary>
+    /// Gets the Smalt color.
+    /// </summary>
+    public static RGBColor Smalt => FromArgb(0, 51, 153);
+    /// <summary>
+    /// Gets the SmashedPumpkin color.
+    /// </summary>
+    public static RGBColor SmashedPumpkin => FromArgb(255, 109, 58);
+    /// <summary>
+    /// Gets the Smitten color.
+    /// </summary>
+    public static RGBColor Smitten => FromArgb(200, 65, 134);
+    /// <summary>
+    /// Gets the Smoke color.
+    /// </summary>
+    public static RGBColor Smoke => FromArgb(115, 130, 118);
+    /// <summary>
+    /// Gets the SmokeyTopaz color.
+    /// </summary>
+    public static RGBColor SmokeyTopaz => FromArgb(147, 61, 65);
+    /// <summary>
+    /// Gets the Snow color.
+    /// </summary>
+    public static RGBColor Snow => FromArgb(255, 250, 250);
+    /// <summary>
+    /// Gets the Soap color.
+    /// </summary>
+    public static RGBColor Soap => FromArgb(206, 200, 239);
+    /// <summary>
+    /// Gets the SolidPink color.
+    /// </summary>
+    public static RGBColor SolidPink => FromArgb(137, 56, 67);
+    /// <summary>
+    /// Gets the SonicSilver color.
+    /// </summary>
+    public static RGBColor SonicSilver => FromArgb(117, 117, 117);
+    /// <summary>
+    /// Gets the SpartanCrimson color.
+    /// </summary>
+    public static RGBColor SpartanCrimson => FromArgb(158, 19, 22);
+    /// <summary>
+    /// Gets the SpaceCadet color.
+    /// </summary>
+    public static RGBColor SpaceCadet => FromArgb(29, 41, 81);
+    /// <summary>
+    /// Gets the SpanishBistre color.
+    /// </summary>
+    public static RGBColor SpanishBistre => FromArgb(128, 117, 50);
+    /// <summary>
+    /// Gets the SpanishBlue color.
+    /// </summary>
+    public static RGBColor SpanishBlue => FromArgb(0, 112, 184);
+    /// <summary>
+    /// Gets the SpanishCarmine color.
+    /// </summary>
+    public static RGBColor SpanishCarmine => FromArgb(209, 0, 71);
+    /// <summary>
+    /// Gets the SpanishGray color.
+    /// </summary>
+    public static RGBColor SpanishGray => FromArgb(152, 152, 152);
+    /// <summary>
+    /// Gets the SpanishGreen color.
+    /// </summary>
+    public static RGBColor SpanishGreen => FromArgb(0, 145, 80);
+    /// <summary>
+    /// Gets the SpanishOrange color.
+    /// </summary>
+    public static RGBColor SpanishOrange => FromArgb(232, 97, 0);
+    /// <summary>
+    /// Gets the SpanishPink color.
+    /// </summary>
+    public static RGBColor SpanishPink => FromArgb(247, 191, 190);
+    /// <summary>
+    /// Gets the SpanishRed color.
+    /// </summary>
+    public static RGBColor SpanishRed => FromArgb(230, 0, 38);
+    /// <summary>
+    /// Gets the SpanishSkyBlue color.
+    /// </summary>
+    public static RGBColor SpanishSkyBlue => FromArgb(0, 255, 255);
+    /// <summary>
+    /// Gets the SpanishViolet color.
+    /// </summary>
+    public static RGBColor SpanishViolet => FromArgb(76, 40, 130);
+    /// <summary>
+    /// Gets the SpanishViridian color.
+    /// </summary>
+    public static RGBColor SpanishViridian => FromArgb(0, 127, 92);
+    /// <summary>
+    /// Gets the SpectralBlue color.
+    /// </summary>
+    public static RGBColor SpectralBlue => FromArgb(46, 88, 148);
+    /// <summary>
+    /// Gets the SpectralGreen color.
+    /// </summary>
+    public static RGBColor SpectralGreen => FromArgb(0, 158, 96);
+    /// <summary>
+    /// Gets the SpectralRed color.
+    /// </summary>
+    public static RGBColor SpectralRed => FromArgb(191, 0, 38);
+    /// <summary>
+    /// Gets the Spice color.
+    /// </summary>
+    public static RGBColor Spice => FromArgb(106, 68, 46);
+    /// <summary>
+    /// Gets the SpicyMix color.
+    /// </summary>
+    public static RGBColor SpicyMix => FromArgb(139, 95, 77);
+    /// <summary>
+    /// Gets the SpiroDiscoBall color.
+    /// </summary>
+    public static RGBColor SpiroDiscoBall => FromArgb(15, 192, 252);
+    /// <summary>
+    /// Gets the SpringBud color.
+    /// </summary>
+    public static RGBColor SpringBud => FromArgb(167, 252, 0);
+    /// <summary>
+    /// Gets the SpringFrost color.
+    /// </summary>
+    public static RGBColor SpringFrost => FromArgb(135, 255, 42);
+    /// <summary>
+    /// Gets the SpringGreen color.
+    /// </summary>
+    public static RGBColor SpringGreen => FromArgb(0, 255, 127);
+    /// <summary>
+    /// Gets the StarCommandBlue color.
+    /// </summary>
+    public static RGBColor StarCommandBlue => FromArgb(0, 123, 184);
+    /// <summary>
+    /// Gets the SteelBlue color.
+    /// </summary>
+    public static RGBColor SteelBlue => FromArgb(70, 130, 180);
+    /// <summary>
+    /// Gets the SteelPink color.
+    /// </summary>
+    public static RGBColor SteelPink => FromArgb(204, 51, 204);
+    /// <summary>
+    /// Gets the SteelTeal color.
+    /// </summary>
+    public static RGBColor SteelTeal => FromArgb(95, 138, 139);
+    /// <summary>
+    /// Gets the StilDeGrainYellow color.
+    /// </summary>
+    public static RGBColor StilDeGrainYellow => FromArgb(250, 218, 94);
+    /// <summary>
+    /// Gets the Stizza color.
+    /// </summary>
+    public static RGBColor Stizza => FromArgb(153, 0, 0);
+    /// <summary>
+    /// Gets the Stormcloud color.
+    /// </summary>
+    public static RGBColor Stormcloud => FromArgb(79, 102, 106);
+    /// <summary>
+    /// Gets the Straw color.
+    /// </summary>
+    public static RGBColor Straw => FromArgb(228, 217, 111);
+    /// <summary>
+    /// Gets the Strawberry color.
+    /// </summary>
+    public static RGBColor Strawberry => FromArgb(252, 90, 141);
+    /// <summary>
+    /// Gets the SugarPlum color.
+    /// </summary>
+    public static RGBColor SugarPlum => FromArgb(145, 78, 117);
+    /// <summary>
+    /// Gets the SunburntCyclops color.
+    /// </summary>
+    public static RGBColor SunburntCyclops => FromArgb(255, 64, 76);
+    /// <summary>
+    /// Gets the Sunglow color.
+    /// </summary>
+    public static RGBColor Sunglow => FromArgb(255, 204, 51);
+    /// <summary>
+    /// Gets the Sunny color.
+    /// </summary>
+    public static RGBColor Sunny => FromArgb(242, 242, 122);
+    /// <summary>
+    /// Gets the Sunray color.
+    /// </summary>
+    public static RGBColor Sunray => FromArgb(227, 171, 87);
+    /// <summary>
+    /// Gets the Sunset color.
+    /// </summary>
+    public static RGBColor Sunset => FromArgb(250, 214, 165);
+    /// <summary>
+    /// Gets the SunsetOrange color.
+    /// </summary>
+    public static RGBColor SunsetOrange => FromArgb(253, 94, 83);
+    /// <summary>
+    /// Gets the SuperPink color.
+    /// </summary>
+    public static RGBColor SuperPink => FromArgb(207, 107, 169);
+    /// <summary>
+    /// Gets the SweetBrown color.
+    /// </summary>
+    public static RGBColor SweetBrown => FromArgb(168, 55, 49);
+    /// <summary>
+    /// Gets the Tan color.
+    /// </summary>
+    public static RGBColor Tan => FromArgb(210, 180, 140);
+    /// <summary>
+    /// Gets the Tangelo color.
+    /// </summary>
+    public static RGBColor Tangelo => FromArgb(249, 77, 0);
+    /// <summary>
+    /// Gets the Tangerine color.
+    /// </summary>
+    public static RGBColor Tangerine => FromArgb(242, 133, 0);
+    /// <summary>
+    /// Gets the TangerineYellow color.
+    /// </summary>
+    public static RGBColor TangerineYellow => FromArgb(255, 204, 0);
+    /// <summary>
+    /// Gets the TangoPink color.
+    /// </summary>
+    public static RGBColor TangoPink => FromArgb(228, 113, 122);
+    /// <summary>
+    /// Gets the TartOrange color.
+    /// </summary>
+    public static RGBColor TartOrange => FromArgb(251, 77, 70);
+    /// <summary>
+    /// Gets the Taupe color.
+    /// </summary>
+    public static RGBColor Taupe => FromArgb(72, 60, 50);
+    /// <summary>
+    /// Gets the TaupeGray color.
+    /// </summary>
+    public static RGBColor TaupeGray => FromArgb(139, 133, 137);
+    /// <summary>
+    /// Gets the TeaGreen color.
+    /// </summary>
+    public static RGBColor TeaGreen => FromArgb(208, 240, 192);
+    /// <summary>
+    /// Gets the TeaRose color.
+    /// </summary>
+    public static RGBColor TeaRose => FromArgb(244, 194, 194);
+    /// <summary>
+    /// Gets the Teal color.
+    /// </summary>
+    public static RGBColor Teal => FromArgb(0, 128, 128);
+    /// <summary>
+    /// Gets the TealBlue color.
+    /// </summary>
+    public static RGBColor TealBlue => FromArgb(54, 117, 136);
+    /// <summary>
+    /// Gets the TealDeer color.
+    /// </summary>
+    public static RGBColor TealDeer => FromArgb(153, 230, 179);
+    /// <summary>
+    /// Gets the TealGreen color.
+    /// </summary>
+    public static RGBColor TealGreen => FromArgb(0, 130, 127);
+    /// <summary>
+    /// Gets the Telemagenta color.
+    /// </summary>
+    public static RGBColor Telemagenta => FromArgb(207, 52, 118);
+    /// <summary>
+    /// Gets the TerraCotta color.
+    /// </summary>
+    public static RGBColor TerraCotta => FromArgb(226, 114, 91);
+    /// <summary>
+    /// Gets the Thistle color.
+    /// </summary>
+    public static RGBColor Thistle => FromArgb(216, 191, 216);
+    /// <summary>
+    /// Gets the ThulianPink color.
+    /// </summary>
+    public static RGBColor ThulianPink => FromArgb(222, 111, 161);
+    /// <summary>
+    /// Gets the TickleMePink color.
+    /// </summary>
+    public static RGBColor TickleMePink => FromArgb(252, 137, 172);
+    /// <summary>
+    /// Gets the TiffanyBlue color.
+    /// </summary>
+    public static RGBColor TiffanyBlue => FromArgb(10, 186, 181);
+    /// <summary>
+    /// Gets the TigersEye color.
+    /// </summary>
+    public static RGBColor TigersEye => FromArgb(224, 141, 60);
+    /// <summary>
+    /// Gets the Timberwolf color.
+    /// </summary>
+    public static RGBColor Timberwolf => FromArgb(219, 215, 210);
+    /// <summary>
+    /// Gets the TitaniumYellow color.
+    /// </summary>
+    public static RGBColor TitaniumYellow => FromArgb(238, 230, 0);
+    /// <summary>
+    /// Gets the Tomato color.
+    /// </summary>
+    public static RGBColor Tomato => FromArgb(255, 99, 71);
+    /// <summary>
+    /// Gets the Toolbox color.
+    /// </summary>
+    public static RGBColor Toolbox => FromArgb(116, 108, 192);
+    /// <summary>
+    /// Gets the Topaz color.
+    /// </summary>
+    public static RGBColor Topaz => FromArgb(255, 200, 124);
+    /// <summary>
+    /// Gets the TractorRed color.
+    /// </summary>
+    public static RGBColor TractorRed => FromArgb(253, 14, 53);
+    /// <summary>
+    /// Gets the TrolleyGrey color.
+    /// </summary>
+    public static RGBColor TrolleyGrey => FromArgb(128, 128, 128);
+    /// <summary>
+    /// Gets the TropicalRainForest color.
+    /// </summary>
+    public static RGBColor TropicalRainForest => FromArgb(0, 117, 94);
+    /// <summary>
+    /// Gets the TrueBlue color.
+    /// </summary>
+    public static RGBColor TrueBlue => FromArgb(0, 115, 207);
+    /// <summary>
+    /// Gets the TuftsBlue color.
+    /// </summary>
+    public static RGBColor TuftsBlue => FromArgb(65, 125, 193);
+    /// <summary>
+    /// Gets the Tulip color.
+    /// </summary>
+    public static RGBColor Tulip => FromArgb(255, 135, 141);
+    /// <summary>
+    /// Gets the Tumbleweed color.
+    /// </summary>
+    public static RGBColor Tumbleweed => FromArgb(222, 170, 136);
+    /// <summary>
+    /// Gets the TurkishRose color.
+    /// </summary>
+    public static RGBColor TurkishRose => FromArgb(181, 114, 129);
+    /// <summary>
+    /// Gets the Turquoise color.
+    /// </summary>
+    public static RGBColor Turquoise => FromArgb(48, 213, 200);
+    /// <summary>
+    /// Gets the TurquoiseBlue color.
+    /// </summary>
+    public static RGBColor TurquoiseBlue => FromArgb(0, 255, 239);
+    /// <summary>
+    /// Gets the TurquoiseGreen color.
+    /// </summary>
+    public static RGBColor TurquoiseGreen => FromArgb(160, 214, 180);
+    /// <summary>
+    /// Gets the TurquoiseSurf color.
+    /// </summary>
+    public static RGBColor TurquoiseSurf => FromArgb(0, 197, 205);
+    /// <summary>
+    /// Gets the TurtleGreen color.
+    /// </summary>
+    public static RGBColor TurtleGreen => FromArgb(138, 154, 91);
+    /// <summary>
+    /// Gets the Tuscan color.
+    /// </summary>
+    public static RGBColor Tuscan => FromArgb(250, 214, 165);
+    /// <summary>
+    /// Gets the TuscanBrown color.
+    /// </summary>
+    public static RGBColor TuscanBrown => FromArgb(111, 78, 55);
+    /// <summary>
+    /// Gets the TuscanRed color.
+    /// </summary>
+    public static RGBColor TuscanRed => FromArgb(124, 72, 72);
+    /// <summary>
+    /// Gets the TuscanTan color.
+    /// </summary>
+    public static RGBColor TuscanTan => FromArgb(166, 123, 91);
+    /// <summary>
+    /// Gets the Tuscany color.
+    /// </summary>
+    public static RGBColor Tuscany => FromArgb(192, 153, 153);
+    /// <summary>
+    /// Gets the TwilightLavender color.
+    /// </summary>
+    public static RGBColor TwilightLavender => FromArgb(138, 73, 107);
+    /// <summary>
+    /// Gets the TyrianPurple color.
+    /// </summary>
+    public static RGBColor TyrianPurple => FromArgb(102, 2, 60);
+    /// <summary>
+    /// Gets the UAblue color.
+    /// </summary>
+    public static RGBColor UAblue => FromArgb(0, 51, 170);
+    /// <summary>
+    /// Gets the UARed color.
+    /// </summary>
+    public static RGBColor UARed => FromArgb(217, 0, 76);
+    /// <summary>
+    /// Gets the Ube color.
+    /// </summary>
+    public static RGBColor Ube => FromArgb(136, 120, 195);
+    /// <summary>
+    /// Gets the UCLAblue color.
+    /// </summary>
+    public static RGBColor UCLAblue => FromArgb(83, 104, 149);
+    /// <summary>
+    /// Gets the UFOGreen color.
+    /// </summary>
+    public static RGBColor UFOGreen => FromArgb(60, 208, 112);
+    /// <summary>
+    /// Gets the Ultramarine color.
+    /// </summary>
+    public static RGBColor Ultramarine => FromArgb(18, 10, 143);
+    /// <summary>
+    /// Gets the UltramarineBlue color.
+    /// </summary>
+    public static RGBColor UltramarineBlue => FromArgb(65, 102, 245);
+    /// <summary>
+    /// Gets the UltraPink color.
+    /// </summary>
+    public static RGBColor UltraPink => FromArgb(255, 111, 255);
+    /// <summary>
+    /// Gets the UltraRed color.
+    /// </summary>
+    public static RGBColor UltraRed => FromArgb(252, 108, 133);
+    /// <summary>
+    /// Gets the Umber color.
+    /// </summary>
+    public static RGBColor Umber => FromArgb(99, 81, 71);
+    /// <summary>
+    /// Gets the UnbleachedSilk color.
+    /// </summary>
+    public static RGBColor UnbleachedSilk => FromArgb(255, 221, 202);
+    /// <summary>
+    /// Gets the UnitedNationsBlue color.
+    /// </summary>
+    public static RGBColor UnitedNationsBlue => FromArgb(91, 146, 229);
+    /// <summary>
+    /// Gets the UniversityOfCaliforniaGold color.
+    /// </summary>
+    public static RGBColor UniversityOfCaliforniaGold => FromArgb(183, 135, 39);
+    /// <summary>
+    /// Gets the UnmellowYellow color.
+    /// </summary>
+    public static RGBColor UnmellowYellow => FromArgb(255, 255, 102);
+    /// <summary>
+    /// Gets the UPForestGreen color.
+    /// </summary>
+    public static RGBColor UPForestGreen => FromArgb(1, 68, 33);
+    /// <summary>
+    /// Gets the UPMaroon color.
+    /// </summary>
+    public static RGBColor UPMaroon => FromArgb(123, 17, 19);
+    /// <summary>
+    /// Gets the UpsdellRed color.
+    /// </summary>
+    public static RGBColor UpsdellRed => FromArgb(174, 32, 41);
+    /// <summary>
+    /// Gets the Urobilin color.
+    /// </summary>
+    public static RGBColor Urobilin => FromArgb(225, 173, 33);
+    /// <summary>
+    /// Gets the USAFABlue color.
+    /// </summary>
+    public static RGBColor USAFABlue => FromArgb(0, 79, 152);
+    /// <summary>
+    /// Gets the UtahCrimson color.
+    /// </summary>
+    public static RGBColor UtahCrimson => FromArgb(211, 0, 63);
+    /// <summary>
+    /// Gets the Vanilla color.
+    /// </summary>
+    public static RGBColor Vanilla => FromArgb(243, 229, 171);
+    /// <summary>
+    /// Gets the VanillaIce color.
+    /// </summary>
+    public static RGBColor VanillaIce => FromArgb(243, 143, 169);
+    /// <summary>
+    /// Gets the VegasGold color.
+    /// </summary>
+    public static RGBColor VegasGold => FromArgb(197, 179, 88);
+    /// <summary>
+    /// Gets the VenetianRed color.
+    /// </summary>
+    public static RGBColor VenetianRed => FromArgb(200, 8, 21);
+    /// <summary>
+    /// Gets the Verdigris color.
+    /// </summary>
+    public static RGBColor Verdigris => FromArgb(67, 179, 174);
+    /// <summary>
+    /// Gets the Vermilion color.
+    /// </summary>
+    public static RGBColor Vermilion => FromArgb(227, 66, 52);
+    /// <summary>
+    /// Gets the Veronica color.
+    /// </summary>
+    public static RGBColor Veronica => FromArgb(160, 32, 240);
+    /// <summary>
+    /// Gets the VeryLightAzure color.
+    /// </summary>
+    public static RGBColor VeryLightAzure => FromArgb(116, 187, 251);
+    /// <summary>
+    /// Gets the VeryLightBlue color.
+    /// </summary>
+    public static RGBColor VeryLightBlue => FromArgb(102, 102, 255);
+    /// <summary>
+    /// Gets the VeryLightMalachiteGreen color.
+    /// </summary>
+    public static RGBColor VeryLightMalachiteGreen => FromArgb(100, 233, 134);
+    /// <summary>
+    /// Gets the VeryLightTangelo color.
+    /// </summary>
+    public static RGBColor VeryLightTangelo => FromArgb(255, 176, 119);
+    /// <summary>
+    /// Gets the VeryPaleOrange color.
+    /// </summary>
+    public static RGBColor VeryPaleOrange => FromArgb(255, 223, 191);
+    /// <summary>
+    /// Gets the VeryPaleYellow color.
+    /// </summary>
+    public static RGBColor VeryPaleYellow => FromArgb(255, 255, 191);
+    /// <summary>
+    /// Gets the Violet color.
+    /// </summary>
+    public static RGBColor Violet => FromArgb(127, 0, 255);
+    /// <summary>
+    /// Gets the VioletBlue color.
+    /// </summary>
+    public static RGBColor VioletBlue => FromArgb(50, 74, 178);
+    /// <summary>
+    /// Gets the VioletRed color.
+    /// </summary>
+    public static RGBColor VioletRed => FromArgb(247, 83, 148);
+    /// <summary>
+    /// Gets the Viridian color.
+    /// </summary>
+    public static RGBColor Viridian => FromArgb(64, 130, 109);
+    /// <summary>
+    /// Gets the ViridianGreen color.
+    /// </summary>
+    public static RGBColor ViridianGreen => FromArgb(0, 150, 152);
+    /// <summary>
+    /// Gets the VistaBlue color.
+    /// </summary>
+    public static RGBColor VistaBlue => FromArgb(124, 158, 217);
+    /// <summary>
+    /// Gets the VividAuburn color.
+    /// </summary>
+    public static RGBColor VividAuburn => FromArgb(146, 39, 36);
+    /// <summary>
+    /// Gets the VividBurgundy color.
+    /// </summary>
+    public static RGBColor VividBurgundy => FromArgb(159, 29, 53);
+    /// <summary>
+    /// Gets the VividCerise color.
+    /// </summary>
+    public static RGBColor VividCerise => FromArgb(218, 29, 129);
+    /// <summary>
+    /// Gets the VividTangerine color.
+    /// </summary>
+    public static RGBColor VividTangerine => FromArgb(255, 160, 137);
+    /// <summary>
+    /// Gets the VividViolet color.
+    /// </summary>
+    public static RGBColor VividViolet => FromArgb(159, 0, 255);
+    /// <summary>
+    /// Gets the WarmBlack color.
+    /// </summary>
+    public static RGBColor WarmBlack => FromArgb(0, 66, 66);
+    /// <summary>
+    /// Gets the Waterspout color.
+    /// </summary>
+    public static RGBColor Waterspout => FromArgb(164, 244, 249);
+    /// <summary>
+    /// Gets the Wenge color.
+    /// </summary>
+    public static RGBColor Wenge => FromArgb(100, 84, 82);
+    /// <summary>
+    /// Gets the Wheat color.
+    /// </summary>
+    public static RGBColor Wheat => FromArgb(245, 222, 179);
+    /// <summary>
+    /// Gets the White color.
+    /// </summary>
+    public static RGBColor White => FromArgb(255, 255, 255);
+    /// <summary>
+    /// Gets the WhiteSmoke color.
+    /// </summary>
+    public static RGBColor WhiteSmoke => FromArgb(245, 245, 245);
+    /// <summary>
+    /// Gets the WildBlueYonder color.
+    /// </summary>
+    public static RGBColor WildBlueYonder => FromArgb(162, 173, 208);
+    /// <summary>
+    /// Gets the WildStrawberry color.
+    /// </summary>
+    public static RGBColor WildStrawberry => FromArgb(255, 67, 164);
+    /// <summary>
+    /// Gets the WildWatermelon color.
+    /// </summary>
+    public static RGBColor WildWatermelon => FromArgb(252, 108, 133);
+    /// <summary>
+    /// Gets the Wine color.
+    /// </summary>
+    public static RGBColor Wine => FromArgb(114, 47, 55);
+    /// <summary>
+    /// Gets the WinterSky color.
+    /// </summary>
+    public static RGBColor WinterSky => FromArgb(255, 0, 124);
+    /// <summary>
+    /// Gets the WinterWizard color.
+    /// </summary>
+    public static RGBColor WinterWizard => FromArgb(160, 230, 255);
+    /// <summary>
+    /// Gets the Wisteria color.
+    /// </summary>
+    public static RGBColor Wisteria => FromArgb(201, 160, 220);
+    /// <summary>
+    /// Gets the Xanadu color.
+    /// </summary>
+    public static RGBColor Xanadu => FromArgb(115, 134, 120);
+    /// <summary>
+    /// Gets the YaleBlue color.
+    /// </summary>
+    public static RGBColor YaleBlue => FromArgb(15, 77, 146);
+    /// <summary>
+    /// Gets the Yellow color.
+    /// </summary>
+    public static RGBColor Yellow => FromArgb(255, 255, 0);
+    /// <summary>
+    /// Gets the YellowGreen color.
+    /// </summary>
+    public static RGBColor YellowGreen => FromArgb(154, 205, 50);
+    /// <summary>
+    /// Gets the YellowOrange color.
+    /// </summary>
+    public static RGBColor YellowOrange => FromArgb(255, 174, 66);
+    /// <summary>
+    /// Gets the YellowRose color.
+    /// </summary>
+    public static RGBColor YellowRose => FromArgb(255, 240, 0);
+    /// <summary>
+    /// Gets the Zaffre color.
+    /// </summary>
+    public static RGBColor Zaffre => FromArgb(0, 20, 168);
+    /// <summary>
+    /// Gets the ZinnwalditeBrown color.
+    /// </summary>
+    public static RGBColor ZinnwalditeBrown => FromArgb(44, 22, 8);
+    /// <summary>
+    /// Gets the Zomp color.
+    /// </summary>
+    public static RGBColor Zomp => FromArgb(57, 167, 142);
 }


### PR DESCRIPTION
## Summary
- update color definitions to include XML comments for each `RGBColor` property

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6873b99533f8832e94b7dd7fb8f5db25