### PR TITLE
Add XML comments for Quill and FullCalendar

### DIFF
--- a/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendar.cs
@@ -1,70 +1,140 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a FullCalendar instance used to display events.
+/// </summary>
 public class FullCalendar : Element {
+    /// <summary>
+    /// Gets or sets the identifier of the calendar container.
+    /// </summary>
     public string Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets events displayed on the calendar.
+    /// </summary>
     public List<FullCalendarEvent> Events {
         get => Options.Events;
         set => Options.Events = value;
     }
 
+    /// <summary>
+    /// Enables or disables the now indicator.
+    /// </summary>
+    /// <param name="value">Whether the indicator should be displayed.</param>
+    /// <returns>The current <see cref="FullCalendar"/> instance.</returns>
     public FullCalendar NowIndicator(bool value) {
         Options.NowIndicator = value;
         return this;
     }
 
+    /// <summary>
+    /// Toggles navigation links on day/week names.
+    /// </summary>
+    /// <param name="value">Whether navigation links are enabled.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar NavLinks(bool value) {
         Options.NavLinks = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets whether business hours are highlighted.
+    /// </summary>
+    /// <param name="value">If set to <c>true</c>, business hours will be shown.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar BusinessHours(bool value) {
         Options.BusinessHours = value;
         return this;
     }
 
+    /// <summary>
+    /// Defines whether dates can be selected.
+    /// </summary>
+    /// <param name="value">If <c>true</c>, date selection is allowed.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar Selectable(bool value) {
         Options.Selectable = value;
         return this;
     }
 
+    /// <summary>
+    /// Mirrors selection to create an event-like placeholder.
+    /// </summary>
+    /// <param name="value">Whether mirror selection is active.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar SelectMirror(bool value) {
         Options.SelectMirror = value;
         return this;
     }
 
+    /// <summary>
+    /// Determines if button text should use icons.
+    /// </summary>
+    /// <param name="value">If <c>true</c>, icons will be used.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar ButtonIcons(bool value) {
         Options.ButtonIcons = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets whether days should display a "more" link when too many events exist.
+    /// </summary>
+    /// <param name="value">If <c>true</c>, event rows will be collapsed.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar DayMaxEventRows(bool value) {
         Options.DayMaxEventRows = value;
         return this;
     }
 
+    /// <summary>
+    /// Shows or hides week numbers.
+    /// </summary>
+    /// <param name="value">Whether week numbers are displayed.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar WeekNumbers(bool value) {
         Options.WeekNumbers = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the week number calculation method.
+    /// </summary>
+    /// <param name="value">The calculation mode.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar WeekNumberCalculation(string value) {
         Options.WeekNumberCalculation = value;
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables event editing via drag and drop.
+    /// </summary>
+    /// <param name="value">If <c>true</c>, events can be edited.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar Editable(bool value) {
         Options.Editable = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the initial date displayed by the calendar.
+    /// </summary>
+    /// <param name="value">Initial date.</param>
+    /// <returns>The current instance.</returns>
     public FullCalendar InitialDate(DateTime value) {
         Options.InitialDate = value;
         return this;
     }
 
+    /// <summary>
+    /// Gets or sets configuration options for the calendar.
+    /// </summary>
     public FullCalendarOptions Options { get; set; } = new FullCalendarOptions();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FullCalendar"/> class with a random identifier.
