### PR TITLE
Add documentation for enum extension classes

### DIFF
--- a/HtmlForgeX/Containers/Core/Enums/Alignment.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Alignment.cs
@@ -13,6 +13,9 @@ public enum Alignment {
     Justify
 }
 
+/// <summary>
+/// Extension methods for the <see cref="Alignment"/> enum.
+/// </summary>
 public static class AlignmentExtensions {
     public static string ToCssValue(this Alignment alignment) => alignment switch
     {

--- a/HtmlForgeX/Containers/Core/Enums/Display.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Display.cs
@@ -71,6 +71,9 @@ public enum Display {
     TableRow
 }
 
+/// <summary>
+/// Extension methods for the <see cref="Display"/> enum.
+/// </summary>
 public static class DisplayExtensions {
     public static string EnumToString(this Display value) {
         var fieldInfo = value.GetType().GetField(value.ToString());

--- a/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
@@ -8,6 +8,9 @@ public enum FontVariant {
     SmallCaps
 }
 
+/// <summary>
+/// Extension methods for the <see cref="FontVariant"/> enum.
+/// </summary>
 public static class FontVariantExtensions {
     /// <summary>
     /// Converts the variant to its CSS string.

--- a/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
@@ -24,6 +24,9 @@ public enum FontWeight {
     Black
 }
 
+/// <summary>
+/// Extension methods for the <see cref="FontWeight"/> enum.
+/// </summary>
 public static class FontWeightExtensions {
     public static string EnumToString(this FontWeight value) {
         return value switch {

--- a/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
+++ b/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
@@ -13,6 +13,9 @@ public enum HeaderLevelTag {
     H6
 }
 
+/// <summary>
+/// Extension methods for the <see cref="HeaderLevelTag"/> enum.
+/// </summary>
 public static class HeaderLevelTagExtensions {
     public static string EnumToString(this HeaderLevelTag tag) {
         return tag.ToString().ToLower();

--- a/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
@@ -20,6 +20,9 @@ public enum TextDecoration {
     Underline
 }
 
+/// <summary>
+/// Extension methods for the <see cref="TextDecoration"/> enum.
+/// </summary>
 public static class TextDecorationExtensions {
     public static string EnumToString(this TextDecoration value) {
         return value switch {


### PR DESCRIPTION
## Summary
- document enum extension helper classes used in Containers/Core

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68756ff07bc8832ebdb02a3357deabd0