### PR TITLE
Add docs to more Tabler components

### DIFF
--- a/HtmlForgeX/Containers/Tabler/Enums/HrTextAlignment.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/HrTextAlignment.cs
@@ -4,14 +4,23 @@ namespace HtmlForgeX;
 /// Specifies horizontal rule text alignment options.
 /// </summary>
 public enum HrTextAlignment {
+    /// <summary>
+    /// Center the text within the horizontal rule.
+    /// </summary>
     Center,
+    /// <summary>
+    /// Left-align the text within the horizontal rule.
+    /// </summary>
     Left,
+    /// <summary>
+    /// Right-align the text within the horizontal rule.
+    /// </summary>
     Right
 }
 
 public static class HrTextAlignmentExtensions {
     /// <summary>
-    /// Initializes or configures ToClassString.
+    /// Converts the <see cref="HrTextAlignment"/> value to a CSS class string.
     /// </summary>
     public static string ToClassString(this HrTextAlignment alignment) {
         return alignment switch {

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerTextAlignment.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerTextAlignment.cs
@@ -4,14 +4,23 @@ namespace HtmlForgeX;
 /// Describes text alignment classes.
 /// </summary>
 public enum TextAlignment {
+    /// <summary>
+    /// Aligns text to the center.
+    /// </summary>
     Center,
+    /// <summary>
+    /// Aligns text to the left.
+    /// </summary>
     Left,
+    /// <summary>
+    /// Aligns text to the right.
+    /// </summary>
     Right
 }
 
 public static class TextAlignmentExtensions {
     /// <summary>
-    /// Initializes or configures ToClassString.
+    /// Converts the <see cref="TextAlignment"/> value to a CSS class string.
     /// </summary>
     public static string ToClassString(this TextAlignment alignment) {
         return alignment switch {

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerTextStyle.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerTextStyle.cs
@@ -4,14 +4,20 @@ namespace HtmlForgeX;
 /// Defines additional text style utilities.
 /// </summary>
 public enum TablerTextStyle {
+    /// <summary>
+    /// Render the text in a muted color.
+    /// </summary>
     Muted,
+    /// <summary>
+    /// Truncate the text and add an ellipsis when it overflows.
+    /// </summary>
     Truncate
     // Add more options here as needed
 }
 
 public static class TextStyleExtensions {
     /// <summary>
-    /// Initializes or configures EnumToString.
+    /// Converts the style enum value to the corresponding CSS class.
     /// </summary>
     public static string EnumToString(this TablerTextStyle style) {
         return "text-" + style.ToString().ToLower();

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerToastPosition.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerToastPosition.cs
@@ -4,10 +4,28 @@ namespace HtmlForgeX;
 /// TablerToastPosition enumeration.
 /// </summary>
 public enum TablerToastPosition {
+    /// <summary>
+    /// Display the toast in the top left corner.
+    /// </summary>
     TopLeft,
+    /// <summary>
+    /// Display the toast in the top center of the screen.
+    /// </summary>
     TopCenter,
+    /// <summary>
+    /// Display the toast in the top right corner.
+    /// </summary>
     TopRight,
+    /// <summary>
+    /// Display the toast in the bottom left corner.
+    /// </summary>
     BottomLeft,
+    /// <summary>
+    /// Display the toast in the bottom center of the screen.
+    /// </summary>
     BottomCenter,
+    /// <summary>
+    /// Display the toast in the bottom right corner.
+    /// </summary>
     BottomRight
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerToastType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerToastType.cs
@@ -4,9 +4,24 @@ namespace HtmlForgeX;
 /// TablerToastType enumeration.
 /// </summary>
 public enum TablerToastType {
+    /// <summary>
+    /// No specific styling is applied.
+    /// </summary>
     Default,
+    /// <summary>
+    /// Indicates a successful action.
+    /// </summary>
     Success,
+    /// <summary>
+    /// Draws the user's attention to a warning.
+    /// </summary>
     Warning,
+    /// <summary>
+    /// Highlights an error or critical message.
+    /// </summary>
     Danger,
+    /// <summary>
+    /// Provides informational context.
+    /// </summary>
     Info
 }

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerForm.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerForm.cs
@@ -6,8 +6,11 @@ namespace HtmlForgeX;
 
 public class TablerForm : Element {
     /// <summary>
-    /// Initializes or configures Input.
+    /// Adds a standard input element to the form.
     /// </summary>
+    /// <param name="name">Name and identifier of the input.</param>
+    /// <param name="config">Optional configuration callback.</param>
+    /// <returns>The created <see cref="TablerInput"/>.</returns>
     public TablerInput Input(string name, Action<TablerInput>? config = null) {
         var input = new TablerInput(name);
         config?.Invoke(input);
@@ -16,8 +19,11 @@ public class TablerForm : Element {
     }
 
     /// <summary>
-    /// Initializes or configures Select.
+    /// Adds a select element to the form.
     /// </summary>
+    /// <param name="name">Name and identifier of the select.</param>
+    /// <param name="config">Optional configuration callback.</param>
+    /// <returns>The created <see cref="TablerSelect"/>.</returns>
     public TablerSelect Select(string name, Action<TablerSelect>? config = null) {
         var select = new TablerSelect(name);
         config?.Invoke(select);
@@ -26,8 +32,11 @@ public class TablerForm : Element {
     }
 
     /// <summary>
-    /// Initializes or configures InputMask.
+    /// Adds an input mask element to the form.
     /// </summary>
+    /// <param name="name">Name and identifier of the mask.</param>
+    /// <param name="config">Optional configuration callback.</param>
+    /// <returns>The created <see cref="TablerInputMask"/>.</returns>
     public TablerInputMask InputMask(string name, Action<TablerInputMask>? config = null) {
         var mask = new TablerInputMask(name);
         config?.Invoke(mask);
@@ -36,7 +45,7 @@ public class TablerForm : Element {
     }
 
     /// <summary>
-    /// Initializes or configures ToString.
+    /// Generates the HTML markup for the form and its child elements.
     /// </summary>
     public override string ToString() {
         var form = new HtmlTag("form").Class("card");

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerFormEnums.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerFormEnums.cs
@@ -4,14 +4,23 @@ namespace HtmlForgeX;
 /// TablerFormEnums enumeration.
 /// </summary>
 public enum InputType {
+    /// <summary>Standard single-line text input.</summary>
     Text,
+    /// <summary>Email address input field.</summary>
     Email,
+    /// <summary>Password input field.</summary>
     Password,
+    /// <summary>Numeric input field.</summary>
     Number,
+    /// <summary>Date picker field.</summary>
     Date,
+    /// <summary>Time picker field.</summary>
     Time,
+    /// <summary>File selection input.</summary>
     File,
+    /// <summary>Telephone number input.</summary>
     Tel,
+    /// <summary>URL input field.</summary>
     Url
 }
 
@@ -19,14 +28,17 @@ public enum InputType {
 /// TablerFormEnums enumeration.
 /// </summary>
 public enum ValidationState {
+    /// <summary>Input is valid.</summary>
     Valid,
+    /// <summary>Input is invalid.</summary>
     Invalid,
+    /// <summary>Input has a warning state.</summary>
     Warning
 }
 
 public static class InputTypeExtensions {
     /// <summary>
-    /// Initializes or configures ToInputString.
+    /// Converts the <see cref="InputType"/> value to its HTML <c>type</c> attribute value.
     /// </summary>
     public static string ToInputString(this InputType type) => type switch {
         InputType.Text => "text",
@@ -44,7 +56,7 @@ public static class InputTypeExtensions {
 
 public static class ValidationStateExtensions {
     /// <summary>
-    /// Initializes or configures ToInputClass.
+    /// Returns the CSS class name that represents the validation state for an input element.
     /// </summary>
     public static string ToInputClass(this ValidationState state) => state switch {
         ValidationState.Valid => "is-valid",
@@ -54,7 +66,7 @@ public static class ValidationStateExtensions {
     };
 
     /// <summary>
-    /// Initializes or configures ToFeedbackClass.
+    /// Returns the CSS class name used for validation feedback elements.
     /// </summary>
     public static string ToFeedbackClass(this ValidationState state) => state switch {
         ValidationState.Valid => "valid-feedback",

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerInput.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerInput.cs
@@ -22,32 +22,45 @@ public class TablerInput : Element {
     }
 
     /// <summary>
-    /// Initializes or configures Type.
+    /// Sets the HTML <c>type</c> attribute for the input element.
     /// </summary>
+    /// <param name="type">The input type to use.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Type(InputType type) { _type = type; return this; }
     /// <summary>
-    /// Initializes or configures Label.
+    /// Sets the label text displayed above the input.
     /// </summary>
+    /// <param name="text">The label text.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Label(string text) { _label = text; return this; }
     /// <summary>
-    /// Initializes or configures Placeholder.
+    /// Sets the placeholder text for the input element.
     /// </summary>
+    /// <param name="text">The placeholder text.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Placeholder(string text) { _placeholder = text; return this; }
     /// <summary>
-    /// Initializes or configures Required.
+    /// Marks the input as required.
     /// </summary>
+    /// <param name="required">Whether the input is required.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Required(bool required = true) { _required = required; return this; }
     /// <summary>
-    /// Initializes or configures Icon.
+    /// Adds an icon to the input element.
     /// </summary>
+    /// <param name="icon">Icon to display inside the input.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Icon(TablerIconType icon) { _icon = icon; return this; }
     /// <summary>
-    /// Initializes or configures Validation.
+    /// Sets validation state and message for the input element.
     /// </summary>
+    /// <param name="state">Validation state.</param>
+    /// <param name="message">Message shown below the input.</param>
+    /// <returns>The current <see cref="TablerInput"/> instance.</returns>
     public TablerInput Validation(ValidationState state, string message) { _state = state; _message = message; return this; }
 
     /// <summary>
-    /// Initializes or configures ToString.
+    /// Generates the HTML markup for the input element and its wrapper.
     /// </summary>
     public override string ToString() {
         var wrapper = new HtmlTag("div").Class("mb-3");

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerInputMask.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerInputMask.cs
@@ -21,6 +21,9 @@ public class TablerInputMask : Element {
     /// </summary>
     public TablerInputMask Pattern(string pattern) { _pattern = pattern; return this; }
 
+    /// <summary>
+    /// Ensures required JavaScript libraries for input masking are registered.
+    /// </summary>
     protected internal override void RegisterLibraries() {
         Document?.Configuration.Libraries.TryAdd(Libraries.IMask, 0);
     }

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerSelect.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerSelect.cs
@@ -18,29 +18,43 @@ public class TablerSelect : Element {
     }
 
     /// <summary>
-    /// Initializes or configures Label.
+    /// Sets the label text displayed above the select element.
     /// </summary>
+    /// <param name="text">The label text.</param>
+    /// <returns>The current <see cref="TablerSelect"/> instance.</returns>
     public TablerSelect Label(string text) { _label = text; return this; }
     /// <summary>
-    /// Initializes or configures Multiple.
+    /// Allows multiple items to be selected.
     /// </summary>
+    /// <param name="multiple">Whether multiple selection is enabled.</param>
+    /// <returns>The current <see cref="TablerSelect"/> instance.</returns>
     public TablerSelect Multiple(bool multiple = true) { _multiple = multiple; return this; }
     /// <summary>
-    /// Initializes or configures Searchable.
+    /// Enables client-side search functionality for the select element.
     /// </summary>
+    /// <param name="enable">Whether search should be enabled.</param>
+    /// <returns>The current <see cref="TablerSelect"/> instance.</returns>
     public TablerSelect Searchable(bool enable = true) { _searchable = enable; return this; }
     /// <summary>
-    /// Initializes or configures Option.
+    /// Adds a selectable option.
     /// </summary>
+    /// <param name="text">Display text for the option.</param>
+    /// <param name="value">Value submitted when the option is selected.</param>
+    /// <returns>The current <see cref="TablerSelect"/> instance.</returns>
     public TablerSelect Option(string text, string value) { _options.Add((value, text)); return this; }
     /// <summary>
-    /// Initializes or configures Options.
+    /// Adds multiple options based on the provided collection of values.
     /// </summary>
+    /// <param name="values">Values to use for both option text and value.</param>
+    /// <returns>The current <see cref="TablerSelect"/> instance.</returns>
     public TablerSelect Options(IEnumerable<string> values) {
         foreach (var v in values) { _options.Add((v, v)); }
         return this;
     }
 
+    /// <summary>
+    /// Registers any required JavaScript libraries for enhanced select controls.
+    /// </summary>
     protected internal override void RegisterLibraries() {
         if (_searchable) {
             Document?.Configuration.Libraries.TryAdd(Libraries.TomSelect, 0);
@@ -48,7 +62,7 @@ public class TablerSelect : Element {
     }
 
     /// <summary>
-    /// Initializes or configures ToString.
+    /// Generates the HTML markup for the select element and associated script.
     /// </summary>
     public override string ToString() {
         var wrapper = new HtmlTag("div").Class("mb-3");

--- a/HtmlForgeX/Containers/Tabler/TablerAccordionItem.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAccordionItem.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a single item within a Tabler accordion component.
+/// </summary>
 public class TablerAccordionItem : Element {
     private string TitleElement { get; set; }
     private Element ContentElement { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerAvatar.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAvatar.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Displays an avatar image or icon with optional styling.
+/// </summary>
 public class TablerAvatar : Element {
     private string ValueEntry { get; set; } = "";
     private string ImageUrl { get; set; } = "";

--- a/HtmlForgeX/Containers/Tabler/TablerBadgeButton.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerBadgeButton.cs
@@ -1,8 +1,22 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Renders a button element with a colored badge next to the text.
+/// </summary>
 public class TablerBadgeButton : Element {
+    /// <summary>
+    /// Gets or sets the main button label.
+    /// </summary>
     public new string Text { get; set; }
+
+    /// <summary>
+    /// Gets or sets the badge text displayed next to the label.
+    /// </summary>
     public string BadgeText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the badge background color.
+    /// </summary>
     public TablerColor BadgeColor { get; set; }
 
     /// <summary>

--- a/HtmlForgeX/Containers/Tabler/TablerBadgeLink.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerBadgeLink.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Generates an anchor element styled as a badge.
+/// </summary>
 public class TablerBadgeLink : Element {
     private new string Text { get; set; }
     private string Href {

--- a/HtmlForgeX/Containers/Tabler/TablerBadgeSpan.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerBadgeSpan.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a badge styled <c>span</c> element.
+/// </summary>
 public class TablerBadgeSpan : Element {
     public new string Text { get; set; }
     public TablerColor? Color { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerCard.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCard.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Provides a fluent API for building Tabler-styled card components.
+/// </summary>
 public class TablerCard : Element {
     private TablerCardFooter PrivateFooter { get; set; } = new TablerCardFooter();
     private TablerCardHeader? PrivateHeader { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
@@ -4,7 +4,13 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents the footer section of a Tabler card.
+/// </summary>
 public class TablerCardFooter : Element {
+    /// <summary>
+    /// Gets or sets optional footer text content.
+    /// </summary>
     public string? Content { get; set; }
 
     /// <summary>

--- a/HtmlForgeX/Containers/Tabler/TablerTabs.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTabs.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Provides a tabbed card component containing multiple panels.
+/// </summary>
 public class TablerTabs : Element {
     public List<TablerTabsPanel> Panels { get; set; } = new List<TablerTabsPanel>();
     private string Id { get; } = GlobalStorage.GenerateRandomId("tabs");

--- a/HtmlForgeX/Containers/Tabler/TablerTabsPanel.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTabsPanel.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a single panel within a <see cref="TablerTabs"/> component.
+/// </summary>
 public class TablerTabsPanel : ElementContainer {
     internal string Id { get; } = GlobalStorage.GenerateRandomId("tabsPanel");
     internal string PrivateTitle { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerToast.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerToast.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Helper for rendering Tabler toast notifications.
+/// </summary>
 public class TablerToast : Element {
     private string Id { get; } = GlobalStorage.GenerateRandomId("toast");
     private string PrivateTitle { get; set; } = string.Empty;

--- a/HtmlForgeX/Containers/Tabler/TablerTrackingBlock.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTrackingBlock.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Small colored block used for visual tracking indicators.
+/// </summary>
 public class TablerTrackingBlock : Element {
     private string TooltipTitle { get; set; }
     private TablerColor PrivateTrackingColor { get; set; }


### PR DESCRIPTION
## Summary
- document more Tabler classes like BadgeButton, BadgeLink and others
- expand XML comments for additional card and tab components

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68754e3172b0832ead83619d5f3a085d