+    /// </summary>
     public FullCalendar() {
         // Libraries will be registered via RegisterLibraries method
         Id = GlobalStorage.GenerateRandomId("fullCalendar");
@@ -73,11 +143,18 @@ public class FullCalendar : Element {
     /// <summary>
     /// Registers the required libraries for FullCalendar.
     /// </summary>
+    /// <summary>
+    /// Registers FullCalendar JavaScript libraries within the document.
+    /// </summary>
     protected internal override void RegisterLibraries() {
         Document?.Configuration.Libraries.TryAdd(Libraries.FullCalendar, 0);
         Document?.Configuration.Libraries.TryAdd(Libraries.Popper, 0);
     }
 
+    /// <summary>
+    /// Builds the HTML and script necessary to render the calendar.
+    /// </summary>
+    /// <returns>The HTML string representation.</returns>
     public override string ToString() {
         var jsonOptions = new JsonSerializerOptions {
             WriteIndented = true
@@ -97,29 +174,56 @@ public class FullCalendar : Element {
     }
 
 
+    /// <summary>
+    /// Adds a new event to the calendar with a description.
+    /// </summary>
+    /// <param name="title">Event title.</param>
+    /// <param name="description">Event description.</param>
+    /// <param name="start">Start date.</param>
+    /// <param name="end">Optional end date.</param>
+    /// <returns>The created event.</returns>
     public FullCalendarEvent AddEvent(string title, string description, DateTime start, DateTime? end = null) {
         var eventItem = new FullCalendarEvent(title, description, start, end);
         Events.Add(eventItem);
         return eventItem;
     }
 
+    /// <summary>
+    /// Adds a new single-day event to the calendar.
+    /// </summary>
+    /// <param name="title">Event title.</param>
+    /// <param name="start">Start date.</param>
+    /// <returns>The created event.</returns>
     public FullCalendarEvent AddEvent(string title, DateTime start) {
         var eventItem = new FullCalendarEvent(title, start);
         Events.Add(eventItem);
         return eventItem;
     }
 
+    /// <summary>
+    /// Adds an existing event instance to the calendar.
+    /// </summary>
+    /// <param name="eventItem">Event instance.</param>
+    /// <returns>The added event.</returns>
     public FullCalendarEvent AddEvent(FullCalendarEvent eventItem) {
         Events.Add(eventItem);
         return eventItem;
     }
 
+    /// <summary>
+    /// Adds and returns a toolbar displayed at the top of the calendar.
+    /// </summary>
+    /// <returns>The created toolbar.</returns>
     public FullCalendarToolbar AddHeaderToolbar() {
         var toolbar = new FullCalendarToolbar();
         Options.HeaderToolbar = toolbar;
         return toolbar;
     }
 
+    /// <summary>
+    /// Adds and returns a toolbar displayed at the bottom of the calendar.
+    /// </summary>
+    /// <returns>The created toolbar.</returns>
     public FullCalendarToolbar AddFooterToolbar() {
         var toolbar = new FullCalendarToolbar();
         Options.FooterToolbar = toolbar;

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarEvent.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarEvent.cs
@@ -107,55 +107,110 @@ public class FullCalendarEvent {
     [JsonPropertyName("textColor")]
     public RGBColor TextColorValue { get; set; }
 
+    /// <summary>
+    /// Sets whether the event spans the entire day.
+    /// </summary>
+    /// <param name="value">True when the event is all day.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent AllDay(bool value) {
         AllDayValue = value;
         return this;
     }
+    /// <summary>
+    /// Changes the title of the event.
+    /// </summary>
+    /// <param name="value">New title.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Title(string value) {
         TitleValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the URL associated with the event.
+    /// </summary>
+    /// <param name="value">URL value.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Url(string value) {
         UrlValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Updates the event description.
+    /// </summary>
+    /// <param name="value">Description text.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Description(string value) {
         DescriptionValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the start date for the event.
+    /// </summary>
+    /// <param name="value">Start time.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Start(DateTime value) {
         StartValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the end date for the event.
+    /// </summary>
+    /// <param name="value">End time.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent End(DateTime? value) {
         EndValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the primary color for the event.
+    /// </summary>
+    /// <param name="value">The color.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Color(RGBColor value) {
         ColorValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the background color of the event.
+    /// </summary>
+    /// <param name="value">Background color.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent BackgroundColor(RGBColor value) {
         BackgroundColorValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the border color of the event.
+    /// </summary>
+    /// <param name="value">Border color.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent BorderColor(RGBColor value) {
         BorderColorValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the text color of the event.
+    /// </summary>
+    /// <param name="value">Text color.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent TextColor(RGBColor value) {
         TextColorValue = value;
         return this;
     }
 
+    /// <summary>
+    /// Specifies whether the event is interactive.
+    /// </summary>
+    /// <param name="value">True when interactive.</param>
+    /// <returns>The current event instance.</returns>
     public FullCalendarEvent Interactive(bool value) {
         InteractiveValue = value;
         return this;

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarEventTimeFormat.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarEventTimeFormat.cs
@@ -9,22 +9,40 @@ namespace HtmlForgeX;
 public class FullCalendarEventTimeFormat {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("hour")]
+    /// <summary>
+    /// The hour format used when displaying event times.
+    /// </summary>
     public string Hour { get; set; } = "2-digit";
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("minute")]
+    /// <summary>
+    /// The minute format.
+    /// </summary>
     public string Minute { get; set; } = "2-digit";
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("second")]
+    /// <summary>
+    /// Optional seconds format.
+    /// </summary>
     public string Second { get; set; }
 
     [JsonPropertyName("omitZeroMinute")]
+    /// <summary>
+    /// Gets or sets a value indicating whether minutes should be omitted when zero.
+    /// </summary>
     public bool OmitZeroMinute { get; set; } = false;
 
     [JsonPropertyName("hour12")]
+    /// <summary>
+    /// Gets or sets whether to use 12-hour time.
+    /// </summary>
     public bool Hour12 { get; set; } = false;
 
     [JsonPropertyName("meridiem")]
+    /// <summary>
+    /// Gets or sets whether to display AM/PM designations.
+    /// </summary>
     public bool Meridiem { get; set; } = false;
 }

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
@@ -7,22 +7,29 @@ namespace HtmlForgeX;
 /// Converts <see cref="DateTime"/> values to ISO-8601 date strings.
 /// </summary>
 public class Iso8601DateConverter : JsonConverter<DateTime> {
+    /// <inheritdoc />
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         return DateTime.Parse(reader.GetString());
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString("yyyy-MM-dd")); // "yyyy-MM-dd" format string represents an ISO 8601 date string
     }
 }
 
