### PR TITLE
Add doc comments for public types

### DIFF
--- a/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexCharts.cs
@@ -8,7 +8,8 @@ using System.Text.Json.Serialization;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents an ApexCharts component that can be embedded in the HTML output.
+/// Represents an ApexCharts component that can be embedded in the HTML output
+/// for displaying dynamic client-side charts.
 /// </summary>
 public class ApexCharts : Element {
     /// <summary>

--- a/HtmlForgeX/Containers/ApexCharts/ApexChartsTitle.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexChartsTitle.cs
@@ -5,7 +5,8 @@ using System.Text.Json.Serialization;
 
 namespace HtmlForgeX;
 /// <summary>
-/// Builder for configuring chart title appearance.
+/// Builder for configuring chart title appearance when using ApexCharts. Allows
+/// setting main titles and subtitles with styling.
 /// </summary>
 public class ApexChartsTitle {
     /// <summary>

--- a/HtmlForgeX/Containers/ApexCharts/ApexLegendOptions.cs
+++ b/HtmlForgeX/Containers/ApexCharts/ApexLegendOptions.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Options controlling the chart legend display.
+/// Options controlling the chart legend display when rendering ApexCharts
+/// graphs.
 /// </summary>
 public class ApexLegendOptions {
     /// <summary>

--- a/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
+++ b/HtmlForgeX/Containers/Bootstrap/BootstrapTable.cs
@@ -5,7 +5,8 @@ using System.Text;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Renders an HTML table styled using Bootstrap classes.
+/// Renders an HTML table styled using Bootstrap classes. Provides convenience
+/// properties for applying Bootstrap table utilities.
 /// </summary>
 public class BootstrapTable : Table {
     /// <summary>

--- a/HtmlForgeX/Containers/Core/BasicElement.cs
+++ b/HtmlForgeX/Containers/Core/BasicElement.cs
@@ -4,7 +4,8 @@ using HtmlForgeX.Extensions;
 namespace HtmlForgeX;
 
 /// <summary>
-/// A concrete implementation of Element for basic content containers.
+/// A concrete implementation of <see cref="Element"/> for basic content
+/// containers such as paragraphs or generic block containers.
 /// </summary>
 public class BasicElement : Element {
     /// <summary>

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -9,7 +9,8 @@ using HtmlForgeX.Extensions;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents an email document with XHTML 1.0 Strict compliance for email clients.
+/// Represents an email document with XHTML&nbsp;1.0 Strict compliance for email
+/// clients. Provides a simplified object model for generating HTML emails.
 /// </summary>
 public class Email : Element {
     private static readonly InternalLogger _logger = new();

--- a/HtmlForgeX/Containers/Core/EmailHead.cs
+++ b/HtmlForgeX/Containers/Core/EmailHead.cs
@@ -7,7 +7,9 @@ using HtmlForgeX.Logging;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents the head section of an email document with email-specific meta tags and styling.
+/// Represents the head section of an email document with email-specific meta
+/// tags and styling. This includes embedded CSS and viewport configuration used
+/// by email clients.
 /// </summary>
 public class EmailHead : Element {
     private static readonly InternalLogger _logger = new();

--- a/HtmlForgeX/Containers/Core/HeaderLevel.cs
+++ b/HtmlForgeX/Containers/Core/HeaderLevel.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents an HTML header element (<c>h1</c> - <c>h6</c>).
+/// Represents an HTML header element (<c>h1</c> through <c>h6</c>) with helper
+/// methods for setting common header attributes.
 /// </summary>
 public class HeaderLevel : Element {
     private HeaderLevelTag PrivateTag { get; }

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -10,7 +10,8 @@ using HtmlForgeX.Extensions;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Provides functionality for generating HTML tables.
+/// Provides functionality for generating HTML tables and populating them from
+/// model data.
 /// </summary>
 public class Table : Element {
     private readonly TableType? Library;

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -3,8 +3,9 @@ using System.Collections.Concurrent;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Configuration class for Document instances.
-/// Manages state, libraries, and settings for document generation.
+/// Configuration class for <see cref="Document"/> instances. It keeps track of
+/// library references, theme selection and output paths used when generating
+/// HTML documents.
 /// </summary>
 public class DocumentConfiguration {
     private readonly object _syncRoot = new();

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -7,6 +7,8 @@ using HtmlForgeX.Extensions;
 namespace HtmlForgeX;
 /// <summary>
 /// Represents a generic HTML tag that can contain attributes and child elements.
+/// This is the fundamental building block used when manually composing DOM
+/// structures with HtmlForgeX.
 /// </summary>
 public class HtmlTag : Element {
     private string PrivateTag { get; set; }

--- a/HtmlForgeX/Libraries/EmailLibrary.cs
+++ b/HtmlForgeX/Libraries/EmailLibrary.cs
@@ -1,8 +1,10 @@
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents an email library containing only inline CSS.
-/// Email libraries cannot contain external links or JavaScript for email client compatibility.
+/// Represents an email library containing only inline CSS. These
+/// libraries are tailored specifically for the restrictive environment
+/// of email clients and therefore do not include any external resources
+/// or JavaScript.
 /// </summary>
 public class EmailLibrary {
     /// <summary>

--- a/HtmlForgeX/Library.cs
+++ b/HtmlForgeX/Library.cs
@@ -3,9 +3,9 @@ using HtmlForgeX.Resources;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Enumeration of available libraries.
-/// Order is important, as it determines the order of the libraries in the HTML.
-/// Having JQuery first is important for other libraries that depend on it.
+/// Enumeration of available libraries that can be injected into generated
+/// documents. The order of values controls the default load order when
+/// rendering a page, so dependencies such as jQuery must appear first.
 /// </summary>
 public enum Libraries {
     /// <summary>No libraries.</summary>

--- a/HtmlForgeX/Logging/InternalLogger.cs
+++ b/HtmlForgeX/Logging/InternalLogger.cs
@@ -3,7 +3,9 @@ using System.Globalization;
 namespace HtmlForgeX.Logging;
 
 /// <summary>
-/// Internal logger that allows to write to console, error or wherever else is needed
+/// Simple logging facility used internally by the library to capture verbose
+/// or warning messages. Consumers can subscribe to expose logging information
+/// to their own infrastructure.
 /// </summary>
 public class InternalLogger {
     private readonly object _lock = new object();

--- a/HtmlForgeX/Logging/Settings.cs
+++ b/HtmlForgeX/Logging/Settings.cs
@@ -3,8 +3,9 @@ using System.Threading;
 namespace HtmlForgeX.Logging;
 
 /// <summary>
-/// Settings for the DnsClientX library.
-/// Provides interface for setting logging levels and number of threads to use.
+/// Configuration options for the logging subsystem.
+/// Allows callers to specify log verbosity and other diagnostics settings
+/// used throughout HtmlForgeX.
 /// </summary>
 public class Settings {
     /// <summary>

--- a/HtmlForgeX/Resources/ApexChartsLibrary.cs
+++ b/HtmlForgeX/Resources/ApexChartsLibrary.cs
@@ -5,7 +5,9 @@ using System.Text;
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata and asset links for the ApexCharts library.
+/// Provides metadata and asset links for the ApexCharts library used for
+/// rendering rich interactive charts. Includes links for both JavaScript and
+/// style dependencies.
 /// </summary>
 public class ApexChartsLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/Bootstrap.cs
+++ b/HtmlForgeX/Resources/Bootstrap.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata and asset links for the Bootstrap framework.
+/// Provides metadata and asset links for the Bootstrap framework which supplies
+/// a wide variety of responsive layout and component utilities.
 /// </summary>
 public class Bootstrap : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/ChartJsLibrary.cs
+++ b/HtmlForgeX/Resources/ChartJsLibrary.cs
@@ -3,7 +3,8 @@ using System;
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata and asset links for the Chart.js library.
+/// Provides metadata and asset links for the Chart.js library. Use this class
+/// when you want to include interactive charts and graphs in your document.
 /// </summary>
 public class ChartJsLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/EasyQRCode.cs
+++ b/HtmlForgeX/Resources/EasyQRCode.cs
@@ -5,7 +5,9 @@ using System.Text;
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata for the EasyQRCode library.
+/// Provides metadata for the EasyQRCode library used to generate QR codes on
+/// the client side. Embedding this library allows documents to display QR
+/// codes without additional services.
 /// </summary>
 public class EasyQRCode : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/FancyTreeLibrary.cs
+++ b/HtmlForgeX/Resources/FancyTreeLibrary.cs
@@ -1,7 +1,9 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata and asset links for the FancyTree jQuery plugin.
+/// Provides metadata and asset links for the FancyTree jQuery plugin used for
+/// creating interactive tree views. This library encapsulates the required CSS
+/// and JavaScript references.
 /// </summary>
 public class FancyTreeLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/FullCalendarLibrary.cs
+++ b/HtmlForgeX/Resources/FullCalendarLibrary.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides metadata and asset links for the FullCalendar library.
+/// Provides metadata and asset links for the FullCalendar library which enables
+/// feature rich calendar interfaces.
 /// </summary>
 public class FullCalendarLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/Jquery.cs
+++ b/HtmlForgeX/Resources/Jquery.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Metadata description for the jQuery library.
+/// Metadata description for the jQuery library. jQuery is used as a dependency
+/// by several other resources bundled with HtmlForgeX.
 /// </summary>
 public class Jquery : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/PopperLibrary.cs
+++ b/HtmlForgeX/Resources/PopperLibrary.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides links for Popper and Tooltip libraries.
+/// Provides links for Popper and Tooltip libraries. Popper is commonly used to
+/// position dropdowns and tooltips within web applications.
 /// </summary>
 public class PopperLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/QuillLibrary.cs
+++ b/HtmlForgeX/Resources/QuillLibrary.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Library definition providing Quill assets.
+/// Library definition providing Quill assets, enabling rich text editing within
+/// generated documents.
 /// </summary>
 public class QuillLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Resources/VisNetworkLoadingBarLibrary.cs
+++ b/HtmlForgeX/Resources/VisNetworkLoadingBarLibrary.cs
@@ -5,7 +5,8 @@ using System.Text;
 namespace HtmlForgeX.Resources;
 
 /// <summary>
-/// Provides assets for the Vis Network loading bar plugin.
+/// Provides assets for the Vis Network loading bar plugin used to display a
+/// progress indicator while network graphs are loading.
 /// </summary>
 public class VisNetworkLoadingBarLibrary : Library {
     /// <summary>

--- a/HtmlForgeX/Styles/Style.cs
+++ b/HtmlForgeX/Styles/Style.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents a simple CSS style definition.
+/// Represents a simple CSS style definition that can be attached to an element
+/// or output as part of a &lt;style&gt; block when rendering a document.
 /// </summary>
 /// <remarks>
 /// This type can be used to build inline style declarations or generate style

--- a/HtmlForgeX/Tags/Anchor.cs
+++ b/HtmlForgeX/Tags/Anchor.cs
@@ -1,7 +1,8 @@
 namespace HtmlForgeX.Tags;
 
 /// <summary>
-/// Represents an HTML <c>&lt;a&gt;</c> tag.
+/// Represents an HTML <c>&lt;a&gt;</c> tag. Use this class to create hyperlinks
+/// with optional target, relationship, and styling attributes.
 /// </summary>
 public class Anchor : HtmlTag {
     /// <summary>

--- a/HtmlForgeX/Tags/Span.cs
+++ b/HtmlForgeX/Tags/Span.cs
@@ -5,6 +5,8 @@ namespace HtmlForgeX;
 
 /// <summary>
 /// Represents a <c>&lt;span&gt;</c> element with configurable styling options.
+/// The <see cref="Span"/> class exposes helper methods for applying common CSS
+/// attributes without manually managing the underlying style collection.
 /// </summary>
 public class Span : Element {
     /// <summary>Content of the span element.</summary>

--- a/HtmlForgeX/Utilities/ImageEmbeddingHelper.cs
+++ b/HtmlForgeX/Utilities/ImageEmbeddingHelper.cs
@@ -174,7 +174,8 @@ public static class ImageEmbeddingHelper {
 }
 
 /// <summary>
-/// Result of an image embedding operation
+/// Result of an image embedding operation providing metadata about the
+/// generated base64 payload.
 /// </summary>
 public class ImageEmbeddingResult {
     /// <summary>Indicates whether the embedding succeeded.</summary>

--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -7,7 +7,9 @@ using HtmlForgeX.Logging;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Support class to help building HTMLForgeX without huge effort on maintaining CSS and JS files.
+/// Support class to help building HtmlForgeX without the manual effort of
+/// maintaining CSS and JS files locally. It downloads the external resources
+/// referenced by available libraries.
 /// </summary>
 public class LibraryDownloader {
     private static readonly HttpClient _client = new();


### PR DESCRIPTION
## Summary
- expand XML documentation comments for several public classes and enums across the project
- clarify descriptions for resource libraries and core containers
- improve summaries for helper utilities

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68756f7010a8832ea70778e565266c8f