### PR TITLE
Add XML docs to VisNetwork container

### DIFF
--- a/HtmlForgeX/Containers/VisNetwork/VisNetwork.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetwork.cs
@@ -3,14 +3,38 @@ using System.Linq;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Container for building interactive diagrams using the Vis Network library.
+/// </summary>
 public class VisNetwork : Element {
+    /// <summary>
+    /// Gets or sets the unique identifier of the diagram container element.
+    /// </summary>
     public string Id { get; set; }
+
+    /// <summary>
+    /// Gets the collection of nodes to render.
+    /// </summary>
     public List<object> Nodes { get; set; } = new List<object>();
+
+    /// <summary>
+    /// Gets the collection of edges connecting nodes.
+    /// </summary>
     public List<object> Edges { get; set; } = new List<object>();
+
+    /// <summary>
+    /// Gets a dictionary of additional options passed directly to Vis Network.
+    /// </summary>
     public Dictionary<string, object> Options { get; set; } = new Dictionary<string, object>();
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the loading bar should be displayed.
+    /// </summary>
     public bool EnableLoadingBar { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisNetwork"/> class.
+    /// </summary>
     public VisNetwork() {
         // Libraries will be registered via RegisterLibraries method
         Id = GlobalStorage.GenerateRandomId("Diagram");
@@ -24,6 +48,10 @@ public class VisNetwork : Element {
         Document?.Configuration.Libraries.TryAdd(Libraries.VisNetworkLoadingBar, 0);
     }
 
+    /// <summary>
+    /// Called when the element is added to a <see cref="Document"/>.
+    /// Ensures that offline embedding rules are applied to all nodes.
+    /// </summary>
     protected override void OnAddedToDocument() {
         foreach (var nodeObj in Nodes) {
             if (nodeObj is VisNetworkNode node) {
@@ -32,11 +60,21 @@ public class VisNetwork : Element {
         }
     }
 
+    /// <summary>
+    /// Adds a raw node object to the diagram.
+    /// </summary>
+    /// <param name="node">Object containing node definition.</param>
+    /// <returns>The current <see cref="VisNetwork"/> instance.</returns>
     public VisNetwork AddNode(object node) {
         Nodes.Add(node);
         return this;
     }
 
+    /// <summary>
+    /// Adds a strongly typed <see cref="VisNetworkNode"/> to the diagram.
+    /// </summary>
+    /// <param name="node">Node to add.</param>
+    /// <returns>The current <see cref="VisNetwork"/> instance.</returns>
     public VisNetwork AddNode(VisNetworkNode node) {
         if (Document != null) {
             node.ApplyDocumentConfiguration(Document);
@@ -45,21 +83,41 @@ public class VisNetwork : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a raw edge object to the diagram.
+    /// </summary>
+    /// <param name="edge">Object containing edge definition.</param>
+    /// <returns>The current <see cref="VisNetwork"/> instance.</returns>
     public VisNetwork AddEdge(object edge) {
         Edges.Add(edge);
         return this;
     }
 
+    /// <summary>
+    /// Adds a <see cref="VisNetworkEdge"/> to the diagram.
+    /// </summary>
+    /// <param name="edge">Edge to add.</param>
+    /// <returns>The current <see cref="VisNetwork"/> instance.</returns>
     public VisNetwork AddEdge(VisNetworkEdge edge) {
         Edges.Add(edge);
         return this;
     }
 
+    /// <summary>
+    /// Sets an option that will be passed to the underlying Vis Network instance.
+    /// </summary>
+    /// <param name="key">Option name.</param>
+    /// <param name="value">Option value.</param>
+    /// <returns>The current <see cref="VisNetwork"/> instance.</returns>
     public VisNetwork SetOption(string key, object value) {
         Options[key] = value;
         return this;
     }
 
+    /// <summary>
+    /// Generates the HTML and JavaScript required to render the diagram.
+    /// </summary>
+    /// <returns>HTML string representing the network diagram.</returns>
     public override string ToString() {
         HtmlTag divTag;
         if (EnableLoadingBar) {

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkEdge.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkEdge.cs
@@ -20,71 +20,142 @@ public class VisNetworkEdge {
     public double? Length { get; set; }
     public Dictionary<string, object> Custom { get; } = new();
 
+    /// <summary>
+    /// Sets a custom property on the edge that will be included in the output dictionary.
+    /// </summary>
+    /// <param name="key">Property name.</param>
+    /// <param name="value">Property value.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge SetCustom(string key, object value) {
         Custom[key] = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the identifier of the edge.
+    /// </summary>
+    /// <param name="id">Identifier value.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge IdValue(object id) {
         Id = id;
         return this;
     }
 
+    /// <summary>
+    /// Sets the identifier of the source node.
+    /// </summary>
+    /// <param name="from">Source node id.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge FromNode(object from) {
         From = from;
         return this;
     }
 
+    /// <summary>
+    /// Sets the identifier of the destination node.
+    /// </summary>
+    /// <param name="to">Destination node id.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge ToNode(object to) {
         To = to;
         return this;
     }
 
+    /// <summary>
+    /// Sets the edge label displayed in the diagram.
+    /// </summary>
+    /// <param name="label">Label text.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeLabel(string label) {
         Label = label;
         return this;
     }
 
+    /// <summary>
+    /// Sets the edge tooltip title.
+    /// </summary>
+    /// <param name="title">Title text.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeTitle(string title) {
         Title = title;
         return this;
     }
 
+    /// <summary>
+    /// Specifies the edge color using a hex or CSS color string.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeColor(string color) {
         Color = color;
         return this;
     }
 
+    /// <summary>
+    /// Specifies the edge color using an <see cref="RGBColor"/> instance.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeColor(RGBColor color) {
         Color = color.ToHex();
         return this;
     }
 
+    /// <summary>
+    /// Configures the arrows displayed on this edge.
+    /// </summary>
+    /// <param name="arrows">Arrow options.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeArrows(VisNetworkArrows arrows) {
         Arrows = arrows;
         return this;
     }
 
+    /// <summary>
+    /// Sets the width of the edge line in pixels.
+    /// </summary>
+    /// <param name="width">Edge width.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeWidth(double width) {
         Width = width;
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables dashed line style for the edge.
+    /// </summary>
+    /// <param name="dashes">Value indicating whether dashes should be used.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeDashes(bool dashes = true) {
         Dashes = dashes;
         return this;
     }
 
+    /// <summary>
+    /// Hides or shows the edge.
+    /// </summary>
+    /// <param name="hidden">True to hide the edge.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeHidden(bool hidden = true) {
         Hidden = hidden;
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables physics calculations for the edge.
+    /// </summary>
+    /// <param name="physics">True to enable physics.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgePhysics(bool physics = true) {
         Physics = physics;
         return this;
     }
 