+/// <summary>
+/// Converts enum values using their <see cref="DescriptionAttribute"/> when serializing.
+/// </summary>
 public class DescriptionEnumConverter<T> : JsonConverter<T> where T : Enum {
+    /// <inheritdoc />
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var enumString = reader.GetString();
         return ((T[])Enum.GetValues(typeof(T)))
             .First(enumValue => GetEnumDescription(enumValue) == enumString);
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
         writer.WriteStringValue(GetEnumDescription(value));
     }
@@ -36,7 +43,11 @@ public class DescriptionEnumConverter<T> : JsonConverter<T> where T : Enum {
     }
 }
 
+/// <summary>
+/// Handles serialization of <see cref="Dictionary{FullCalendarViewOption, FullCalendarView}"/> using description names.
+/// </summary>
 public class ViewOptionDictionaryConverter : JsonConverter<Dictionary<FullCalendarViewOption, FullCalendarView>> {
+    /// <inheritdoc />
     public override Dictionary<FullCalendarViewOption, FullCalendarView> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = JsonSerializer.Deserialize<Dictionary<string, FullCalendarView>>(ref reader, options);
         var result = new Dictionary<FullCalendarViewOption, FullCalendarView>();
@@ -50,6 +61,7 @@ public class ViewOptionDictionaryConverter : JsonConverter<Dictionary<FullCalend
         return result;
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, Dictionary<FullCalendarViewOption, FullCalendarView> value, JsonSerializerOptions options) {
         var newDict = value.ToDictionary(
             kvp => GetEnumDescription(kvp.Key),
@@ -68,11 +80,16 @@ public class ViewOptionDictionaryConverter : JsonConverter<Dictionary<FullCalend
     }
 }
 
