### PR TITLE
Add XML docs for enums and FancyTreeNode properties

### DIFF
--- a/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
+++ b/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
@@ -5,17 +5,36 @@ using System.Text;
 namespace HtmlForgeX;
 
 public class BootstrapTable : Table {
+    /// <summary>
+    /// Gets the unique identifier of the table element.
+    /// </summary>
     public string Id;
+
+    /// <summary>
+    /// Gets the collection of styles applied to the table.
+    /// </summary>
     public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BootstrapTable"/> class.
+    /// </summary>
     public BootstrapTable() : base() {
         Id = GlobalStorage.GenerateRandomId("table");
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BootstrapTable"/> class with data.
+    /// </summary>
+    /// <param name="objects">Objects to render.</param>
+    /// <param name="library">Table type library.</param>
     public BootstrapTable(IEnumerable<object> objects, TableType library) : base(objects, library) {
         Id = GlobalStorage.GenerateRandomId("table");
     }
 
+    /// <summary>
+    /// Builds the HTML table markup.
+    /// </summary>
+    /// <returns>The generated HTML.</returns>
     public override string BuildTable() {
         string tableInside = base.BuildTable();
         string classNames = StyleList.BuildTableStyles();
@@ -26,6 +45,11 @@ public class BootstrapTable : Table {
         return tableTag.ToString();
     }
 
+    /// <summary>
+    /// Adds a style to the table.
+    /// </summary>
+    /// <param name="style">Style to apply.</param>
+    /// <returns>The current <see cref="BootstrapTable"/> instance.</returns>
     public BootstrapTable Style(BootStrapTableStyle style) {
         StyleList.Add(style);
         return this;

--- a/HtmlForgeX/Containers/Bootstrap/BootstrapTableStyle.cs
+++ b/HtmlForgeX/Containers/Bootstrap/BootstrapTableStyle.cs
@@ -1,17 +1,52 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Styles that can be applied to a Bootstrap table.
+/// </summary>
 public enum BootStrapTableStyle {
+    /// <summary>
+    /// Wrap the table in a responsive container.
+    /// </summary>
     Responsive,
+    /// <summary>
+    /// Apply alternating row striping.
+    /// </summary>
     Striped,
+    /// <summary>
+    /// Render the table using a dark theme.
+    /// </summary>
     DarkMode,
+    /// <summary>
+    /// Add borders to all table cells.
+    /// </summary>
     Borders,
+    /// <summary>
+    /// Highlight rows on hover.
+    /// </summary>
     Hover,
+    /// <summary>
+    /// Use the small table style.
+    /// </summary>
     Small,
+    /// <summary>
+    /// Use the medium table style.
+    /// </summary>
     Medium,
+    /// <summary>
+    /// Use the large table style.
+    /// </summary>
     Large
 }
 
+/// <summary>
+/// Extension helpers for <see cref="BootStrapTableStyle"/> collections.
+/// </summary>
 public static class BootStrapTableStyleExtensions {
+    /// <summary>
+    /// Converts the style flags to the corresponding CSS class string.
+    /// </summary>
+    /// <param name="styles">Styles to convert.</param>
+    /// <returns>A string with space separated CSS class names.</returns>
     public static string BuildTableStyles(this IEnumerable<BootStrapTableStyle> styles) {
         var classes = new List<string> { "table" };
         foreach (var style in styles) {

--- a/HtmlForgeX/Containers/ChartJs/ChartJs.cs
+++ b/HtmlForgeX/Containers/ChartJs/ChartJs.cs
@@ -11,8 +11,20 @@ public class ChartJs : Element {
     /// Gets or sets the canvas identifier.
     /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chart type.
+    /// </summary>
     public ChartJsType Type { get; set; } = ChartJsType.Bar;
+
+    /// <summary>
+    /// Gets the labels for the dataset.
+    /// </summary>
     public List<string> Labels { get; } = new();
+
+    /// <summary>
+    /// Gets the numeric values for the dataset.
+    /// </summary>
     public List<double> Data { get; } = new();
 
     public ChartJs() {
@@ -23,21 +35,50 @@ public class ChartJs : Element {
         Document?.Configuration.Libraries.TryAdd(Libraries.ChartJs, 0);
     }
 
+    /// <summary>
+    /// Adds a data point to the chart.
+    /// </summary>
+    /// <param name="label">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ChartJs"/> instance.</returns>
     public ChartJs AddData(string label, double value) {
         Labels.Add(label);
         Data.Add(value);
         return this;
     }
 
+    /// <summary>
+    /// Sets the chart type.
+    /// </summary>
+    /// <param name="type">Chart type.</param>
+    /// <returns>The current <see cref="ChartJs"/> instance.</returns>
     public ChartJs SetType(ChartJsType type) {
         Type = type;
         return this;
     }
 
+    /// <summary>
+    /// Shortcut for <see cref="SetType(ChartJsType.Line)"/>.
+    /// </summary>
+    /// <returns>The current <see cref="ChartJs"/> instance.</returns>
     public ChartJs Line() => SetType(ChartJsType.Line);
+
+    /// <summary>
+    /// Shortcut for <see cref="SetType(ChartJsType.Bar)"/>.
+    /// </summary>
+    /// <returns>The current <see cref="ChartJs"/> instance.</returns>
     public ChartJs Bar() => SetType(ChartJsType.Bar);
+
+    /// <summary>
+    /// Shortcut for <see cref="SetType(ChartJsType.Pie)"/>.
+    /// </summary>
+    /// <returns>The current <see cref="ChartJs"/> instance.</returns>
     public ChartJs Pie() => SetType(ChartJsType.Pie);
 
+    /// <summary>
+    /// Generates the HTML required to render the chart.
+    /// </summary>
+    /// <returns>The HTML markup.</returns>
     public override string ToString() {
         var canvas = new HtmlTag("canvas").Id(Id);
         var options = new {

--- a/HtmlForgeX/Containers/ChartJs/ChartJsType.cs
+++ b/HtmlForgeX/Containers/ChartJs/ChartJsType.cs
@@ -9,12 +9,25 @@ namespace HtmlForgeX;
 /// </summary>
 [JsonConverter(typeof(ChartJsTypeConverter))]
 public enum ChartJsType {
+    /// <summary>
+    /// Render a line chart.
+    /// </summary>
     Line,
+    /// <summary>
+    /// Render a bar chart.
+    /// </summary>
     Bar,
+    /// <summary>
+    /// Render a pie chart.
+    /// </summary>
     Pie
 }
 
+/// <summary>
+/// Converts <see cref="ChartJsType"/> values to and from JSON strings.
+/// </summary>
 public class ChartJsTypeConverter : JsonConverter<ChartJsType> {
+    /// <inheritdoc />
     public override ChartJsType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value switch {
@@ -25,6 +38,7 @@ public class ChartJsTypeConverter : JsonConverter<ChartJsType> {
         };
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, ChartJsType value, JsonSerializerOptions options) {
         var stringValue = value switch {
             ChartJsType.Line => "line",

--- a/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
+++ b/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
@@ -3,10 +3,20 @@ using System.Text.Json;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Renders a QR code using the EasyQRCode library.
+/// </summary>
 public class EasyQRCodeElement : Element {
+    /// <summary>
+    /// Gets the HTML element identifier.
+    /// </summary>
     public string Id { get; set; }
     private string PrivateText { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EasyQRCodeElement"/> class.
+    /// </summary>
+    /// <param name="text">Text to encode.</param>
     public EasyQRCodeElement(string text) {
         // Libraries will be registered via RegisterLibraries method
         Id = GlobalStorage.GenerateRandomId("QrCode");
@@ -20,6 +30,10 @@ public class EasyQRCodeElement : Element {
         Document?.Configuration.Libraries.TryAdd(Libraries.EasyQRCode, 0);
     }
 
+    /// <summary>
+    /// Generates the HTML and script elements for the QR code.
+    /// </summary>
+    /// <returns>The HTML string.</returns>
     public override string ToString() {
         var divTag = new HtmlTag("div").Class("qrcode").Id(Id);
 

--- a/HtmlForgeX/Containers/FancyTree/FancyTree.cs
+++ b/HtmlForgeX/Containers/FancyTree/FancyTree.cs
@@ -4,21 +4,44 @@ namespace HtmlForgeX;
 /// Fancy Tree element provides a tree view of the data in a graphical way.
 /// </summary>
 public class FancyTree : Element {
+    /// <summary>
+    /// Gets the unique identifier of the tree element.
+    /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Gets the list of nodes displayed by the control.
+    /// </summary>
     public List<FancyTreeNode> Items { get; set; } = new List<FancyTreeNode>();
 
+    /// <summary>
+    /// Gets the options used when rendering the tree.
+    /// </summary>
     public FancyTreeOptions Options { get; set; } = new FancyTreeOptions();
 
+    /// <summary>
+    /// Sets the minimum expand level for the tree.
+    /// </summary>
+    /// <param name="level">The level to expand to by default.</param>
+    /// <returns>The current <see cref="FancyTree"/> instance.</returns>
     public FancyTree MinimumExpandLevel(int level) {
         Options.MinExpandLevel = level;
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables automatic scrolling of the tree.
+    /// </summary>
+    /// <param name="autoScroll">Whether auto scroll should be enabled.</param>
+    /// <returns>The current <see cref="FancyTree"/> instance.</returns>
     public FancyTree AutoScroll(bool autoScroll) {
         Options.AutoScroll = autoScroll;
         return this;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FancyTree"/> class.
+    /// </summary>
     public FancyTree() {
         // Libraries will be registered via RegisterLibraries method
         Id = GlobalStorage.GenerateRandomId("fancyTree");
@@ -32,6 +55,10 @@ public class FancyTree : Element {
         Document?.Configuration.Libraries.TryAdd(Libraries.FancyTree, 0);
     }
 
+    /// <summary>
+    /// Renders the element as an HTML fragment.
+    /// </summary>
+    /// <returns>The generated HTML.</returns>
     public override string ToString() {
         var jsonOptions = new JsonSerializerOptions {
             WriteIndented = true
@@ -50,6 +77,11 @@ public class FancyTree : Element {
     }
 
 
+    /// <summary>
+    /// Adds a new top level node to the tree.
+    /// </summary>
+    /// <param name="title">Text displayed for the new node.</param>
+    /// <returns>The created <see cref="FancyTreeNode"/>.</returns>
     public FancyTreeNode Title(string title) {
         var item = new FancyTreeNode().Title(title);
         Items.Add(item);

--- a/HtmlForgeX/Containers/FancyTree/FancyTreeNode.cs
+++ b/HtmlForgeX/Containers/FancyTree/FancyTreeNode.cs
@@ -2,51 +2,102 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a single node within a <see cref="FancyTree"/> control.
+/// </summary>
 public class FancyTreeNode {
     [JsonPropertyName("title")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Display text for the node.
+    /// </summary>
     public string? NodeTitle { get; set; }
 
     [JsonPropertyName("icon")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Name of the icon used for the node.
+    /// </summary>
     public string? NodeIcon { get; set; }
 
     [JsonPropertyName("folder")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    /// <summary>
+    /// Gets or sets whether the node represents a folder.
+    /// </summary>
     public bool? NodeFolder { get; set; }
 
     [JsonPropertyName("children")]
+    /// <summary>
+    /// Child nodes contained under this node.
+    /// </summary>
     public List<FancyTreeNode> Nodes { get; set; } = new List<FancyTreeNode>();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FancyTreeNode"/> class.
+    /// </summary>
     public FancyTreeNode() { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FancyTreeNode"/> class with values.
+    /// </summary>
+    /// <param name="title">Node title.</param>
+    /// <param name="icon">Node icon.</param>
+    /// <param name="folder">Indicates if the node is a folder.</param>
     public FancyTreeNode(string title, string icon = "", bool folder = false) {
         NodeTitle = title;
         NodeIcon = icon;
         NodeFolder = folder;
     }
 
+    /// <summary>
+    /// Sets the display title for the node.
+    /// </summary>
+    /// <param name="title">Title text.</param>
+    /// <returns>The current <see cref="FancyTreeNode"/>.</returns>
     public FancyTreeNode Title(string title) {
         NodeTitle = title;
         return this;
     }
 
+    /// <summary>
+    /// Sets the icon for the node.
+    /// </summary>
+    /// <param name="icon">Icon name.</param>
+    /// <returns>The current <see cref="FancyTreeNode"/>.</returns>
     public FancyTreeNode Icon(string icon) {
         NodeIcon = icon;
         return this;
     }
 
+    /// <summary>
+    /// Adds a child node.
+    /// </summary>
+    /// <param name="node">Node to add.</param>
+    /// <returns>The added node.</returns>
     public FancyTreeNode AddNode(FancyTreeNode node) {
         Nodes.Add(node);
         return node;
     }
 
+    /// <summary>
+    /// Creates and adds a child node.
+    /// </summary>
+    /// <param name="title">Child title.</param>
+    /// <param name="icon">Child icon.</param>
+    /// <param name="nodeFolder">Whether the child is a folder.</param>
+    /// <returns>The created node.</returns>
     public FancyTreeNode AddNode(string title, string icon = null, bool nodeFolder = false) {
         var node = new FancyTreeNode { NodeTitle = title, NodeIcon = icon, NodeFolder = nodeFolder };
         Nodes.Add(node);
         return node;
     }
 
+    /// <summary>
+    /// Creates and configures a child node using a callback.
+    /// </summary>
+    /// <param name="config">Configuration delegate.</param>
+    /// <returns>The created node.</returns>
     public FancyTreeNode AddNode(Action<FancyTreeNode> config) {
         var node = new FancyTreeNode();
         config(node);

--- a/HtmlForgeX/Containers/FancyTree/FancyTreeOptions.cs
+++ b/HtmlForgeX/Containers/FancyTree/FancyTreeOptions.cs
@@ -1,19 +1,37 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Configuration options for <see cref="FancyTree"/>.
+/// </summary>
 public class FancyTreeOptions {
+    /// <summary>
+    /// Gets the list of additional extensions to enable.
+    /// </summary>
     [JsonPropertyName("extensions")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string> Extensions { get; set; } = new List<string>();
 
+    /// <summary>
+    /// Gets or sets the selection mode for the tree.
+    /// </summary>
     [JsonPropertyName("selectMode")]
     public int SelectMode { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the tree should auto scroll.
+    /// </summary>
     [JsonPropertyName("autoScroll")]
     public bool AutoScroll { get; set; }
 
+    /// <summary>
+    /// Gets or sets the initial tree expand level.
+    /// </summary>
     [JsonPropertyName("minExpandLevel")]
     public int MinExpandLevel { get; set; }
 
+    /// <summary>
+    /// Gets or sets the node data used to build the tree.
+    /// </summary>
     [JsonPropertyName("source")]
     public List<FancyTreeNode> Source { get; set; }
 }

--- a/HtmlForgeX/Containers/ScrollingText/ScrollingTextItem.cs
+++ b/HtmlForgeX/Containers/ScrollingText/ScrollingTextItem.cs
@@ -26,8 +26,8 @@ public class ScrollingTextItem : Element {
     /// <summary>
     /// Constructor for the ScrollingTextItem.
     /// </summary>
-    /// <param name="title"></param>
-    /// <param name="content"></param>
+    /// <param name="title">Title of the new item.</param>
+    /// <param name="content">Optional HTML content.</param>
     internal ScrollingTextItem(string title, string content = "") {
         Id = $"scrolling-{Guid.NewGuid().ToString("N")}";
         Title = title;
@@ -39,9 +39,9 @@ public class ScrollingTextItem : Element {
     /// <summary>
     /// Allows you to add a child element to the ScrollingTextItem.
     /// </summary>
-    /// <param name="title"></param>
-    /// <param name="config"></param>
-    /// <returns></returns>
+    /// <param name="title">Title of the child item.</param>
+    /// <param name="config">Callback used to configure the item.</param>
+    /// <returns>The newly created item.</returns>
     public ScrollingTextItem AddItem(string title, Action<ScrollingTextItem> config) {
         var child = new ScrollingTextItem(title);
         config(child);

--- a/HtmlForgeX/Resources/ApexChartsLibrary.cs
+++ b/HtmlForgeX/Resources/ApexChartsLibrary.cs
@@ -3,7 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Provides metadata and asset links for the ApexCharts library.
+/// </summary>
 public class ApexChartsLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApexChartsLibrary"/> class.
+    /// </summary>
     public ApexChartsLibrary() {
         Header = new LibraryLinks {
             JsLink = [

--- a/HtmlForgeX/Resources/Bootstrap.cs
+++ b/HtmlForgeX/Resources/Bootstrap.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Provides metadata and asset links for the Bootstrap framework.
+/// </summary>
 public class Bootstrap : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Bootstrap"/> class.
+    /// </summary>
     public Bootstrap() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"],

--- a/HtmlForgeX/Resources/ChartJsLibrary.cs
+++ b/HtmlForgeX/Resources/ChartJsLibrary.cs
@@ -1,7 +1,14 @@
 using System;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Provides metadata and asset links for the Chart.js library.
+/// </summary>
 public class ChartJsLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChartJsLibrary"/> class.
+    /// </summary>
     public ChartJsLibrary() {
         Header = new LibraryLinks {
             JsLink = [

--- a/HtmlForgeX/Resources/DataTables.cs
+++ b/HtmlForgeX/Resources/DataTables.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library descriptor for DataTables integration.
+/// </summary>
 internal class DataTables : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataTables"/> class.
+    /// </summary>
     public DataTables() {
         Header = new LibraryLinks {
             JsLink = [

--- a/HtmlForgeX/Resources/EasyQRCode.cs
+++ b/HtmlForgeX/Resources/EasyQRCode.cs
@@ -3,7 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Provides metadata for the EasyQRCode library.
+/// </summary>
 public class EasyQRCode : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EasyQRCode"/> class.
+    /// </summary>
     public EasyQRCode() {
         // CSS styles and JS go in HEAD
         Header = new LibraryLinks {

--- a/HtmlForgeX/Resources/FancyTreeLibrary.cs
+++ b/HtmlForgeX/Resources/FancyTreeLibrary.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Provides metadata and asset links for the FancyTree jQuery plugin.
+/// </summary>
 public class FancyTreeLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FancyTreeLibrary"/> class.
+    /// </summary>
     public FancyTreeLibrary() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.2/dist/skin-win8/ui.fancytree.min.css"],

--- a/HtmlForgeX/Resources/FontLoader.cs
+++ b/HtmlForgeX/Resources/FontLoader.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Utility methods for embedding custom fonts.
+/// </summary>
 public static class FontLoader {
     /// <summary>
     /// Loads a font file and returns a <see cref="Style"/> object representing a CSS <c>@font-face</c> rule with the font embedded as Base64.

--- a/HtmlForgeX/Resources/Jquery.cs
+++ b/HtmlForgeX/Resources/Jquery.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Metadata description for the jQuery library.
+/// </summary>
 public class Jquery : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Jquery"/> class.
+    /// </summary>
     public Jquery() {
         Header = new LibraryLinks {
             JsLink = ["https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"],

--- a/HtmlForgeX/Resources/Main.cs
+++ b/HtmlForgeX/Resources/Main.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Base styling library used across documents.
+/// </summary>
 internal class Primary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Primary"/> class.
+    /// </summary>
     public Primary() {
         Header = new LibraryLinks {
             CssStyle = new List<Style> {

--- a/HtmlForgeX/Resources/PopperLibrary.cs
+++ b/HtmlForgeX/Resources/PopperLibrary.cs
@@ -1,5 +1,12 @@
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Provides links for Popper and Tooltip libraries.
+/// </summary>
 public class PopperLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PopperLibrary"/> class.
+    /// </summary>
     public PopperLibrary() {
         Header = new LibraryLinks {
             JsLink = [

--- a/HtmlForgeX/Resources/ScrollingTextLibrary.cs
+++ b/HtmlForgeX/Resources/ScrollingTextLibrary.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library providing assets for the scrolling text component.
+/// </summary>
 public class ScrollingTextLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScrollingTextLibrary"/> class.
+    /// </summary>
     public ScrollingTextLibrary() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/gh/evotecit/cdn@0.0.27/CSS/sectionScrolling.min.css"],

--- a/HtmlForgeX/Resources/Tabler.cs
+++ b/HtmlForgeX/Resources/Tabler.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Core Tabler CSS/JS framework library descriptor.
+/// </summary>
 internal class Tabler : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Tabler"/> class.
+    /// </summary>
     public Tabler() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/core@1.3.0/dist/css/tabler.min.css"],

--- a/HtmlForgeX/Resources/TablerFlags.cs
+++ b/HtmlForgeX/Resources/TablerFlags.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library descriptor for Tabler flag icons.
+/// </summary>
 internal class TablerFlags : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerFlags"/> class.
+    /// </summary>
     public TablerFlags() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/core@1.3.0/dist/css/tabler-flags.min.css"],

--- a/HtmlForgeX/Resources/TablerIconLibrary.cs
+++ b/HtmlForgeX/Resources/TablerIconLibrary.cs
@@ -3,7 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Library descriptor for Tabler icon fonts.
+/// </summary>
 internal class TablerIconLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerIconLibrary"/> class.
+    /// </summary>
     public TablerIconLibrary() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css"],

--- a/HtmlForgeX/Resources/TablerPayments.cs
+++ b/HtmlForgeX/Resources/TablerPayments.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library descriptor for Tabler payment icon set.
+/// </summary>
 internal class TablerPayments : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerPayments"/> class.
+    /// </summary>
     public TablerPayments() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/core@1.3.0/dist/css/tabler-payments.min.css"],

--- a/HtmlForgeX/Resources/TablerSocials.cs
+++ b/HtmlForgeX/Resources/TablerSocials.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library descriptor for Tabler social media icons.
+/// </summary>
 internal class TablerSocials : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerSocials"/> class.
+    /// </summary>
     public TablerSocials() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/core@1.3.0/dist/css/tabler-socials.min.css"],

--- a/HtmlForgeX/Resources/TablerThemes.cs
+++ b/HtmlForgeX/Resources/TablerThemes.cs
@@ -1,6 +1,12 @@
 namespace HtmlForgeX.Resources;
 
+/// <summary>
+/// Library descriptor for Tabler theme support.
+/// </summary>
 internal class TablerThemes : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerThemes"/> class.
+    /// </summary>
     public TablerThemes() {
         Header = new LibraryLinks {
             CssLink = ["https://cdn.jsdelivr.net/npm/@tabler/core@1.3.0/dist/css/tabler-themes.min.css"],

--- a/HtmlForgeX/Resources/VisNetworkLibrary.cs
+++ b/HtmlForgeX/Resources/VisNetworkLibrary.cs
@@ -3,7 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Library descriptor for Vis Network diagrams.
+/// </summary>
 internal class VisNetworkLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisNetworkLibrary"/> class.
+    /// </summary>
     public VisNetworkLibrary() {
         Header = new LibraryLinks {
             CssLink = [

--- a/HtmlForgeX/Resources/VisNetworkLoadingBarLibrary.cs
+++ b/HtmlForgeX/Resources/VisNetworkLoadingBarLibrary.cs
@@ -3,7 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 
 namespace HtmlForgeX.Resources;
+
+/// <summary>
+/// Provides assets for the Vis Network loading bar plugin.
+/// </summary>
 public class VisNetworkLoadingBarLibrary : Library {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisNetworkLoadingBarLibrary"/> class.
+    /// </summary>
     public VisNetworkLoadingBarLibrary() {
         Header = new LibraryLinks {
             CssLink = [


### PR DESCRIPTION
## Summary
- document each `BootStrapTableStyle` value
- document each `ChartJsType` value
- document `Line`, `Bar` and `Pie` helper methods in `ChartJs`
- document FancyTreeNode public properties

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6873e976a9f0832e99e83c1cbf7b79c4