### PR TITLE
Add theme support for TablerLogs

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -48,6 +48,7 @@ internal class Program {
         // Toast examples
         ExampleTablerToast.Create(openInBrowser);
         ExampleTablerToastAdvanced.Create(openInBrowser);
+        ExampleTablerLogs.Create(openInBrowser);
 
         // Container examples
         BasicHtmlContainer01.Demo01(openInBrowser);

--- a/HtmlForgeX.Examples/Tags/ExampleTablerLogs.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerLogs.cs
@@ -1,0 +1,31 @@
+namespace HtmlForgeX.Examples.Tags;
+
+internal static class ExampleTablerLogs {
+    public static void Create(bool openInBrowser = false) {
+        var document = new Document { Head = { Title = "Logs Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Logs(new[] { "Line 1", "Line 2" }, TablerLogsTheme.Light)
+                            .Title(HeaderLevelTag.H4, "Light Theme");
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Logs(new[] { "Line 3", "Line 4" }, TablerLogsTheme.Lime)
+                            .Title(HeaderLevelTag.H4, "Lime Theme");
+                    });
+                });
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Logs(new[] { "Custom A", "Custom B" }, TablerLogsTheme.Dark, "bg-purple", "text-yellow")
+                            .Title(HeaderLevelTag.H4, "Custom Theme");
+                    });
+                });
+            });
+        });
+
+        document.Save("TablerLogsDemo.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerLogs.cs
+++ b/HtmlForgeX.Tests/TestTablerLogs.cs
@@ -1,0 +1,38 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerLogs {
+    [TestMethod]
+    public void TablerLogs_DefaultTheme() {
+        var logs = new TablerLogs("Test");
+        var html = logs.ToString();
+        Assert.IsTrue(html.Contains("bg-dark"));
+        Assert.IsTrue(html.Contains("text-white"));
+    }
+
+    [TestMethod]
+    public void TablerLogs_LightTheme() {
+        var logs = new TablerLogs("Test").Theme(TablerLogsTheme.Light);
+        var html = logs.ToString();
+        Assert.IsTrue(html.Contains("bg-light"));
+        Assert.IsTrue(html.Contains("text-dark"));
+    }
+
+    [TestMethod]
+    public void TablerLogs_LimeTheme() {
+        var logs = new TablerLogs("Test").Theme(TablerLogsTheme.Lime);
+        var html = logs.ToString();
+        Assert.IsTrue(html.Contains("bg-lime"));
+        Assert.IsTrue(html.Contains("text-dark"));
+    }
+
+    [TestMethod]
+    public void TablerLogs_CustomTheme() {
+        var logs = new TablerLogs("Test").CustomTheme("bg-purple", "text-yellow");
+        var html = logs.ToString();
+        Assert.IsTrue(html.Contains("bg-purple"));
+        Assert.IsTrue(html.Contains("text-yellow"));
+    }
+}

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -294,20 +294,35 @@ public abstract class Element {
         return progressBar;
     }
 
-    public TablerLogs Logs(string code) {
+    public TablerLogs Logs(string code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
+        if (backgroundClass != null && textClass != null) {
+            logs.CustomTheme(backgroundClass, textClass);
+        } else {
+            logs.Theme(theme);
+        }
         this.Add(logs);
         return logs;
     }
 
-    public TablerLogs Logs(string[] code) {
+    public TablerLogs Logs(string[] code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
+        if (backgroundClass != null && textClass != null) {
+            logs.CustomTheme(backgroundClass, textClass);
+        } else {
+            logs.Theme(theme);
+        }
         this.Add(logs);
         return logs;
     }
 
-    public TablerLogs Logs(List<string> code) {
+    public TablerLogs Logs(List<string> code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
+        if (backgroundClass != null && textClass != null) {
+            logs.CustomTheme(backgroundClass, textClass);
+        } else {
+            logs.Theme(theme);
+        }
         this.Add(logs);
         return logs;
     }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerLogsTheme.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerLogsTheme.cs
@@ -1,0 +1,54 @@
+namespace HtmlForgeX;
+
+public enum TablerLogsTheme {
+    Dark,
+    Light,
+    Primary,
+    Secondary,
+    Success,
+    Danger,
+    Warning,
+    Info,
+    Azure,
+    Indigo,
+    Purple,
+    Pink,
+    Red,
+    Orange,
+    Yellow,
+    Lime,
+    Green,
+    Teal,
+    Blue,
+    Gray,
+    Custom
+}
+
+public static class TablerLogsThemeExtensions {
+    public static string ToClassString(this TablerLogsTheme theme) {
+        return theme switch {
+            TablerLogsTheme.Dark => "bg-dark text-white",
+            TablerLogsTheme.Light => "bg-light text-dark",
+            TablerLogsTheme.Primary => "bg-primary text-white",
+            TablerLogsTheme.Secondary => "bg-secondary text-white",
+            TablerLogsTheme.Success => "bg-success text-white",
+            TablerLogsTheme.Danger => "bg-danger text-white",
+            TablerLogsTheme.Warning => "bg-warning text-dark",
+            TablerLogsTheme.Info => "bg-info text-white",
+            TablerLogsTheme.Azure => "bg-azure text-white",
+            TablerLogsTheme.Indigo => "bg-indigo text-white",
+            TablerLogsTheme.Purple => "bg-purple text-white",
+            TablerLogsTheme.Pink => "bg-pink text-white",
+            TablerLogsTheme.Red => "bg-red text-white",
+            TablerLogsTheme.Orange => "bg-orange text-white",
+            TablerLogsTheme.Yellow => "bg-yellow text-dark",
+            TablerLogsTheme.Lime => "bg-lime text-dark",
+            TablerLogsTheme.Green => "bg-green text-white",
+            TablerLogsTheme.Teal => "bg-teal text-white",
+            TablerLogsTheme.Blue => "bg-blue text-white",
+            TablerLogsTheme.Gray => "bg-gray text-white",
+            TablerLogsTheme.Custom => string.Empty,
+            _ => throw new ArgumentOutOfRangeException(nameof(theme), theme, null)
+        };
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerLogs.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerLogs.cs
@@ -4,6 +4,9 @@ public class TablerLogs : Element {
     private HeaderLevelTag? PrivateLevelTitle { get; set; }
     private string? PrivateTitle { get; set; }
     private string PrivateCode { get; set; }
+    private TablerLogsTheme ThemeEntry { get; set; } = TablerLogsTheme.Dark;
+    private string? CustomBackgroundClass { get; set; }
+    private string? CustomTextClass { get; set; }
     public TablerLogs(string code) {
         PrivateCode = code;
     }
@@ -21,6 +24,18 @@ public class TablerLogs : Element {
         return this;
     }
 
+    public TablerLogs Theme(TablerLogsTheme theme) {
+        ThemeEntry = theme;
+        return this;
+    }
+
+    public TablerLogs CustomTheme(string backgroundClass, string textClass) {
+        ThemeEntry = TablerLogsTheme.Custom;
+        CustomBackgroundClass = backgroundClass;
+        CustomTextClass = textClass;
+        return this;
+    }
+
     public override string ToString() {
         HeaderLevel? header;
         if (PrivateLevelTitle != null && PrivateTitle != null) {
@@ -32,7 +47,13 @@ public class TablerLogs : Element {
         }
 
         HtmlTag logsTag = new HtmlTag("div");
-        HtmlTag preTag = new HtmlTag("pre").Value(PrivateCode);
+        string classes = ThemeEntry == TablerLogsTheme.Custom
+            ? $"{CustomBackgroundClass} {CustomTextClass}".Trim()
+            : ThemeEntry.ToClassString();
+
+        HtmlTag preTag = new HtmlTag("pre")
+            .Class(classes)
+            .Value(PrivateCode);
         logsTag.Value(preTag);
 
         if (header != null) {


### PR DESCRIPTION
## Summary
- add many preset themes and custom option for TablerLogs
- expose optional custom classes via Element helpers
- show new features in TablerLogs example
- test lime and custom themes

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build --no-restore`
- `dotnet test --framework net472 --verbosity minimal` *(fails: reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68741a5a4278832e8d22e08efc46e932