### PR TITLE
Fix missing documentation warnings

### DIFF
--- a/HtmlForgeX/Containers/Core/Document.Main.cs
+++ b/HtmlForgeX/Containers/Core/Document.Main.cs
@@ -16,29 +16,51 @@ public partial class Document : Element {
     /// </summary>
     public DocumentConfiguration Configuration { get; } = new();
 
+    /// <summary>
+    /// Gets the <see cref="Head"/> element of this document.
+    /// </summary>
     public Head Head { get; }
+
+    /// <summary>
+    /// Gets the <see cref="Body"/> element of this document.
+    /// </summary>
     public Body Body { get; }
 
+    /// <summary>
+    /// Gets or sets how external libraries are loaded.
+    /// </summary>
     public LibraryMode LibraryMode {
         get => Configuration.LibraryMode;
         set => Configuration.LibraryMode = value;
     }
 
+    /// <summary>
+    /// Gets or sets the initial theme mode.
+    /// </summary>
     public ThemeMode ThemeMode {
         get => Configuration.ThemeMode;
         set => Configuration.ThemeMode = value;
     }
 
+    /// <summary>
+    /// Gets or sets the output path used when saving the document.
+    /// </summary>
     public string Path {
         get => Configuration.Path;
         set => Configuration.Path = value;
     }
 
+    /// <summary>
+    /// Gets or sets the default style output path.
+    /// </summary>
     public string StylePath {
         get => Configuration.StylePath;
         set => Configuration.StylePath = value;
     }
 
+    /// <summary>
+    /// Gets or sets the default script output path.
+    /// </summary>
     public string ScriptPath {
         get => Configuration.ScriptPath;
         set => Configuration.ScriptPath = value;

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -4,7 +4,13 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Base class for all HTML elements in HtmlForgeX.
+/// </summary>
 public abstract class Element {
+    /// <summary>
+    /// Collection of child elements contained within this element.
+    /// </summary>
     public List<Element> Children { get; } = new List<Element>();
 
     private Document? _document;
@@ -93,6 +99,10 @@ public abstract class Element {
         // Base implementation does nothing - override in derived classes
     }
 
+    /// <summary>
+    /// Returns a string representation of the element.
+    /// </summary>
+    /// <returns>HTML output for this element.</returns>
     public abstract override string ToString();
 
     /// <summary>


### PR DESCRIPTION
## Summary
- remove NoWarn suppression for CS1591
- document key properties in `Document` and `Element`

## Testing
- `dotnet restore HtmlForgeX.sln`
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln --no-build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68754aa04fa8832e97f7f417c4b75ace