### PR TITLE
Add missing XML documentation for public types

### DIFF
--- a/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
+++ b/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Renders an HTML table styled using Bootstrap classes.
+/// </summary>
 public class BootstrapTable : Table {
     /// <summary>
     /// Gets the unique identifier of the table element.

--- a/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Common font-weight values mapped to numeric CSS representations.
+/// </summary>
 public enum FontWeight {
     /// <summary>Thin text (100)</summary>
     Thin,

--- a/HtmlForgeX/Containers/Core/HeaderLevel.cs
+++ b/HtmlForgeX/Containers/Core/HeaderLevel.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents an HTML header element (<c>h1</c> - <c>h6</c>).
+/// </summary>
 public class HeaderLevel : Element {
     private HeaderLevelTag PrivateTag { get; }
 

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -9,6 +9,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Provides functionality for generating HTML tables.
+/// </summary>
 public class Table : Element {
     private readonly TableType? Library;
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();

--- a/HtmlForgeX/Containers/DataTables/DataTablesLanguage.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesLanguage.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Localization strings for DataTables user interface elements.
+/// </summary>
 public class DataTablesLanguage
 {
     [JsonPropertyName("search")]

--- a/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Configuration options for the DataTables JavaScript plugin.
+/// </summary>
 public class DataTablesOptions
 {
     [JsonPropertyName("pageLength")]

--- a/HtmlForgeX/Containers/DataTables/DataTablesPaginate.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesPaginate.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Text for pagination navigation in DataTables.
+/// </summary>
 public class DataTablesPaginate
 {
     [JsonPropertyName("first")]

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
@@ -24,6 +24,9 @@ public enum FullCalendarViewOption {
     ListDay
 }
 
+/// <summary>
+/// Defines settings for how a view is presented within FullCalendar.
+/// </summary>
 public class FullCalendarView {
     /// <summary>
     /// Gets or sets the text shown on the corresponding toolbar button.

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerForm.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerForm.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Form container that provides fluent APIs for building Tabler forms.
+/// </summary>
 public class TablerForm : Element {
     /// <summary>
     /// Adds a standard input element to the form.

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerInput.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerInput.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Generic form input element styled with Tabler classes.
+/// </summary>
 public class TablerInput : Element {
     private readonly string _name;
     private InputType _type = InputType.Text;

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerInputMask.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerInputMask.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Input element that uses IMask for client-side input masking.
+/// </summary>
 public class TablerInputMask : Element {
     private readonly string _name;
     private string? _label;

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerSelect.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerSelect.cs
@@ -3,6 +3,9 @@ using System.Linq;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Dropdown/select element styled for the Tabler framework.
+/// </summary>
 public class TablerSelect : Element {
     private readonly string _name;
     private string? _label;

--- a/HtmlForgeX/Containers/Tabler/TablerAccordion.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAccordion.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Accordion container composed of expandable TablerAccordionItem elements.
+/// </summary>
 public class TablerAccordion : Element {
     public List<TablerAccordionItem> Items { get; set; } = new List<TablerAccordionItem>();
     private string Id { get; } = GlobalStorage.GenerateRandomId("accordion");

--- a/HtmlForgeX/Containers/Tabler/TablerAlerts.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerAlerts.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Component for displaying alert messages in Tabler style.
+/// </summary>
 public class TablerAlert : Element {
     private string Title { get; }
     private string Message { get; }

--- a/HtmlForgeX/Containers/Tabler/TablerCardBasic.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardBasic.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Base card component for presenting content within the Tabler UI framework.
+/// </summary>
 public class TablerCardBasic : Element {
     private string? PrivateCardStyle { get; set; }
     private string SubHeaderText { get; set; } = "";

--- a/HtmlForgeX/Containers/Tabler/TablerCardMini.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardMini.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Compact version of <see cref="TablerCard"/> typically used for dashboard widgets.
+/// </summary>
 public class TablerCardMini : TablerCard {
     private string? PrivateCardStyle { get; set; }
     private TablerIconType AvatarIcon { get; set; } = TablerIconType.Badge;

--- a/HtmlForgeX/Containers/Tabler/TablerColumn.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerColumn.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Responsive column container for arranging <see cref="TablerCard"/> elements.
+/// </summary>
 public class TablerColumn : Element {
     public List<TablerCard> Cards { get; set; } = new List<TablerCard>();
     public string? Class { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerDivider.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerDivider.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Horizontal divider with optional text using Tabler styling.
+/// </summary>
 public class TablerDivider : Element {
     private string Text { get; }
     private HrTextAlignment Alignment { get; }

--- a/HtmlForgeX/Containers/Tabler/TablerLegendItem.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerLegendItem.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a legend entry consisting of a colored indicator and label.
+/// </summary>
 public class TablerLegendItem : Element {
     private string Name { get; set; }
     private string Value { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerList.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerList.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Simple unordered list rendered with Tabler styles.
+/// </summary>
 public class UnorderedList : Element {
     private HtmlTag ulTag;
     private HtmlTag liTag;

--- a/HtmlForgeX/Containers/Tabler/TablerLogs.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerLogs.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Displays code or log snippets with optional themed styling.
+/// </summary>
 public class TablerLogs : Element {
     private HeaderLevelTag? PrivateLevelTitle { get; set; }
     private string? PrivateTitle { get; set; }

--- a/HtmlForgeX/Containers/Tabler/TablerPage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerPage.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Root container for constructing a Tabler-based page layout.
+/// </summary>
 public class TablerPage : Element {
     /// <summary>
     /// Initializes or configures TablerPage.

--- a/HtmlForgeX/Containers/Tabler/TablerSteps.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerSteps.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Step indicator component for progressive workflows.
+/// </summary>
 public class TablerSteps : Element {
     private StepsOrientation PrivateOrientation { get; set; } = StepsOrientation.Horizontal;
     private bool PrivateStepCounting { get; set; } = false;
@@ -120,6 +123,9 @@ public class TablerSteps : Element {
 }
 
 
+/// <summary>
+/// Represents a single step within a <see cref="TablerSteps"/> component.
+/// </summary>
 public class TablerStepItem : Element {
     private string Name { get; set; } = "";
     private new string Text { get; set; } = "";

--- a/HtmlForgeX/Containers/Tabler/TablerTable.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTable.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Specialized table control using Tabler and Bootstrap styles.
+/// </summary>
 public class TablerTable : Table {
     public string Id;
     public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();

--- a/HtmlForgeX/Containers/Tabler/TablerText.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerText.cs
@@ -1,5 +1,8 @@
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a text element styled using Tabler CSS classes.
+/// </summary>
 public class TablerText : Element {
     /// <summary>
     /// Initializes or configures TablerText.

--- a/HtmlForgeX/Containers/Tabler/TablerTimeline.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTimeline.cs
@@ -2,6 +2,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Container for displaying a sequence of events using Tabler styling.
+/// </summary>
 public class TablerTimeline : Element {
     private readonly List<TablerTimelineItem> _items = new();
 
@@ -27,6 +30,9 @@ public class TablerTimeline : Element {
     }
 }
 
+/// <summary>
+/// Represents a single item displayed within a <see cref="TablerTimeline"/>.
+/// </summary>
 public class TablerTimelineItem : Element {
     private string? _time;
     private TablerIconType? _icon;

--- a/HtmlForgeX/Containers/Tabler/TablerTracking.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerTracking.cs
@@ -4,6 +4,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Visual representation of item progress using colored blocks.
+/// </summary>
 public class TablerTracking : Element {
     private List<TablerTrackingBlock> Blocks { get; set; } = new List<TablerTrackingBlock>();
 

--- a/HtmlForgeX/Library.cs
+++ b/HtmlForgeX/Library.cs
@@ -56,6 +56,9 @@ public enum Libraries {
     IMask
 }
 
+/// <summary>
+/// Represents metadata describing an external library or resource set.
+/// </summary>
 public class Library {
     /// <summary>Descriptive comment for the library.</summary>
     public string Comment { get; set; } = string.Empty;
@@ -79,6 +82,9 @@ public class Library {
     public bool Email { get; set; } = false;
 }
 
+/// <summary>
+/// Holds links and resources associated with a library.
+/// </summary>
 public class LibraryLinks {
     /// <summary>
     /// Link to styles hosted on CDN
@@ -118,6 +124,9 @@ public class LibraryLinks {
 
 }
 
+/// <summary>
+/// Utility methods for translating <see cref="Libraries"/> enum values into library objects.
+/// </summary>
 public class LibrariesConverter {
     public static Library MapLibraryEnumToLibraryObject(Libraries libraries) {
         switch (libraries) {

--- a/HtmlForgeX/Tags/Span.cs
+++ b/HtmlForgeX/Tags/Span.cs
@@ -3,6 +3,9 @@ using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
 
+/// <summary>
+/// Represents a <c>&lt;span&gt;</c> element with configurable styling options.
+/// </summary>
 public class Span : Element {
     /// <summary>Content of the span element.</summary>
     public string? Content { get; set; }

--- a/HtmlForgeX/Tags/TagBundle.cs
+++ b/HtmlForgeX/Tags/TagBundle.cs
@@ -112,4 +112,7 @@ public class EmSpace : Element {
     }
 }
 
+/// <summary>
+/// Represents an HTML <c>&lt;strong&gt;</c> tag used for emphasizing text.
+/// </summary>
 public class Strong(string value) : HtmlTag("strong", value);


### PR DESCRIPTION
## Summary
- add XML documentation comments to various public classes and enums across the library
- ensure every public type has top-level remarks for generated docs

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687563c8f52c832e8dbf6acb71920fed