### PR TITLE
Add XML docs for Tabler enums

### DIFF
--- a/HtmlForgeX/Containers/Tabler/Enums/AvatarSize.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/AvatarSize.cs
@@ -11,6 +11,9 @@ public enum AvatarSize {
     XL
 }
 
+/// <summary>
+/// Extension helpers for <see cref="AvatarSize"/> values.
+/// </summary>
 public static class AvatarSizeExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/HrTextAlignment.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/HrTextAlignment.cs
@@ -18,6 +18,9 @@ public enum HrTextAlignment {
     Right
 }
 
+/// <summary>
+/// Extension methods for <see cref="HrTextAlignment"/> values.
+/// </summary>
 public static class HrTextAlignmentExtensions {
     /// <summary>
     /// Converts the <see cref="HrTextAlignment"/> value to a CSS class string.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerAccordionType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerAccordionType.cs
@@ -30,6 +30,9 @@ public enum TablerAccordionType {
     Plus
 }
 
+/// <summary>
+/// Extension methods for <see cref="TablerAccordionType"/> values.
+/// </summary>
 public static class TablerAccordionTypeExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerBorder.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerBorder.cs
@@ -57,6 +57,9 @@ public enum TablerBorderRadius {
     Pill
 }
 
+/// <summary>
+/// Extension methods for Tabler border-related enums.
+/// </summary>
 public static class TablerBorderExtensions {
     /// <summary>
     /// Initializes or configures ToTablerBorderClass.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerCardStyles.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerCardStyles.cs
@@ -76,6 +76,9 @@ public enum TablerCardSize {
     Large
 }
 
+/// <summary>
+/// Extension methods for card style enums.
+/// </summary>
 public static class TablerCardStyleExtensions {
     /// <summary>
     /// Initializes or configures ToTablerCardStateClass.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
@@ -83,6 +83,9 @@ public enum TablerColor {
     Transparent
 }
 
+/// <summary>
+/// Helper methods for working with <see cref="TablerColor"/> values.
+/// </summary>
 public static class ColorExtensions {
     /// <summary>
     /// Initializes or configures ToTablerString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerColumnNumber.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerColumnNumber.cs
@@ -87,6 +87,9 @@ public enum TablerColumnNumber {
     SmallFourMediumFourLargeThreeExtraLargeTwo
 }
 
+/// <summary>
+/// Extension methods for <see cref="TablerColumnNumber"/> values.
+/// </summary>
 public static class ColumnNumberExtension {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerDataGridLayout.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerDataGridLayout.cs
@@ -64,6 +64,9 @@ public enum TablerDataGridTitleWidth {
     Custom
 }
 
+/// <summary>
+/// Extension helpers for Tabler DataGrid layout enums.
+/// </summary>
 public static class TablerDataGridLayoutExtensions {
     /// <summary>
     /// Gets the CSS classes for the specified layout.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerDataGridSpacing.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerDataGridSpacing.cs
@@ -20,6 +20,9 @@ public enum TablerDataGridSpacing {
     Custom
 }
 
+/// <summary>
+/// Extension helpers for <see cref="TablerDataGridSpacing"/> values.
+/// </summary>
 public static class TablerDataGridSpacingExtensions {
     /// <summary>
     /// Converts TablerDataGridSpacing to CSS value.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerLogsTheme.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerLogsTheme.cs
@@ -27,6 +27,9 @@ public enum TablerLogsTheme {
     Custom
 }
 
+/// <summary>
+/// Extension methods for <see cref="TablerLogsTheme"/> values.
+/// </summary>
 public static class TablerLogsThemeExtensions {
     /// <summary>
     /// Initializes or configures ToClassString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerMargin.cs
@@ -55,6 +55,9 @@ public enum TablerMargin {
     AllTriple
 }
 
+/// <summary>
+/// Extension helpers for <see cref="TablerMargin"/> values.
+/// </summary>
 public static class TablerMarginExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerMarginStyle.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerMarginStyle.cs
@@ -54,6 +54,9 @@ public enum TablerMarginStyle {
     MY5
 }
 
+/// <summary>
+/// Extension helpers for <see cref="TablerMarginStyle"/> values.
+/// </summary>
 public static class MarginStyleExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerPadding.cs
@@ -57,6 +57,9 @@ public enum TablerPadding {
 
 
 
+/// <summary>
+/// Extension helpers for <see cref="TablerPadding"/> values.
+/// </summary>
 public static class TablerPaddingExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerProgressBarType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerProgressBarType.cs
@@ -10,6 +10,9 @@ public enum TablerProgressBarType {
 }
 
 
+/// <summary>
+/// Extension helpers for <see cref="TablerProgressBarType"/> values.
+/// </summary>
 public static class TablerProgressBarTypeExtensions {
     /// <summary>
     /// Initializes or configures ToClassString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerRowType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerRowType.cs
@@ -9,6 +9,9 @@ public enum TablerRowType {
     Cards
 }
 
+/// <summary>
+/// Extension helpers for <see cref="TablerRowType"/> values.
+/// </summary>
 public static class TablerRowTypeExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerStepsOrientation.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerStepsOrientation.cs
@@ -13,6 +13,9 @@ public enum StepsOrientation {
 }
 
 
+/// <summary>
+/// Extension helpers for <see cref="StepsOrientation"/> values.
+/// </summary>
 public static class StepsOrientationExtensions {
     /// <summary>
     /// Initializes or configures EnumToString.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerTextAlignment.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerTextAlignment.cs
@@ -18,6 +18,9 @@ public enum TextAlignment {
     Right
 }
 
+/// <summary>
+/// Extension helpers for <see cref="TextAlignment"/> values.
+/// </summary>
 public static class TextAlignmentExtensions {
     /// <summary>
     /// Converts the <see cref="TextAlignment"/> value to a CSS class string.

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerTextStyle.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerTextStyle.cs
@@ -15,6 +15,9 @@ public enum TablerTextStyle {
     // Add more options here as needed
 }
 
+/// <summary>
+/// Extension methods for <see cref="TablerTextStyle"/> values.
+/// </summary>
 public static class TextStyleExtensions {
     /// <summary>
     /// Converts the style enum value to the corresponding CSS class.


### PR DESCRIPTION
## Summary
- document extension classes in `HtmlForgeX/Containers/Tabler/Enums`

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68756fc0c160832e9347ab0b33d05eec