+/// <summary>
+/// Serializes <see cref="FullCalendarToolbar"/> instances to JSON.
+/// </summary>
 public class FullCalendarToolbarConverter : JsonConverter<FullCalendarToolbar> {
+    /// <inheritdoc />
     public override FullCalendarToolbar Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         throw new NotImplementedException();
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, FullCalendarToolbar value, JsonSerializerOptions options) {
         writer.WriteStartObject();
         writer.WriteString("left", string.Join(",", value.LeftOptions.Select(o => GetEnumDescription(o))));
@@ -90,21 +107,31 @@ public class FullCalendarToolbarConverter : JsonConverter<FullCalendarToolbar> {
     }
 }
 
+/// <summary>
+/// Writes <see cref="RGBColor"/> values as hexadecimal strings.
+/// </summary>
 public class RGBColorConverter : JsonConverter<RGBColor> {
+    /// <inheritdoc />
     public override RGBColor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         throw new NotImplementedException();
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, RGBColor value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToHex());
     }
 }
 
+/// <summary>
+/// Allows embedding of raw JavaScript functions within JSON options.
+/// </summary>
 public class JavaScriptFunctionConverter : JsonConverter<string> {
+    /// <inheritdoc />
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         return reader.GetString() ?? string.Empty;
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) {
         writer.WriteRawValue(value, skipInputValidation: true);
     }

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarOptions.cs
@@ -7,42 +7,92 @@ public class FullCalendarOptions {
     [JsonConverter(typeof(FullCalendarToolbarConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("headerToolbar")]
-    /// <summary>Toolbar displayed at the top.</summary>
+    /// <summary>
+    /// Gets or sets the toolbar displayed at the top of the calendar.
+    /// </summary>
     public FullCalendarToolbar HeaderToolbar { get; set; }
 
     [JsonConverter(typeof(FullCalendarToolbarConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("footerToolbar")]
+    /// <summary>
+    /// Gets or sets the toolbar displayed at the bottom of the calendar.
+    /// </summary>
     public FullCalendarToolbar FooterToolbar { get; set; }
 
     [JsonConverter(typeof(Iso8601DateConverter))]
     [JsonPropertyName("initialDate")]
+    /// <summary>
+    /// Gets or sets the initial date the calendar will display.
+    /// </summary>
     public DateTime InitialDate { get; set; } = DateTime.Now;
 
-    [JsonPropertyName("nowIndicator")] public bool NowIndicator { get; set; }
+    [JsonPropertyName("nowIndicator")]
+    /// <summary>
+    /// Gets or sets a value indicating whether the current time indicator is displayed.
+    /// </summary>
+    public bool NowIndicator { get; set; }
 
-    [JsonPropertyName("navLinks")] public bool NavLinks { get; set; }
+    [JsonPropertyName("navLinks")]
+    /// <summary>
+    /// Gets or sets a value indicating whether day and week names act as navigation links.
+    /// </summary>
+    public bool NavLinks { get; set; }
 
-    [JsonPropertyName("businessHours")] public bool BusinessHours { get; set; }
+    [JsonPropertyName("businessHours")]
+    /// <summary>
+    /// Gets or sets a value indicating whether business hours are highlighted.
+    /// </summary>
+    public bool BusinessHours { get; set; }
 
-    [JsonPropertyName("editable")] public bool Editable { get; set; }
+    [JsonPropertyName("editable")]
+    /// <summary>
+    /// Gets or sets a value indicating whether events can be modified by the user.
+    /// </summary>
+    public bool Editable { get; set; }
 
-    [JsonPropertyName("dayMaxEventRows")] public bool DayMaxEventRows { get; set; }
+    [JsonPropertyName("dayMaxEventRows")]
+    /// <summary>
+    /// Gets or sets a value indicating whether to limit events per day and show a "more" link.
+    /// </summary>
+    public bool DayMaxEventRows { get; set; }
 
-    [JsonPropertyName("weekNumbers")] public bool WeekNumbers { get; set; }
+    [JsonPropertyName("weekNumbers")]
+    /// <summary>
+    /// Gets or sets a value indicating whether week numbers are displayed.
+    /// </summary>
+    public bool WeekNumbers { get; set; }
 
     [JsonPropertyName("weekNumberCalculation")]
+    /// <summary>
+    /// Gets or sets the method used to calculate week numbers.
+    /// </summary>
     public string WeekNumberCalculation { get; set; } = "ISO";
 
-    [JsonPropertyName("selectable")] public bool Selectable { get; set; }
+    [JsonPropertyName("selectable")]
+    /// <summary>
+    /// Gets or sets a value indicating whether date range selection is enabled.
+    /// </summary>
+    public bool Selectable { get; set; }
 
-    [JsonPropertyName("selectMirror")] public bool SelectMirror { get; set; }
+    [JsonPropertyName("selectMirror")]
+    /// <summary>
+    /// Gets or sets a value indicating whether a placeholder event is shown when selecting dates.
+    /// </summary>
+    public bool SelectMirror { get; set; }
 
-    [JsonPropertyName("buttonIcons")] public bool ButtonIcons { get; set; }
+    [JsonPropertyName("buttonIcons")]
+    /// <summary>
+    /// Gets or sets a value indicating whether toolbar buttons use icons.
+    /// </summary>
+    public bool ButtonIcons { get; set; }
 
     [JsonConverter(typeof(ViewOptionDictionaryConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("views")]
+    /// <summary>
+    /// Gets or sets configuration for custom calendar views.
+    /// </summary>
     public Dictionary<FullCalendarViewOption, FullCalendarView> Views { get; set; } = new Dictionary<FullCalendarViewOption, FullCalendarView> {
         [FullCalendarViewOption.ListWeek] = new FullCalendarView { ButtonText = "list week" },
         [FullCalendarViewOption.ListMonth] = new FullCalendarView { ButtonText = "list month" },
@@ -51,16 +101,28 @@ public class FullCalendarOptions {
     };
 
     [JsonPropertyName("events")]
+    /// <summary>
+    /// Gets or sets the collection of calendar events.
+    /// </summary>
     public List<FullCalendarEvent> Events { get; set; } = new List<FullCalendarEvent>();
 
     [JsonPropertyName("eventTimeFormat")]
+    /// <summary>
+    /// Gets or sets the time formatting options for event rendering.
+    /// </summary>
     public FullCalendarEventTimeFormat EventTimeFormat { get; set; } = new FullCalendarEventTimeFormat();
 
     [JsonPropertyName("slotLabelFormat")]
+    /// <summary>
+    /// Gets or sets the format used for slot labels.
+    /// </summary>
     public FullCalendarEventTimeFormat TimeFormat { get; set; } = new FullCalendarEventTimeFormat();
 
     [JsonConverter(typeof(JavaScriptFunctionConverter))]
     [JsonPropertyName("eventDidMount")]
+    /// <summary>
+    /// Gets or sets JavaScript executed when an event element is added to the DOM.
+    /// </summary>
     public string EventDidMount { get; set; } = @"
         function (info) {
             var tooltip = new Tooltip(info.el, {
@@ -74,6 +136,9 @@ public class FullCalendarOptions {
 
     [JsonConverter(typeof(JavaScriptFunctionConverter))]
     [JsonPropertyName("eventClick")]
+    /// <summary>
+    /// Gets or sets JavaScript executed when an event is clicked.
+    /// </summary>
     public string EventClick { get; set; } = @"
         function (info) {
             var eventObj = info.event;

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbar.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbar.cs
@@ -10,35 +10,55 @@ public class FullCalendarToolbar {
     /// <summary>Options on the left side.</summary>
     public List<FullCalendarToolbarOption> LeftOptions { get; set; } = new List<FullCalendarToolbarOption>();
     [JsonPropertyName("center")]
+    /// <summary>Options displayed in the center.</summary>
     public List<FullCalendarToolbarOption> CenterOptions { get; set; } = new List<FullCalendarToolbarOption>();
     [JsonPropertyName("right")]
+    /// <summary>Options on the right side.</summary>
     public List<FullCalendarToolbarOption> RightOptions { get; set; } = new List<FullCalendarToolbarOption>();
 
+    /// <summary>
+    /// Adds a single option to the left side of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Left(FullCalendarToolbarOption option) {
         LeftOptions.Add(option);
         return this;
     }
 
+    /// <summary>
+    /// Adds a single option to the center of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Center(FullCalendarToolbarOption option) {
         CenterOptions.Add(option);
         return this;
     }
 
+    /// <summary>
+    /// Adds a single option to the right side of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Right(FullCalendarToolbarOption option) {
         RightOptions.Add(option);
         return this;
     }
 
+    /// <summary>
+    /// Adds multiple options to the left side of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Left(params FullCalendarToolbarOption[] options) {
         LeftOptions.AddRange(options);
         return this;
     }
 
+    /// <summary>
+    /// Adds multiple options to the center of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Center(params FullCalendarToolbarOption[] options) {
         CenterOptions.AddRange(options);
         return this;
     }
 
+    /// <summary>
+    /// Adds multiple options to the right side of the toolbar.
+    /// </summary>
     public FullCalendarToolbar Right(params FullCalendarToolbarOption[] options) {
         RightOptions.AddRange(options);
         return this;

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
@@ -26,5 +26,8 @@ public enum FullCalendarViewOption {
 
 public class FullCalendarView {
     [JsonPropertyName("buttonText")]
+    /// <summary>
+    /// Gets or sets the text shown on the corresponding toolbar button.
+    /// </summary>
     public string ButtonText { get; set; }
 }

--- a/HtmlForgeX/Containers/Quill/QuillEditor.cs
+++ b/HtmlForgeX/Containers/Quill/QuillEditor.cs
@@ -3,21 +3,43 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a Quill rich text editor instance.
+/// </summary>
 public class QuillEditor : Element {
+    /// <summary>
+    /// Gets or sets the id assigned to the editor container.
+    /// </summary>
     public string Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the height of the editor area.
+    /// </summary>
     public string Height { get; set; } = "200px";
 
+    /// <summary>
+    /// Gets or sets configuration options for the editor.
+    /// </summary>
     public QuillEditorOptions Options { get; set; } = new QuillEditorOptions();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuillEditor"/> class with a random identifier.
+    /// </summary>
     public QuillEditor() {
         Id = GlobalStorage.GenerateRandomId("quill");
     }
 
+    /// <summary>
+    /// Registers Quill library requirements with the document.
+    /// </summary>
     protected internal override void RegisterLibraries() {
         Document?.Configuration.Libraries.TryAdd(Libraries.Quill, 0);
     }
 
+    /// <summary>
+    /// Returns HTML markup representing the editor and initialization script.
+    /// </summary>
+    /// <returns>The HTML string that renders the editor.</returns>
     public override string ToString() {
         var div = new HtmlTag("div").Id(Id).Style("height", Height);
         var options = new JsonSerializerOptions {

--- a/HtmlForgeX/Containers/Quill/QuillEditorOptions.cs
+++ b/HtmlForgeX/Containers/Quill/QuillEditorOptions.cs
@@ -3,23 +3,41 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Configuration options for a <see cref="QuillEditor"/> instance.
+/// </summary>
 public class QuillEditorOptions {
     [JsonPropertyName("theme")]
+    /// <summary>
+    /// Gets or sets the editor theme.
+    /// </summary>
     public QuillTheme Theme { get; set; } = QuillTheme.Snow;
 
     [JsonPropertyName("readOnly")]
+    /// <summary>
+    /// Gets or sets a value indicating whether the editor is read only.
+    /// </summary>
     public bool ReadOnly { get; set; }
 
     [JsonPropertyName("placeholder")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Gets or sets placeholder text displayed when the editor is empty.
+    /// </summary>
     public string? Placeholder { get; set; }
 
     [JsonPropertyName("modules")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Gets or sets module configuration.
+    /// </summary>
     public QuillModules? Modules { get; set; }
 
     [JsonPropertyName("formats")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonConverter(typeof(EnumListDescriptionConverter<QuillFormat>))]
+    /// <summary>
+    /// Gets or sets the enabled formatting options.
+    /// </summary>
     public List<QuillFormat>? Formats { get; set; }
 }

--- a/HtmlForgeX/Containers/Quill/QuillEnums.cs
+++ b/HtmlForgeX/Containers/Quill/QuillEnums.cs
@@ -3,12 +3,18 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Available themes for the Quill editor.
+/// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<QuillTheme>))]
 public enum QuillTheme {
     [Description("snow")] Snow,
     [Description("bubble")] Bubble
 }
 
+/// <summary>
+/// Supported Quill formatting options used across modules and toolbars.
+/// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<QuillFormat>))]
 public enum QuillFormat {
     [Description("background")] Background,

--- a/HtmlForgeX/Containers/Quill/QuillJsonConverters.cs
+++ b/HtmlForgeX/Containers/Quill/QuillJsonConverters.cs
@@ -5,7 +5,11 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Converts a list of enum values to and from their <see cref="DescriptionAttribute"/> values.
+/// </summary>
 public class EnumListDescriptionConverter<T> : JsonConverter<List<T>> where T : Enum {
+    /// <inheritdoc />
     public override List<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var list = JsonSerializer.Deserialize<List<string>>(ref reader, options) ?? new List<string>();
         var result = new List<T>();
@@ -16,11 +20,17 @@ public class EnumListDescriptionConverter<T> : JsonConverter<List<T>> where T : 
         return result;
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, List<T> value, JsonSerializerOptions options) {
         var list = value.Select(GetDescription).ToList();
         JsonSerializer.Serialize(writer, list, options);
     }
 
+    /// <summary>
+    /// Retrieves the description attribute value for the provided enum item.
+    /// </summary>
+    /// <param name="value">Enum value to retrieve description for.</param>
+    /// <returns>Description string.</returns>
     private static string GetDescription(T value) {
         return value.GetType()
             .GetMember(value.ToString())

--- a/HtmlForgeX/Containers/Quill/QuillModules.cs
+++ b/HtmlForgeX/Containers/Quill/QuillModules.cs
@@ -3,13 +3,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents configuration for Quill modules.
+/// </summary>
 public class QuillModules {
     [JsonPropertyName("clipboard")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Gets or sets clipboard module configuration.
+    /// </summary>
     public object? Clipboard { get; set; }
 
     [JsonPropertyName("toolbar")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonConverter(typeof(EnumListDescriptionConverter<QuillFormat>))]
+    /// <summary>
+    /// Gets or sets a toolbar configuration defined as a list of formats.
+    /// </summary>
     public List<QuillFormat>? Toolbar { get; set; }
 }

--- a/HtmlForgeX/Resources/FullCalendarLibrary.cs
+++ b/HtmlForgeX/Resources/FullCalendarLibrary.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Provides metadata and asset links for the FullCalendar library.
+/// </summary>
 public class FullCalendarLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FullCalendarLibrary"/> class.
+    /// </summary>
     public FullCalendarLibrary() {
         Header = new LibraryLinks {
             JsLink = ["https://cdn.jsdelivr.net/npm/fullcalendar@6.1.13/index.global.min.js"],

--- a/HtmlForgeX/Resources/QuillLibrary.cs
+++ b/HtmlForgeX/Resources/QuillLibrary.cs
@@ -1,5 +1,12 @@
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Library definition providing Quill assets.
+/// </summary>
 public class QuillLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QuillLibrary"/> class.
+    /// </summary>
     public QuillLibrary() {
         Header = new LibraryLinks {
             CssLink = [


### PR DESCRIPTION
## Summary
- document the Quill editor classes and resources
- document FullCalendar classes, enums, and resources
- ensure JSON converter methods have `<inheritdoc />`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6873b9c2f1ec832eb518380c113d7814