+    /// <summary>
+    /// Specifies the ideal length of the edge in pixels.
+    /// </summary>
+    /// <param name="length">Length value.</param>
+    /// <returns>The current <see cref="VisNetworkEdge"/> instance.</returns>
     public VisNetworkEdge EdgeLength(double length) {
         Length = length;
         return this;

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkEnums.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkEnums.cs
@@ -4,23 +4,86 @@ namespace HtmlForgeX;
 /// Available node shapes in VisNetwork.
 /// </summary>
 public enum VisNetworkNodeShape {
+    /// <summary>
+    /// Renders the node as an ellipse.
+    /// </summary>
     Ellipse,
+
+    /// <summary>
+    /// Renders the node as a circle.
+    /// </summary>
     Circle,
+
+    /// <summary>
+    /// Uses a database icon for the node.
+    /// </summary>
     Database,
+
+    /// <summary>
+    /// Shows the node as a rectangular box.
+    /// </summary>
     Box,
+
+    /// <summary>
+    /// Displays the node with a simple text label.
+    /// </summary>
     Text,
+
+    /// <summary>
+    /// References an image specified by the <c>Image</c> property.
+    /// </summary>
     Image,
+
+    /// <summary>
+    /// Similar to <see cref="Image"/> but clips the image to a circle.
+    /// </summary>
     CircularImage,
+
+    /// <summary>
+    /// Renders the node as a diamond shape.
+    /// </summary>
     Diamond,
+
+    /// <summary>
+    /// Shows the node as a small dot.
+    /// </summary>
     Dot,
+
+    /// <summary>
+    /// Renders the node as a square.
+    /// </summary>
     Square,
+
+    /// <summary>
+    /// Displays the node as a triangle pointing up.
+    /// </summary>
     Triangle,
+
+    /// <summary>
+    /// Displays the node as a triangle pointing down.
+    /// </summary>
     TriangleDown,
+
+    /// <summary>
+    /// Renders the node as a hexagon.
+    /// </summary>
     Hexagon,
+
+    /// <summary>
+    /// Displays the node using a star icon.
+    /// </summary>
     Star
 }
 
+/// <summary>
+/// Helper methods for <see cref="VisNetworkNodeShape"/> values.
+/// </summary>
 public static class VisNetworkNodeShapeExtensions {
+    /// <summary>
+    /// Converts a <see cref="VisNetworkNodeShape"/> value to its string representation used by the library.
+    /// </summary>
+    /// <param name="shape">Shape to convert.</param>
+    /// <returns>String representation understood by Vis Network.</returns>
     public static string EnumToString(this VisNetworkNodeShape shape) => shape switch {
         VisNetworkNodeShape.CircularImage => "circularImage",
         VisNetworkNodeShape.TriangleDown => "triangleDown",
@@ -33,13 +96,36 @@ public static class VisNetworkNodeShapeExtensions {
 /// </summary>
 [Flags]
 public enum VisNetworkArrows {
+    /// <summary>
+    /// No arrows are rendered on the edge.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// Draws an arrow pointing towards the target node.
+    /// </summary>
     To = 1,
+
+    /// <summary>
+    /// Draws an arrow pointing away from the source node.
+    /// </summary>
     From = 2,
+
+    /// <summary>
+    /// Draws an arrow in the middle of the edge.
+    /// </summary>
     Middle = 4
 }
 
+/// <summary>
+/// Extension helpers for working with <see cref="VisNetworkArrows"/> values.
+/// </summary>
 public static class VisNetworkArrowExtensions {
+    /// <summary>
+    /// Converts a <see cref="VisNetworkArrows"/> flag combination to the string format expected by Vis Network.
+    /// </summary>
+    /// <param name="arrows">Flags describing which arrows are enabled.</param>
+    /// <returns>Comma separated string used in JavaScript configuration.</returns>
     public static string EnumToString(this VisNetworkArrows arrows) {
         if (arrows == VisNetworkArrows.None) {
             return string.Empty;

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
@@ -24,78 +24,155 @@ public class VisNetworkNode {
     public bool SkipAutoEmbedding { get; set; }
     public Dictionary<string, object> Custom { get; } = new();
 
+    /// <summary>
+    /// Adds a custom property that will be serialized with the node.
+    /// </summary>
+    /// <param name="key">Property name.</param>
+    /// <param name="value">Property value.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode SetCustom(string key, object value) {
         Custom[key] = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the node identifier.
+    /// </summary>
+    /// <param name="id">Identifier value.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode IdValue(object id) {
         Id = id;
         return this;
     }
 
+    /// <summary>
+    /// Sets the text label shown on the node.
+    /// </summary>
+    /// <param name="label">Label text.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode LabelText(string label) {
         Label = label;
         return this;
     }
 
+    /// <summary>
+    /// Sets the tooltip title for the node.
+    /// </summary>
+    /// <param name="title">Title text.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode TitleText(string title) {
         Title = title;
         return this;
     }
 
+    /// <summary>
+    /// Uses an external image for the node.
+    /// </summary>
+    /// <param name="url">URL of the image.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode UseImage(string url) {
         Image = url;
         Shape ??= VisNetworkNodeShape.Image;
         return this;
     }
 
+    /// <summary>
+    /// Embeds an image from a file or URL into the document.
+    /// </summary>
+    /// <param name="source">Local path or URL of the image.</param>
+    /// <param name="timeoutSeconds">Download timeout in seconds.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode UseImageOffline(string source, int timeoutSeconds = 30) {
         Image = EmbedImage(source, timeoutSeconds);
         Shape ??= VisNetworkNodeShape.Image;
         return this;
     }
 
+    /// <summary>
+    /// Sets the visual shape of the node.
+    /// </summary>
+    /// <param name="shape">Shape type.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeShape(VisNetworkNodeShape shape) {
         Shape = shape;
         return this;
     }
 
+    /// <summary>
+    /// Assigns the node to a group.
+    /// </summary>
+    /// <param name="group">Group name.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeGroup(string group) {
         Group = group;
         return this;
     }
 
+    /// <summary>
+    /// Sets the node color using a CSS color string.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeColor(string color) {
         Color = color;
         return this;
     }
 
