### PR TITLE
Add XML docs for ApexCharts

### DIFF
--- a/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
@@ -7,16 +7,46 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents an ApexCharts component that can be embedded in the HTML output.
+/// </summary>
 public class ApexCharts : Element {
+    /// <summary>
+    /// Gets or sets the DOM element identifier for the chart container.
+    /// </summary>
     public string Id { get; set; }
+    /// <summary>
+    /// Gets or sets the type of chart to render.
+    /// </summary>
     public ApexChartType Type { get; set; }
+    /// <summary>
+    /// Gets the numeric data series used by most chart types.
+    /// </summary>
     public List<double> Series { get; set; } = new List<double>();
+    /// <summary>
+    /// Gets the labels associated with <see cref="Series"/> values.
+    /// </summary>
     public List<string> Labels { get; set; } = new List<string>();
+    /// <summary>
+    /// Gets the heatmap specific series collection.
+    /// </summary>
     public List<ApexHeatmapSeries> HeatmapSeries { get; set; } = new();
+    /// <summary>
+    /// Gets the title configuration.
+    /// </summary>
     public ApexChartsTitle Title { get; set; } = new ApexChartsTitle();
+    /// <summary>
+    /// Gets the subtitle configuration.
+    /// </summary>
     public ApexChartSubtitle Subtitle { get; set; } = new ApexChartSubtitle();
+    /// <summary>
+    /// Gets additional options passed directly to ApexCharts.
+    /// </summary>
     public Dictionary<string, object> Options { get; set; } = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApexCharts"/> class.
+    /// </summary>
     public ApexCharts() {
         // Libraries will be registered via RegisterLibraries method
         Id = GlobalStorage.GenerateRandomId("apexChart");
@@ -25,10 +55,17 @@ public class ApexCharts : Element {
     /// <summary>
     /// Registers the required libraries for ApexCharts.
     /// </summary>
+    /// <inheritdoc />
     protected internal override void RegisterLibraries() {
         Document?.Configuration.Libraries.TryAdd(Libraries.ApexCharts, 0);
     }
 
+    /// <summary>
+    /// Adds a pie chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddPie(string name, double value) {
         Type = ApexChartType.Pie;
         Labels.Add(name);
@@ -36,6 +73,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a donut chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddDonut(string name, double value) {
         Type = ApexChartType.Donut;
         Labels.Add(name);
@@ -43,6 +86,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a bar chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddBar(string name, double value) {
         Type = ApexChartType.Bar;
         Labels.Add(name);
@@ -50,6 +99,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds an area chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddArea(string name, double value) {
         Type = ApexChartType.Area;
         Labels.Add(name);
@@ -57,6 +112,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a treemap chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddTreemap(string name, double value) {
         Type = ApexChartType.Treemap;
         Labels.Add(name);
@@ -64,6 +125,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a radar chart data point.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddRadar(string name, double value) {
         Type = ApexChartType.Radar;
         Labels.Add(name);
@@ -71,6 +138,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a heatmap series consisting of multiple points.
+    /// </summary>
+    /// <param name="name">Series name.</param>
+    /// <param name="points">Collection of points (X,Y).</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddHeatmap(string name, IEnumerable<(string X, double Y)> points) {
         Type = ApexChartType.Heatmap;
         var series = new ApexHeatmapSeries { Name = name };
@@ -81,6 +154,12 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds a data point for a mixed chart.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts AddMixed(string name, double value) {
         Type = ApexChartType.Mixed;
         Labels.Add(name);
@@ -88,49 +167,95 @@ public class ApexCharts : Element {
         return this;
     }
 
+    /// <summary>
+    /// Sets a raw option value passed directly to the ApexCharts configuration.
+    /// </summary>
+    /// <param name="key">Option key.</param>
+    /// <param name="value">Option value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts SetOption(string key, object value) {
         Options[key] = value;
         return this;
     }
 
+    /// <summary>
+    /// Configures plot options using a fluent builder.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure options.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts PlotOptions(Action<ApexPlotOptions> configure) {
         var options = new ApexPlotOptions();
         configure(options);
         return SetOption("plotOptions", options);
     }
 
+    /// <summary>
+    /// Configures grid options using a fluent builder.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure grid options.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Grid(Action<ApexGridOptions> configure) {
         var options = new ApexGridOptions();
         configure(options);
         return SetOption("grid", options);
     }
 
+    /// <summary>
+    /// Configures legend options using a fluent builder.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure legend options.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Legend(Action<ApexLegendOptions> configure) {
         var options = new ApexLegendOptions();
         configure(options);
         return SetOption("legend", options);
     }
 
+    /// <summary>
+    /// Sets the responsive option value.
+    /// </summary>
+    /// <param name="value">Responsive configuration object.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Responsive(object value) => SetOption("responsive", value);
 
+    /// <summary>
+    /// Configures tooltip options using a fluent builder.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure tooltip options.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Tooltip(Action<ApexTooltipOptions> configure) {
         var options = new ApexTooltipOptions();
         configure(options);
         return SetOption("tooltip", options);
     }
 
+    /// <summary>
+    /// Configures theme options.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure theme options.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Theme(Action<ApexThemeOptions> configure) {
         var options = new ApexThemeOptions();
         configure(options);
         return SetOption("theme", options);
     }
 
+    /// <summary>
+    /// Adds a data point to the chart using the currently selected type.
+    /// </summary>
+    /// <param name="name">Label for the data point.</param>
+    /// <param name="value">Numeric value.</param>
+    /// <returns>The current <see cref="ApexCharts"/> instance.</returns>
     public ApexCharts Data(string name, double value) {
         Labels.Add(name);
         Series.Add(value);
         return this;
     }
 
+    /// <summary>
+    /// Generates the HTML and JavaScript required to render the chart.
+    /// </summary>
+    /// <returns>HTML markup representing the chart.</returns>
     public override string ToString() {
         // Generate ID if not already set
         if (string.IsNullOrEmpty(Id)) {

--- a/HtmlForgeX/Containers/ApexCharts/ApexChartsTitle.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexChartsTitle.cs
@@ -4,11 +4,23 @@ using System.Text;
 using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
+/// <summary>
+/// Builder for configuring chart title appearance.
+/// </summary>
 public class ApexChartsTitle {
+    /// <summary>
+    /// Gets or sets the title text.
+    /// </summary>
     [JsonPropertyName("text")]
     public string? TitleText { get; set; }
+    /// <summary>
+    /// Gets or sets the title alignment.
+    /// </summary>
     [JsonPropertyName("align")]
     public string TitleAlign { get; set; } = "center";
+    /// <summary>
+    /// Gets the style dictionary applied to the title.
+    /// </summary>
     [JsonPropertyName("style")]
     public Dictionary<string, string> Style { get; set; } = new Dictionary<string, string>();
 
@@ -21,36 +33,73 @@ public class ApexChartsTitle {
     [JsonIgnore]
     public bool IsSet => !string.IsNullOrEmpty(TitleText);
 
+    /// <summary>
+    /// Sets the title text.
+    /// </summary>
+    /// <param name="text">Text to display.</param>
+    /// <returns>The current <see cref="ApexChartsTitle"/> instance.</returns>
     public ApexChartsTitle Text(string text) {
         TitleText = text;
         return this;
     }
 
+    /// <summary>
+    /// Sets the title color using a CSS string value.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="ApexChartsTitle"/> instance.</returns>
     public ApexChartsTitle Color(string color) {
         Style["color"] = color;
         return this;
     }
 
+    /// <summary>
+    /// Sets the title color from an <see cref="RGBColor"/>.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="ApexChartsTitle"/> instance.</returns>
     public ApexChartsTitle Color(RGBColor color) {
         Style["color"] = color.ToString();
         return this;
     }
 
+    /// <summary>
+    /// Sets the title font size.
+    /// </summary>
+    /// <param name="fontSize">Size value with units.</param>
+    /// <returns>The current <see cref="ApexChartsTitle"/> instance.</returns>
     public ApexChartsTitle FontSize(string fontSize) {
         Style["fontSize"] = fontSize;
         return this;
     }
 
+    /// <summary>
+    /// Sets the title font weight.
+    /// </summary>
+    /// <param name="fontWeight">Font weight value.</param>
+    /// <returns>The current <see cref="ApexChartsTitle"/> instance.</returns>
     public ApexChartsTitle FontWeight(string fontWeight) {
         Style["fontWeight"] = fontWeight;
         return this;
     }
 }
 
+/// <summary>
+/// Builder for configuring a chart subtitle.
+/// </summary>
 public class ApexChartSubtitle {
+    /// <summary>
+    /// Gets or sets the subtitle text.
+    /// </summary>
     [JsonPropertyName("text")]
     public string? SubTitleText { get; set; }
+    /// <summary>
+    /// Gets or sets the subtitle alignment.
+    /// </summary>
     public string SubTitleAlign { get; set; } = "center";
+    /// <summary>
+    /// Gets the style dictionary applied to the subtitle.
+    /// </summary>
     public Dictionary<string, string> Style { get; set; } = new Dictionary<string, string>();
 
     /// <summary>
@@ -62,26 +111,51 @@ public class ApexChartSubtitle {
     [JsonIgnore]
     public bool IsSet => !string.IsNullOrEmpty(SubTitleText);
 
+    /// <summary>
+    /// Sets the subtitle text.
+    /// </summary>
+    /// <param name="text">Text to display.</param>
+    /// <returns>The current <see cref="ApexChartSubtitle"/> instance.</returns>
     public ApexChartSubtitle Text(string text) {
         SubTitleText = text;
         return this;
     }
 
+    /// <summary>
+    /// Sets the subtitle color using a CSS value.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="ApexChartSubtitle"/> instance.</returns>
     public ApexChartSubtitle Color(string color) {
         Style["color"] = color;
         return this;
     }
 
+    /// <summary>
+    /// Sets the subtitle color from an <see cref="RGBColor"/> instance.
+    /// </summary>
+    /// <param name="color">Color value.</param>
+    /// <returns>The current <see cref="ApexChartSubtitle"/> instance.</returns>
     public ApexChartSubtitle Color(RGBColor color) {
         Style["color"] = color.ToHex();
         return this;
     }
 
+    /// <summary>
+    /// Sets the subtitle font size.
+    /// </summary>
+    /// <param name="fontSize">Size value with units.</param>
+    /// <returns>The current <see cref="ApexChartSubtitle"/> instance.</returns>
     public ApexChartSubtitle FontSize(string fontSize) {
         Style["fontSize"] = fontSize;
         return this;
     }
 
+    /// <summary>
+    /// Sets the subtitle font weight.
+    /// </summary>
+    /// <param name="fontWeight">Font weight value.</param>
+    /// <returns>The current <see cref="ApexChartSubtitle"/> instance.</returns>
     public ApexChartSubtitle FontWeight(string fontWeight) {
         Style["fontWeight"] = fontWeight;
         return this;

--- a/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexChartsType.cs
@@ -8,18 +8,31 @@ namespace HtmlForgeX;
 /// </summary>
 [JsonConverter(typeof(ApexChartTypeConverter))]
 public enum ApexChartType {
+    /// <summary>Pie chart.</summary>
     Pie,
+    /// <summary>Donut chart.</summary>
     Donut,
+    /// <summary>Bar chart.</summary>
     Bar,
+    /// <summary>Radial bar chart.</summary>
     RadialBar,
+    /// <summary>Area chart.</summary>
     Area,
+    /// <summary>Treemap chart.</summary>
     Treemap,
+    /// <summary>Heatmap chart.</summary>
     Heatmap,
+    /// <summary>Radar chart.</summary>
     Radar,
+    /// <summary>Mixed chart.</summary>
     Mixed
 }
 
+/// <summary>
+/// JSON converter used to serialize <see cref="ApexChartType"/> values.
+/// </summary>
 public class ApexChartTypeConverter : JsonConverter<ApexChartType> {
+    /// <inheritdoc />
     public override ApexChartType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
 
@@ -37,6 +50,7 @@ public class ApexChartTypeConverter : JsonConverter<ApexChartType> {
         };
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, ApexChartType value, JsonSerializerOptions options) {
         var stringValue = value switch {
             ApexChartType.Pie => "pie",

--- a/HtmlForgeX/Containers/ApexCharts/ApexGridOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexGridOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Grid related options controlling layout around the chart.
+/// </summary>
 public class ApexGridOptions {
+    /// <summary>
+    /// Gets or sets padding around the chart area.
+    /// </summary>
     [JsonPropertyName("padding")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ApexGridPadding? Padding { get; set; }
 
+    /// <summary>
+    /// Configures the padding values using a fluent builder.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure padding.</param>
+    /// <returns>The current <see cref="ApexGridOptions"/> instance.</returns>
     public ApexGridOptions PaddingOptions(Action<ApexGridPadding> configure) {
         Padding ??= new ApexGridPadding();
         configure(Padding);

--- a/HtmlForgeX/Containers/ApexCharts/ApexGridPadding.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexGridPadding.cs
@@ -2,43 +2,83 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Padding configuration applied to the grid surrounding the chart.
+/// </summary>
 public class ApexGridPadding {
+    /// <summary>
+    /// Gets or sets the padding above the chart area.
+    /// </summary>
     [JsonPropertyName("top")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Top { get; set; }
 
+    /// <summary>
+    /// Gets or sets the padding on the right side of the chart area.
+    /// </summary>
     [JsonPropertyName("right")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Right { get; set; }
 
+    /// <summary>
+    /// Gets or sets the padding below the chart area.
+    /// </summary>
     [JsonPropertyName("bottom")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Bottom { get; set; }
 
+    /// <summary>
+    /// Gets or sets the padding on the left side of the chart area.
+    /// </summary>
     [JsonPropertyName("left")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Left { get; set; }
 
+    /// <summary>
+    /// Sets the top padding value.
+    /// </summary>
+    /// <param name="value">Padding in pixels.</param>
+    /// <returns>The current <see cref="ApexGridPadding"/> instance.</returns>
     public ApexGridPadding TopPadding(int value) {
         Top = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the right padding value.
+    /// </summary>
+    /// <param name="value">Padding in pixels.</param>
+    /// <returns>The current <see cref="ApexGridPadding"/> instance.</returns>
     public ApexGridPadding RightPadding(int value) {
         Right = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the bottom padding value.
+    /// </summary>
+    /// <param name="value">Padding in pixels.</param>
+    /// <returns>The current <see cref="ApexGridPadding"/> instance.</returns>
     public ApexGridPadding BottomPadding(int value) {
         Bottom = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets the left padding value.
+    /// </summary>
+    /// <param name="value">Padding in pixels.</param>
+    /// <returns>The current <see cref="ApexGridPadding"/> instance.</returns>
     public ApexGridPadding LeftPadding(int value) {
         Left = value;
         return this;
     }
 
+    /// <summary>
+    /// Sets all padding values to the same amount.
+    /// </summary>
+    /// <param name="value">Padding in pixels.</param>
+    /// <returns>The current <see cref="ApexGridPadding"/> instance.</returns>
     public ApexGridPadding All(int value) {
         Top = value;
         Right = value;

--- a/HtmlForgeX/Containers/ApexCharts/ApexHeatmapData.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexHeatmapData.cs
@@ -2,10 +2,19 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a single point within a heatmap series.
+/// </summary>
 public class ApexHeatmapData {
+    /// <summary>
+    /// Gets or sets the X axis value for the heatmap point.
+    /// </summary>
     [JsonPropertyName("x")]
     public string X { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the Y axis value for the heatmap point.
+    /// </summary>
     [JsonPropertyName("y")]
     public double Y { get; set; }
 }

--- a/HtmlForgeX/Containers/ApexCharts/ApexHeatmapOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexHeatmapOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Configuration options specific to heatmap charts.
+/// </summary>
 public class ApexHeatmapOptions {
+    /// <summary>
+    /// Gets or sets the radius applied to heatmap points.
+    /// </summary>
     [JsonPropertyName("radius")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? Radius { get; set; }
 
+    /// <summary>
+    /// Sets the radius value for the heatmap points.
+    /// </summary>
+    /// <param name="radius">Radius of each point.</param>
+    /// <returns>The current <see cref="ApexHeatmapOptions"/> instance.</returns>
     public ApexHeatmapOptions RadiusValue(double radius) {
         Radius = radius;
         return this;

--- a/HtmlForgeX/Containers/ApexCharts/ApexHeatmapSeries.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexHeatmapSeries.cs
@@ -3,10 +3,19 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a collection of data points for a single heatmap series.
+/// </summary>
 public class ApexHeatmapSeries {
+    /// <summary>
+    /// Gets or sets the name of the series.
+    /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets the list of <see cref="ApexHeatmapData"/> points belonging to this series.
+    /// </summary>
     [JsonPropertyName("data")]
     public List<ApexHeatmapData> Data { get; set; } = new();
 }

--- a/HtmlForgeX/Containers/ApexCharts/ApexLegendOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexLegendOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Options controlling the chart legend display.
+/// </summary>
 public class ApexLegendOptions {
+    /// <summary>
+    /// Gets or sets a value indicating whether the legend is visible.
+    /// </summary>
     [JsonPropertyName("show")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Show { get; set; }
 
+    /// <summary>
+    /// Enables or disables the legend.
+    /// </summary>
+    /// <param name="value">Whether to show the legend.</param>
+    /// <returns>The current <see cref="ApexLegendOptions"/> instance.</returns>
     public ApexLegendOptions ShowLegend(bool value) {
         Show = value;
         return this;

--- a/HtmlForgeX/Containers/ApexCharts/ApexPlotOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexPlotOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Container for per-chart-type plot options.
+/// </summary>
 public class ApexPlotOptions {
+    /// <summary>
+    /// Gets or sets heatmap specific configuration.
+    /// </summary>
     [JsonPropertyName("heatmap")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ApexHeatmapOptions? Heatmap { get; set; }
 
+    /// <summary>
+    /// Configures heatmap options via a delegate.
+    /// </summary>
+    /// <param name="configure">Delegate used to configure heatmap options.</param>
+    /// <returns>The current <see cref="ApexPlotOptions"/> instance.</returns>
     public ApexPlotOptions HeatmapOptions(Action<ApexHeatmapOptions> configure) {
         Heatmap ??= new ApexHeatmapOptions();
         configure(Heatmap);

--- a/HtmlForgeX/Containers/ApexCharts/ApexThemeMode.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexThemeMode.cs
@@ -3,13 +3,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Theme modes supported by ApexCharts.
+/// </summary>
 [JsonConverter(typeof(ApexThemeModeConverter))]
 public enum ApexThemeMode {
+    /// <summary>Light theme mode.</summary>
     Light,
+    /// <summary>Dark theme mode.</summary>
     Dark
 }
 
+/// <summary>
+/// JSON converter used to serialize <see cref="ApexThemeMode"/> values.
+/// </summary>
 public class ApexThemeModeConverter : JsonConverter<ApexThemeMode> {
+    /// <inheritdoc />
     public override ApexThemeMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value switch {
@@ -19,6 +28,7 @@ public class ApexThemeModeConverter : JsonConverter<ApexThemeMode> {
         };
     }
 
+    /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, ApexThemeMode value, JsonSerializerOptions options) {
         var stringValue = value switch {
             ApexThemeMode.Light => "light",

--- a/HtmlForgeX/Containers/ApexCharts/ApexThemeOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexThemeOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Theme related configuration for ApexCharts.
+/// </summary>
 public class ApexThemeOptions {
+    /// <summary>
+    /// Gets or sets the theme mode to apply.
+    /// </summary>
     [JsonPropertyName("mode")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ApexThemeMode? Mode { get; set; }
 
+    /// <summary>
+    /// Sets the desired <see cref="ApexThemeMode"/>.
+    /// </summary>
+    /// <param name="mode">Theme mode value.</param>
+    /// <returns>The current <see cref="ApexThemeOptions"/> instance.</returns>
     public ApexThemeOptions ModeValue(ApexThemeMode mode) {
         Mode = mode;
         return this;

--- a/HtmlForgeX/Containers/ApexCharts/ApexTooltipOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexTooltipOptions.cs
@@ -2,11 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Options controlling tooltip behaviour.
+/// </summary>
 public class ApexTooltipOptions {
+    /// <summary>
+    /// Gets or sets a value indicating whether tooltips are enabled.
+    /// </summary>
     [JsonPropertyName("enabled")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Enabled { get; set; }
 
+    /// <summary>
+    /// Enables or disables tooltips.
+    /// </summary>
+    /// <param name="enabled">True to enable tooltips.</param>
+    /// <returns>The current <see cref="ApexTooltipOptions"/> instance.</returns>
     public ApexTooltipOptions Enable(bool enabled) {
         Enabled = enabled;
         return this;


### PR DESCRIPTION
## Summary
- add missing XML comments for ApexCharts classes and enums
- document heatmap options and grid options
- flesh out title and subtitle builders

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68754a75c540832e944ee9e86661d7b6