+    /// <summary>
+    /// Sets the node color using an <see cref="RGBColor"/> object.
+    /// </summary>
+    /// <param name="color">Color instance.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeColor(RGBColor color) {
         Color = color.ToHex();
         return this;
     }
 
+    /// <summary>
+    /// Sets the size of the node.
+    /// </summary>
+    /// <param name="size">Size value.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeSize(double size) {
         Size = size;
         return this;
     }
 
+    /// <summary>
+    /// Determines whether the node should be hidden.
+    /// </summary>
+    /// <param name="hidden">True to hide the node.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodeHidden(bool hidden = true) {
         Hidden = hidden;
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables physics calculations for the node.
+    /// </summary>
+    /// <param name="physics">True to enable physics.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode NodePhysics(bool physics = true) {
         Physics = physics;
         return this;
     }
 
+    /// <summary>
+    /// Prevents the library from automatically embedding the image when offline mode is active.
+    /// </summary>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode WithoutAutoEmbedding() {
         SkipAutoEmbedding = true;
         return this;
     }
 
+    /// <summary>
+    /// Sets the initial position of the node.
+    /// </summary>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    /// <returns>The current <see cref="VisNetworkNode"/> instance.</returns>
     public VisNetworkNode Position(double x, double y) {
         X = x;
         Y = y;


### PR DESCRIPTION
## Summary
- document VisNetwork enums and extension helpers
- add XML comments for VisNetwork container and related node/edge classes

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687549a393ec832ea8e250a863027f7b