### PR TITLE
Add missing XML docs across core library

### DIFF
--- a/HtmlForgeX/Containers/Core/Element.Charts.cs
+++ b/HtmlForgeX/Containers/Core/Element.Charts.cs
@@ -1,6 +1,11 @@
 namespace HtmlForgeX;
 
 public abstract partial class Element {
+    /// <summary>
+    /// Adds an <see cref="ApexCharts"/> element and applies the provided configuration.
+    /// </summary>
+    /// <param name="config">Action used to configure the chart.</param>
+    /// <returns>The created chart element.</returns>
     public ApexCharts ApexChart(Action<ApexCharts> config) {
         var apexChart = new ApexCharts();
         config(apexChart);
@@ -8,6 +13,11 @@ public abstract partial class Element {
         return apexChart;
     }
 
+    /// <summary>
+    /// Adds a <see cref="ChartJs"/> element and applies the provided configuration.
+    /// </summary>
+    /// <param name="config">Action used to configure the chart.</param>
+    /// <returns>The created chart element.</returns>
     public ChartJs ChartJs(Action<ChartJs> config) {
         var chartJs = new ChartJs();
         config(chartJs);
@@ -15,6 +25,11 @@ public abstract partial class Element {
         return chartJs;
     }
 
+    /// <summary>
+    /// Adds a <see cref="VisNetwork"/> element and applies the provided configuration.
+    /// </summary>
+    /// <param name="config">Action used to configure the network diagram.</param>
+    /// <returns>The created network element.</returns>
     public VisNetwork DiagramNetwork(Action<VisNetwork> config) {
         var visNetwork = new VisNetwork();
         config(visNetwork);

--- a/HtmlForgeX/Containers/Core/Element.Email.cs
+++ b/HtmlForgeX/Containers/Core/Element.Email.cs
@@ -2,12 +2,22 @@ namespace HtmlForgeX;
 
 public abstract partial class Element {
     // Email Extension Methods for Natural Builder Pattern
+    /// <summary>
+    /// Adds an <see cref="EmailText"/> element with optional content.
+    /// </summary>
+    /// <param name="content">Initial text content.</param>
+    /// <returns>The created element.</returns>
     public EmailText EmailText(string content = "") {
         var emailText = new EmailText(content);
         this.Add(emailText);
         return emailText;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailText"/> element using the provided action.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailText(Action<EmailText> config) {
         var emailText = new EmailText();
         config(emailText);
@@ -15,6 +25,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailTable"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailTable(Action<EmailTable> config) {
         var emailTable = new EmailTable();
         config(emailTable);
@@ -22,6 +37,12 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds an <see cref="EmailTable"/> populated from a collection.
+    /// </summary>
+    /// <typeparam name="T">Type of items in the collection.</typeparam>
+    /// <param name="data">Data used to populate the table.</param>
+    /// <returns>The created table element.</returns>
     public EmailTable EmailTable<T>(IEnumerable<T> data) where T : class {
         var emailTable = new EmailTable();
         emailTable.PopulateFromData(data);
@@ -29,6 +50,11 @@ public abstract partial class Element {
         return emailTable;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailList"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailList(Action<EmailList> config) {
         var emailList = new EmailList();
         config(emailList);
@@ -36,6 +62,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailRow"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailRow(Action<EmailRow> config) {
         var emailRow = new EmailRow();
         emailRow.Email = this.Email;
@@ -44,6 +75,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailColumn"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailColumn(Action<EmailColumn> config) {
         var emailColumn = new EmailColumn();
         emailColumn.Email = this.Email;
@@ -52,6 +88,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailBox"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailBox(Action<EmailBox> config) {
         var emailBox = new EmailBox();
         emailBox.Email = this.Email;
@@ -60,6 +101,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailTextBox"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailTextBox(Action<EmailTextBox> config) {
         var emailTextBox = new EmailTextBox();
         config(emailTextBox);
@@ -67,6 +113,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailImage"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailImage(Action<EmailImage> config) {
         var emailImage = new EmailImage();
         config(emailImage);
@@ -74,42 +125,80 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds an <see cref="EmailImage"/> element with the specified source.
+    /// </summary>
+    /// <param name="source">Image source path or URL.</param>
+    /// <returns>The created image element.</returns>
     public EmailImage EmailImage(string source) {
         var emailImage = new EmailImage(source);
         this.Add(emailImage);
         return emailImage;
     }
 
+    /// <summary>
+    /// Adds an <see cref="EmailImage"/> element with specified source and width.
+    /// </summary>
+    /// <param name="source">Image source path or URL.</param>
+    /// <param name="width">Width value.</param>
+    /// <returns>The created image element.</returns>
     public EmailImage EmailImage(string source, string width) {
         var emailImage = new EmailImage(source, width);
         this.Add(emailImage);
         return emailImage;
     }
 
+    /// <summary>
+    /// Adds an empty line break.
+    /// </summary>
+    /// <returns>The created line break element.</returns>
     public EmailLineBreak EmailLineBreak() {
         var lineBreak = new EmailLineBreak();
         this.Add(lineBreak);
         return lineBreak;
     }
 
+    /// <summary>
+    /// Adds a line break with a specific height.
+    /// </summary>
+    /// <param name="height">CSS height value.</param>
+    /// <returns>The created line break element.</returns>
     public EmailLineBreak EmailLineBreak(string height) {
         var lineBreak = new EmailLineBreak(height);
         this.Add(lineBreak);
         return lineBreak;
     }
 
+    /// <summary>
+    /// Adds a hyperlink element with text and target URL.
+    /// </summary>
+    /// <param name="content">Link text.</param>
+    /// <param name="href">Target URL.</param>
+    /// <returns>The created link element.</returns>
     public EmailLink EmailLink(string content, string href) {
         var emailLink = new EmailLink(content, href);
         this.Add(emailLink);
         return emailLink;
     }
 
+    /// <summary>
+    /// Adds a hyperlink element with an option to open in a new window.
+    /// </summary>
+    /// <param name="content">Link text.</param>
+    /// <param name="href">Target URL.</param>
+    /// <param name="openInNewWindow">If set to <c>true</c>, the link opens in a new window.</param>
+    /// <returns>The created link element.</returns>
     public EmailLink EmailLink(string content, string href, bool openInNewWindow) {
         var emailLink = new EmailLink(content, href, openInNewWindow);
         this.Add(emailLink);
         return emailLink;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailLink"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailLink(Action<EmailLink> config) {
         var emailLink = new EmailLink();
         config(emailLink);
@@ -117,6 +206,11 @@ public abstract partial class Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds and configures an <see cref="EmailContent"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The current element for chaining.</returns>
     public Element EmailContent(Action<EmailContent> config) {
         var emailContent = new EmailContent();
         emailContent.Email = this.Email;

--- a/HtmlForgeX/Containers/Core/Element.Tabler.cs
+++ b/HtmlForgeX/Containers/Core/Element.Tabler.cs
@@ -3,6 +3,11 @@ using HtmlForgeX.Tags;
 namespace HtmlForgeX;
 
 public abstract partial class Element {
+    /// <summary>
+    /// Adds and configures a <see cref="TablerDataGrid"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created data grid.</returns>
     public TablerDataGrid DataGrid(Action<TablerDataGrid> config) {
         var dataGrid = new TablerDataGrid();
         config(dataGrid);
@@ -10,6 +15,11 @@ public abstract partial class Element {
         return dataGrid;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerForm"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created form element.</returns>
     public TablerForm Form(Action<TablerForm> config) {
         var form = new TablerForm();
         config(form);
@@ -17,6 +27,11 @@ public abstract partial class Element {
         return form;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerColumn"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created column element.</returns>
     public TablerColumn Column(Action<TablerColumn> config) {
         var column = new TablerColumn();
         config(column);
@@ -24,6 +39,12 @@ public abstract partial class Element {
         return column;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerColumn"/> element with a specific width.
+    /// </summary>
+    /// <param name="number">Column width.</param>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created column element.</returns>
     public TablerColumn Column(TablerColumnNumber number, Action<TablerColumn> config) {
         var column = new TablerColumn(number);
         config(column);
@@ -31,6 +52,11 @@ public abstract partial class Element {
         return column;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerRow"/> element.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created row element.</returns>
     public TablerRow Row(Action<TablerRow> config) {
         var row = new TablerRow();
         config(row);
@@ -38,24 +64,42 @@ public abstract partial class Element {
         return row;
     }
 
+    /// <summary>
+    /// Adds a simple <see cref="TablerAvatar"/> element.
+    /// </summary>
+    /// <returns>The created avatar element.</returns>
     public TablerAvatar Avatar() {
         var avatar = new TablerAvatar();
         this.Add(avatar);
         return avatar;
     }
 
+    /// <summary>
+    /// Adds a text element with initial value.
+    /// </summary>
+    /// <param name="text">Initial text.</param>
+    /// <returns>The created text element.</returns>
     public TablerText Text(string text) {
         var tablerText = new TablerText(text);
         this.Add(tablerText);
         return tablerText;
     }
 
+    /// <summary>
+    /// Adds an empty text element.
+    /// </summary>
+    /// <returns>The created text element.</returns>
     public TablerText Text() {
         var tablerText = new TablerText();
         this.Add(tablerText);
         return tablerText;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerCard"/>.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created card element.</returns>
     public TablerCard Card(Action<TablerCard> config) {
         var card = new TablerCard();
         config(card);
@@ -63,6 +107,12 @@ public abstract partial class Element {
         return card;
     }
 
+    /// <summary>
+    /// Adds and configures a <see cref="TablerCard"/> with a preset count.
+    /// </summary>
+    /// <param name="count">Initial counter value.</param>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created card element.</returns>
     public TablerCard Card(int count, Action<TablerCard> config) {
         var card = new TablerCard(count);
         config(card);
@@ -70,36 +120,68 @@ public abstract partial class Element {
         return card;
     }
 
+    /// <summary>
+    /// Adds a mini variant of <see cref="TablerCard"/>.
+    /// </summary>
+    /// <returns>The created card element.</returns>
     public TablerCardMini CardMini() {
         var card = new TablerCardMini();
         this.Add(card);
         return card;
     }
 
+    /// <summary>
+    /// Adds a basic tabler card.
+    /// </summary>
+    /// <returns>The created card element.</returns>
     public TablerCardBasic CardBasic() {
         var card = new TablerCardBasic();
         this.Add(card);
         return card;
     }
 
+    /// <summary>
+    /// Adds a basic card with title and text.
+    /// </summary>
+    /// <param name="title">Card title.</param>
+    /// <param name="text">Card text.</param>
+    /// <returns>The created card element.</returns>
     public TablerCardBasic CardBasic(string title, string text) {
         var card = new TablerCardBasic(title, text);
         this.Add(card);
         return card;
     }
 
+    /// <summary>
+    /// Adds a header element of the specified level.
+    /// </summary>
+    /// <param name="level">Header level.</param>
+    /// <param name="text">Header text.</param>
+    /// <returns>The created header element.</returns>
     public HeaderLevel HeaderLevel(HeaderLevelTag level, string text) {
         var header = new HeaderLevel(level, text);
         this.Add(header);
         return header;
     }
 
+    /// <summary>
+    /// Adds a progress bar of a given type.
+    /// </summary>
+    /// <param name="type">Progress bar type.</param>
+    /// <returns>The created progress bar.</returns>
     public TablerProgressBar ProgressBar(TablerProgressBarType type) {
         var progressBar = new TablerProgressBar(type);
         this.Add(progressBar);
         return progressBar;
     }
 
+    /// <summary>
+    /// Adds a progress bar prepopulated with a value.
+    /// </summary>
+    /// <param name="type">Progress bar type.</param>
+    /// <param name="percentage">Initial percentage value.</param>
+    /// <param name="tablerBackground">Optional background color.</param>
+    /// <returns>The created progress bar.</returns>
     public TablerProgressBar ProgressBar(TablerProgressBarType type, int percentage, TablerColor? tablerBackground = null) {
         var progressBar = new TablerProgressBar(type);
         if (tablerBackground is null) {
@@ -111,6 +193,14 @@ public abstract partial class Element {
         return progressBar;
     }
 
+    /// <summary>
+    /// Adds a log viewer with source code as a single string.
+    /// </summary>
+    /// <param name="code">Code to display.</param>
+    /// <param name="theme">Color theme.</param>
+    /// <param name="backgroundClass">Optional custom background class.</param>
+    /// <param name="textClass">Optional custom text class.</param>
+    /// <returns>The created log element.</returns>
     public TablerLogs Logs(string code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
         if (backgroundClass != null && textClass != null) {
@@ -122,6 +212,9 @@ public abstract partial class Element {
         return logs;
     }
 
+    /// <summary>
+    /// Adds a log viewer from an array of strings.
+    /// </summary>
     public TablerLogs Logs(string[] code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
         if (backgroundClass != null && textClass != null) {
@@ -133,6 +226,9 @@ public abstract partial class Element {
         return logs;
     }
 
+    /// <summary>
+    /// Adds a log viewer from a list of strings.
+    /// </summary>
     public TablerLogs Logs(List<string> code, TablerLogsTheme theme = TablerLogsTheme.Dark, string? backgroundClass = null, string? textClass = null) {
         var logs = new TablerLogs(code);
         if (backgroundClass != null && textClass != null) {
@@ -144,30 +240,45 @@ public abstract partial class Element {
         return logs;
     }
 
+    /// <summary>
+    /// Adds a log viewer with custom colors.
+    /// </summary>
     public TablerLogs Logs(string code, RGBColor backgroundColor, RGBColor textColor) {
         var logs = new TablerLogs(code).CustomColors(backgroundColor, textColor);
         this.Add(logs);
         return logs;
     }
 
+    /// <summary>
+    /// Adds a log viewer from an array of strings with custom colors.
+    /// </summary>
     public TablerLogs Logs(string[] code, RGBColor backgroundColor, RGBColor textColor) {
         var logs = new TablerLogs(code).CustomColors(backgroundColor, textColor);
         this.Add(logs);
         return logs;
     }
 
+    /// <summary>
+    /// Adds a log viewer from a list of strings with custom colors.
+    /// </summary>
     public TablerLogs Logs(List<string> code, RGBColor backgroundColor, RGBColor textColor) {
         var logs = new TablerLogs(code).CustomColors(backgroundColor, textColor);
         this.Add(logs);
         return logs;
     }
 
+    /// <summary>
+    /// Adds a steps component.
+    /// </summary>
     public TablerSteps Steps() {
         var steps = new TablerSteps();
         this.Add(steps);
         return steps;
     }
 
+    /// <summary>
+    /// Adds and configures an accordion component.
+    /// </summary>
     public TablerAccordion Accordion(Action<TablerAccordion> config) {
         var accordion = new TablerAccordion();
         config(accordion);
@@ -175,6 +286,9 @@ public abstract partial class Element {
         return accordion;
     }
 
+    /// <summary>
+    /// Adds and configures tab navigation.
+    /// </summary>
     public TablerTabs Tabs(Action<TablerTabs> config) {
         var tabs = new TablerTabs();
         config(tabs);
@@ -182,24 +296,40 @@ public abstract partial class Element {
         return tabs;
     }
 
+    /// <summary>
+    /// Adds a divider element with text.
+    /// </summary>
+    /// <param name="text">Divider caption.</param>
+    /// <returns>The created divider.</returns>
     public TablerDivider Divider(string text) {
         var divider = new TablerDivider(text);
         this.Add(divider);
         return divider;
     }
 
+    /// <summary>
+    /// Adds an alert element.
+    /// </summary>
     public TablerAlert Alert(string title, string message, TablerColor alertColor = TablerColor.Default, TablerAlertType alertType = TablerAlertType.Regular) {
         var alert = new TablerAlert(title, message, alertColor, alertType);
         this.Add(alert);
         return alert;
     }
 
+    /// <summary>
+    /// Adds an invisible tracking pixel component.
+    /// </summary>
     public TablerTracking Tracking() {
         var tracking = new TablerTracking();
         this.Add(tracking);
         return tracking;
     }
 
+    /// <summary>
+    /// Adds and configures a FullCalendar component.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created calendar element.</returns>
     public FullCalendar FullCalendar(Action<FullCalendar> config) {
         var fullCalendar = new FullCalendar();
         config(fullCalendar);
@@ -207,18 +337,27 @@ public abstract partial class Element {
         return fullCalendar;
     }
 
+    /// <summary>
+    /// Adds an unordered list styled with Tabler classes.
+    /// </summary>
     public UnorderedList TablerList() {
         var unorderedList = new UnorderedList();
         this.Add(unorderedList);
         return unorderedList;
     }
 
+    /// <summary>
+    /// Adds a toast notification with preset text.
+    /// </summary>
     public TablerToast Toast(string title, string message, TablerToastType type = TablerToastType.Default) {
         var toast = new TablerToast(title, message, type);
         this.Add(toast);
         return toast;
     }
 
+    /// <summary>
+    /// Adds and configures a toast notification.
+    /// </summary>
     public TablerToast Toast(Action<TablerToast> config) {
         var toast = new TablerToast();
         config(toast);
@@ -226,6 +365,9 @@ public abstract partial class Element {
         return toast;
     }
 
+    /// <summary>
+    /// Adds and configures a timeline component.
+    /// </summary>
     public TablerTimeline Timeline(Action<TablerTimeline> config) {
         var timeline = new TablerTimeline();
         config(timeline);

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -137,24 +137,45 @@ public abstract partial class Element {
     /// <param name="objects">The objects.</param>
     /// <param name="tableType">Type of the table.</param>
     /// <returns></returns>
+    /// <summary>
+    /// Creates a table from a collection of objects.
+    /// </summary>
+    /// <param name="objects">Data source.</param>
+    /// <param name="tableType">Table library type.</param>
+    /// <returns>The created table element.</returns>
     public Table Table(IEnumerable<object> objects, TableType tableType) {
         var table = HtmlForgeX.Table.Create(objects, tableType);
         this.Add(table);
         return table;
     }
 
-    public Table Table(Object objects, TableType tableType) {
+    /// <summary>
+    /// Creates a table from a single object instance.
+    /// </summary>
+    /// <param name="objects">Object containing data.</param>
+    /// <param name="tableType">Table library type.</param>
+    /// <returns>The created table element.</returns>
+    public Table Table(object objects, TableType tableType) {
         var table = HtmlForgeX.Table.Create(objects, tableType);
         this.Add(table);
         return table;
     }
 
+    /// <summary>
+    /// Adds a line break element.
+    /// </summary>
+    /// <returns>The created line break.</returns>
     public LineBreak LineBreak() {
         var lineBreak = new LineBreak();
         this.Add(lineBreak);
         return lineBreak;
     }
 
+    /// <summary>
+    /// Adds and configures a fancy tree widget.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created tree element.</returns>
     public FancyTree FancyTree(Action<FancyTree> config) {
         var fancyTree = new FancyTree();
         config(fancyTree);
@@ -162,12 +183,22 @@ public abstract partial class Element {
         return fancyTree;
     }
 
+    /// <summary>
+    /// Adds a QR code element with specified text.
+    /// </summary>
+    /// <param name="text">Text to encode.</param>
+    /// <returns>The created QR code element.</returns>
     public EasyQRCodeElement QRCode(string text) {
         var qrCode = new EasyQRCodeElement(text);
         this.Add(qrCode);
         return qrCode;
     }
 
+    /// <summary>
+    /// Adds a Quill editor component.
+    /// </summary>
+    /// <param name="config">Optional configuration.</param>
+    /// <returns>The created editor element.</returns>
     public QuillEditor QuillEditor(Action<QuillEditor>? config = null) {
         var editor = new QuillEditor();
         config?.Invoke(editor);
@@ -175,6 +206,11 @@ public abstract partial class Element {
         return editor;
     }
 
+    /// <summary>
+    /// Adds a scrolling text component.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created component.</returns>
     public ScrollingText ScrollingText(Action<ScrollingText> config) {
         var scrollingText = new ScrollingText();
         config(scrollingText);

--- a/HtmlForgeX/Containers/Core/ElementContainer.cs
+++ b/HtmlForgeX/Containers/Core/ElementContainer.cs
@@ -7,6 +7,10 @@ namespace HtmlForgeX;
 /// Basic container element rendering its children.
 /// </summary>
 public class ElementContainer : Element {
+    /// <summary>
+    /// Renders all non-null child elements into a single HTML string.
+    /// </summary>
+    /// <returns>Concatenated HTML of all children.</returns>
     public override string ToString() {
         return string.Join("", Children.WhereNotNull().Select(child => child.ToString()));
     }

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -9,7 +9,7 @@ using HtmlForgeX.Extensions;
 namespace HtmlForgeX;
 
 /// <summary>
-/// Represents an email document with XHTML&nbsp;1.0 Strict compliance for email
+/// Represents an email document with XHTML&#160;1.0 Strict compliance for email
 /// clients. Provides a simplified object model for generating HTML emails.
 /// </summary>
 public class Email : Element {

--- a/HtmlForgeX/Containers/Core/Enums/Alignment.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Alignment.cs
@@ -7,9 +7,16 @@ namespace HtmlForgeX;
 /// supported by many email clients and may not render as expected.
 /// </summary>
 public enum Alignment {
+    /// <summary>Left aligned.</summary>
     Left = 1,
+
+    /// <summary>Centered.</summary>
     Center,
+
+    /// <summary>Right aligned.</summary>
     Right,
+
+    /// <summary>Justified text.</summary>
     Justify
 }
 
@@ -17,6 +24,11 @@ public enum Alignment {
 /// Extension methods for the <see cref="Alignment"/> enum.
 /// </summary>
 public static class AlignmentExtensions {
+    /// <summary>
+    /// Converts an alignment value to its CSS representation.
+    /// </summary>
+    /// <param name="alignment">Alignment option.</param>
+    /// <returns>CSS text-align value.</returns>
     public static string ToCssValue(this Alignment alignment) => alignment switch
     {
         Alignment.Left => "left",
@@ -26,6 +38,10 @@ public static class AlignmentExtensions {
         _ => "left"
     };
 
+    /// <summary>
+    /// Validates that the alignment is allowed for email components.
+    /// </summary>
+    /// <param name="alignment">Alignment to validate.</param>
     public static void ValidateEmailAlignment(this Alignment alignment) {
         if (alignment is Alignment.Left or Alignment.Right or Alignment.Center) {
             return;

--- a/HtmlForgeX/Containers/Core/Enums/AnalyticsProvider.cs
+++ b/HtmlForgeX/Containers/Core/Enums/AnalyticsProvider.cs
@@ -7,6 +7,9 @@ public enum AnalyticsProvider
 {
     /// <summary>No provider.</summary>
     None,
+    /// <summary>Google Analytics.</summary>
     GoogleAnalytics,
+
+    /// <summary>Cloudflare Insights.</summary>
     CloudflareInsights
 }

--- a/HtmlForgeX/Containers/Core/Enums/Display.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Display.cs
@@ -10,63 +10,83 @@ public enum Display {
     [Description("none")]
     None = 1,
 
+    /// <summary>Specifies <c>display: inline</c>.</summary>
     [Description("inline")]
     Inline,
 
+    /// <summary>Specifies <c>display: block</c>.</summary>
     [Description("block")]
     Block,
 
+    /// <summary>Specifies <c>display: inline-block</c>.</summary>
     [Description("inline-block")]
     InlineBlock,
 
+    /// <summary>Specifies <c>display: contents</c>.</summary>
     [Description("contents")]
     Contents,
 
+    /// <summary>Specifies <c>display: flex</c>.</summary>
     [Description("flex")]
     Flex,
 
+    /// <summary>Specifies <c>display: grid</c>.</summary>
     [Description("grid")]
     Grid,
 
+    /// <summary>Specifies <c>display: inline-flex</c>.</summary>
     [Description("inline-flex")]
     InlineFlex,
 
+    /// <summary>Specifies <c>display: inline-grid</c>.</summary>
     [Description("inline-grid")]
     InlineGrid,
 
+    /// <summary>Specifies <c>display: inline-table</c>.</summary>
     [Description("inline-table")]
     InlineTable,
 
+    /// <summary>Specifies <c>display: list-item</c>.</summary>
     [Description("list-item")]
     ListItem,
 
+    /// <summary>Specifies <c>display: run-in</c>.</summary>
     [Description("run-in")]
     RunIn,
 
+    /// <summary>Specifies <c>display: table</c>.</summary>
     [Description("table")]
     Table,
 
+    /// <summary>Specifies <c>display: table-caption</c>.</summary>
     [Description("table-caption")]
     TableCaption,
 
+    /// <summary>Specifies <c>display: table-column-group</c>.</summary>
     [Description("table-column-group")]
     TableColumnGroup,
 
+    /// <summary>Specifies <c>display: table-header-group</c>.</summary>
     [Description("table-header-group")]
     TableHeaderGroup,
 
+    /// <summary>Specifies <c>display: table-footer-group</c>.</summary>
     [Description("table-footer-group")]
     TableFooterGroup,
 
+    /// <summary>Specifies <c>display: table-row-group</c>.</summary>
     [Description("table-row-group")]
     TableRowGroup,
 
+    /// <summary>Specifies <c>display: table-cell</c>.</summary>
     [Description("table-cell")]
     TableCell,
 
+    /// <summary>Specifies <c>display: table-column</c>.</summary>
     [Description("table-column")]
     TableColumn,
 
+    /// <summary>Specifies <c>display: table-row</c>.</summary>
     [Description("table-row")]
     TableRow
 }

--- a/HtmlForgeX/Containers/Core/Enums/FontStyle.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontStyle.cs
@@ -6,6 +6,9 @@ namespace HtmlForgeX;
 public enum FontStyle {
     /// <summary>Normal style.</summary>
     Normal = 1,
+    /// <summary>Italic style.</summary>
     Italic,
+
+    /// <summary>Oblique style.</summary>
     Oblique
 }

--- a/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontVariant.cs
@@ -4,7 +4,10 @@ namespace HtmlForgeX;
 /// CSS font-variant values.
 /// </summary>
 public enum FontVariant {
+    /// <summary>Normal variant.</summary>
     Normal = 1,
+
+    /// <summary>Small caps variant.</summary>
     SmallCaps
 }
 

--- a/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
+++ b/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
@@ -6,10 +6,19 @@ namespace HtmlForgeX;
 public enum HeaderLevelTag {
     /// <summary>&lt;h1&gt; element.</summary>
     H1,
+    /// <summary>&lt;h2&gt; element.</summary>
     H2,
+
+    /// <summary>&lt;h3&gt; element.</summary>
     H3,
+
+    /// <summary>&lt;h4&gt; element.</summary>
     H4,
+
+    /// <summary>&lt;h5&gt; element.</summary>
     H5,
+
+    /// <summary>&lt;h6&gt; element.</summary>
     H6
 }
 

--- a/HtmlForgeX/Containers/Core/Enums/TableType.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TableType.cs
@@ -3,8 +3,15 @@ namespace HtmlForgeX;
 /// Table library type.
 /// </summary>
 public enum TableType {
+    /// <summary>No specific library.</summary>
     None,
+
+    /// <summary>BootstrapTable library.</summary>
     BootstrapTable,
+
+    /// <summary>jQuery DataTables library.</summary>
     DataTables,
+
+    /// <summary>Tabler table component.</summary>
     Tabler
 }

--- a/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
@@ -10,12 +10,15 @@ public enum TextDecoration {
     [Description("none")]
     None = 1,
 
+    /// <summary>Specifies <c>line-through</c>.</summary>
     [Description("line-through")]
     LineThrough,
 
+    /// <summary>Specifies <c>overline</c>.</summary>
     [Description("overline")]
     Overline,
 
+    /// <summary>Specifies <c>underline</c>.</summary>
     [Description("underline")]
     Underline
 }

--- a/HtmlForgeX/Containers/Core/Enums/TextTransform.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextTransform.cs
@@ -4,10 +4,21 @@ namespace HtmlForgeX;
 /// Text transformation options.
 /// </summary>
 public enum TextTransform {
+    /// <summary>Uppercase all letters.</summary>
     Uppercase,
+
+    /// <summary>Lowercase all letters.</summary>
     Lowercase,
+
+    /// <summary>Capitalize each word.</summary>
     Capitalize,
+
+    /// <summary>No transformation.</summary>
     None,
+
+    /// <summary>Inherit from parent.</summary>
     Inherit,
+
+    /// <summary>Use the CSS initial value.</summary>
     Initial
 }

--- a/HtmlForgeX/Containers/Core/Enums/ThemeMode.cs
+++ b/HtmlForgeX/Containers/Core/Enums/ThemeMode.cs
@@ -4,7 +4,12 @@ namespace HtmlForgeX;
 /// Theme mode selection.
 /// </summary>
 public enum ThemeMode {
+    /// <summary>Follow the operating system preference.</summary>
     System,
+
+    /// <summary>Always use a light theme.</summary>
     Light,
+
+    /// <summary>Always use a dark theme.</summary>
     Dark
 }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -77,8 +77,14 @@ public class Head : Element {
     /// </value>
     public DateTime? Revised { get; set; }
 
+    /// <summary>
+    /// Gets or sets the page description meta tag.
+    /// </summary>
     public string? Description { get; set; }
 
+    /// <summary>
+    /// Gets or sets the keywords meta tag.
+    /// </summary>
     public string? Keywords { get; set; }
 
     /// <summary>
@@ -88,9 +94,25 @@ public class Head : Element {
     /// The meta tags.
     /// </value>
     public List<HtmlTag> MetaTags { get; set; } = new List<HtmlTag>();
+
+    /// <summary>
+    /// Collection of inline &lt;style&gt; definitions or CSS strings.
+    /// </summary>
     public List<object> Styles { get; set; } = new List<object>();
+
+    /// <summary>
+    /// Collection of inline scripts.
+    /// </summary>
     public List<string> Scripts { get; set; } = new List<string>();
+
+    /// <summary>
+    /// External CSS links to include in the head.
+    /// </summary>
     public List<string> CssLinks { get; set; } = new List<string>();
+
+    /// <summary>
+    /// External JavaScript links to include in the head.
+    /// </summary>
     public List<string> JsLinks { get; set; } = new List<string>();
     private readonly HashSet<string> _cssLinkSet = new();
     private readonly HashSet<string> _jsLinkSet = new();
@@ -149,37 +171,73 @@ public class Head : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds or replaces the charset meta tag.
+    /// </summary>
+    /// <param name="charset">Character set to use.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddCharsetMeta(string charset) {
         Charset = charset;
         return this;
     }
 
+    /// <summary>
+    /// Adds an HTTP-equiv meta tag.
+    /// </summary>
+    /// <param name="httpEquiv">HTTP-equivalent header name.</param>
+    /// <param name="content">Content value.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddHttpEquivMeta(string httpEquiv, string content) {
         HttpEquiv = httpEquiv;
         Content = content;
         return this;
     }
 
+    /// <summary>
+    /// Adds a viewport meta tag.
+    /// </summary>
+    /// <param name="content">Viewport value.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddViewportMeta(string content) {
         Viewport = content;
         return this;
     }
 
+    /// <summary>
+    /// Adds an author meta tag.
+    /// </summary>
+    /// <param name="author">Author name.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddAuthorMeta(string author) {
         Author = author;
         return this;
     }
 
+    /// <summary>
+    /// Adds a revised date meta tag.
+    /// </summary>
+    /// <param name="date">Revision date.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddRevisedMeta(DateTime date) {
         Revised = date;
         return this;
     }
 
+    /// <summary>
+    /// Adds a strongly typed style element.
+    /// </summary>
+    /// <param name="style">Style to add.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddStyle(Style style) {
         Styles.Add(style);
         return this;
     }
 
+    /// <summary>
+    /// Adds a raw CSS style string.
+    /// </summary>
+    /// <param name="style">Style markup.</param>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddStyle(string style) {
         Styles.Add(style);
         return this;

--- a/HtmlForgeX/Containers/Core/HeaderLevel.cs
+++ b/HtmlForgeX/Containers/Core/HeaderLevel.cs
@@ -26,12 +26,16 @@ public class HeaderLevel : Element {
     /// For example: <h1 class="card-title"></h1>
     /// </summary>
     /// <param name="className">Name of the class.</param>
-    /// <returns></returns>
+    /// <returns>The current <see cref="HeaderLevel"/> instance.</returns>
     public HeaderLevel Class(string className) {
         PrivateClass += className;
         return this;
     }
 
+    /// <summary>
+    /// Converts the header element to its HTML representation.
+    /// </summary>
+    /// <returns>HTML string representing the header.</returns>
     public override string ToString() {
         var tag = new HtmlTag(PrivateTag.ToString()).Value(PrivateText);
         if (!string.IsNullOrEmpty(PrivateClass)) {

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -16,8 +16,13 @@ namespace HtmlForgeX;
 public class Table : Element {
     private readonly TableType? Library;
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
+    /// <summary>Collection of table headers.</summary>
     public List<string> TableHeaders { get; set; } = new List<string>();
+
+    /// <summary>Collection of table footers.</summary>
     public List<string> TableFooters { get; set; } = new List<string>();
+
+    /// <summary>Collection of table rows.</summary>
     public List<List<string>> TableRows { get; set; } = new List<List<string>>();
 
     private static PropertyInfo[] GetCachedProperties(Type type) {
@@ -47,30 +52,50 @@ public class Table : Element {
         AddLibrariesBasedOnTableType();
     }
 
+    /// <summary>
+    /// Adds a table header cell.
+    /// </summary>
+    /// <param name="header">Header text.</param>
+    /// <returns>The current table.</returns>
     public Table AddHeader(string header) {
         TableHeaders.Add(header);
         return this;
     }
+    /// <summary>
+    /// Adds multiple header cells.
+    /// </summary>
     public Table AddHeaders(params string[] headers) {
         TableHeaders.AddRange(headers);
         return this;
     }
 
+    /// <summary>
+    /// Adds a table footer cell.
+    /// </summary>
     public Table AddFooter(string footer) {
         TableFooters.Add(footer);
         return this;
     }
 
+    /// <summary>
+    /// Adds multiple footer cells.
+    /// </summary>
     public Table AddFooters(params string[] footers) {
         TableFooters.AddRange(footers);
         return this;
     }
 
+    /// <summary>
+    /// Adds a row consisting of cell strings.
+    /// </summary>
     public Table AddRow(List<string> row) {
         TableRows.Add(row);
         return this;
     }
 
+    /// <summary>
+    /// Adds multiple table rows.
+    /// </summary>
     public Table AddRows(params List<string>[] rows) {
         TableRows.AddRange(rows);
         return this;

--- a/HtmlForgeX/Containers/DataTables/DataTablesLanguage.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesLanguage.cs
@@ -7,38 +7,47 @@ namespace HtmlForgeX;
 /// </summary>
 public class DataTablesLanguage
 {
+    /// <summary>Label for the search input.</summary>
     [JsonPropertyName("search")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Search { get; set; }
 
+    /// <summary>Text for the page length menu.</summary>
     [JsonPropertyName("lengthMenu")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? LengthMenu { get; set; }
 
+    /// <summary>Information text.</summary>
     [JsonPropertyName("info")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Info { get; set; }
 
+    /// <summary>Text shown when no records are present.</summary>
     [JsonPropertyName("infoEmpty")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? InfoEmpty { get; set; }
 
+    /// <summary>Text for filtered results information.</summary>
     [JsonPropertyName("infoFiltered")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? InfoFiltered { get; set; }
 
+    /// <summary>Loading message.</summary>
     [JsonPropertyName("loadingRecords")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? LoadingRecords { get; set; }
 
+    /// <summary>Processing message.</summary>
     [JsonPropertyName("processing")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Processing { get; set; }
 
+    /// <summary>Text shown when no matching records are found.</summary>
     [JsonPropertyName("zeroRecords")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ZeroRecords { get; set; }
 
+    /// <summary>Text used for pagination buttons.</summary>
     [JsonPropertyName("paginate")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DataTablesPaginate? Paginate { get; set; }

--- a/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesOptions.cs
@@ -7,46 +7,57 @@ namespace HtmlForgeX;
 /// </summary>
 public class DataTablesOptions
 {
+    /// <summary>Default number of rows per page.</summary>
     [JsonPropertyName("pageLength")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? PageLength { get; set; }
 
+    /// <summary>Available page length options.</summary>
     [JsonPropertyName("lengthMenu")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int[]? LengthMenu { get; set; }
 
+    /// <summary>Enable DataTables state saving.</summary>
     [JsonPropertyName("stateSave")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? StateSave { get; set; }
 
+    /// <summary>Vertical scroll height.</summary>
     [JsonPropertyName("scrollY")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ScrollY { get; set; }
 
+    /// <summary>Enable collapsing the table height when fewer rows are present.</summary>
     [JsonPropertyName("scrollCollapse")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? ScrollCollapse { get; set; }
 
+    /// <summary>Automatically calculate column widths.</summary>
     [JsonPropertyName("autoWidth")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? AutoWidth { get; set; }
 
+    /// <summary>Defer rendering for speed on large data sets.</summary>
     [JsonPropertyName("deferRender")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? DeferRender { get; set; }
 
+    /// <summary>Show the processing indicator.</summary>
     [JsonPropertyName("processing")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Processing { get; set; }
 
+    /// <summary>Enable server-side processing.</summary>
     [JsonPropertyName("serverSide")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? ServerSide { get; set; }
 
+    /// <summary>Localization options.</summary>
     [JsonPropertyName("language")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DataTablesLanguage? Language { get; set; }
 
+    /// <summary>DOM positioning configuration string.</summary>
     [JsonPropertyName("dom")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Dom { get; set; }

--- a/HtmlForgeX/Containers/DataTables/DataTablesPaginate.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesPaginate.cs
@@ -7,18 +7,22 @@ namespace HtmlForgeX;
 /// </summary>
 public class DataTablesPaginate
 {
+    /// <summary>Text for the first page button.</summary>
     [JsonPropertyName("first")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? First { get; set; }
 
+    /// <summary>Text for the last page button.</summary>
     [JsonPropertyName("last")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Last { get; set; }
 
+    /// <summary>Text for the next page button.</summary>
     [JsonPropertyName("next")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Next { get; set; }
 
+    /// <summary>Text for the previous page button.</summary>
     [JsonPropertyName("previous")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Previous { get; set; }

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -14,49 +14,69 @@ public class DataTablesTable : Table {
     /// Gets the table identifier.
     /// </summary>
     public string Id;
+
+    /// <summary>List of table styles to apply.</summary>
     public List<BootStrapTableStyle> StyleList { get; set; } = new List<BootStrapTableStyle>();
     private readonly Dictionary<string, object> config = new Dictionary<string, object>();
 
+    /// <summary>DataTables configuration options.</summary>
     public DataTablesOptions Options { get; } = new();
 
+    /// <summary>Enable paging feature.</summary>
     public bool EnablePaging {
         get => config.ContainsKey("paging") && (bool)config["paging"];
         set => config["paging"] = value;
     }
 
+    /// <summary>Enable searching feature.</summary>
     public bool EnableSearching {
         get => config.ContainsKey("searching") && (bool)config["searching"];
         set => config["searching"] = value;
     }
 
+    /// <summary>Enable column ordering.</summary>
     public bool EnableOrdering {
         get => config.ContainsKey("ordering") && (bool)config["ordering"];
         set => config["ordering"] = value;
     }
 
+    /// <summary>Enable horizontal scrolling.</summary>
     public bool EnableScrollX {
         get => config.ContainsKey("scrollX") && (bool)config["scrollX"];
         set => config["scrollX"] = value;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="DataTablesTable"/> class.</summary>
     public DataTablesTable() {
         Id = GlobalStorage.GenerateRandomId("table");
     }
 
+    /// <summary>
+    /// Initializes a new instance populated with data.
+    /// </summary>
     public DataTablesTable(IEnumerable<object> objects, TableType library) : base(objects, library) {
         Id = GlobalStorage.GenerateRandomId("table");
     }
 
+    /// <summary>
+    /// Adds a bootstrap table style.
+    /// </summary>
     public DataTablesTable Style(BootStrapTableStyle style) {
         StyleList.Add(style);
         return this;
     }
 
+    /// <summary>
+    /// Applies additional DataTables configuration.
+    /// </summary>
     public DataTablesTable Configure(Action<DataTablesOptions> configure) {
         configure?.Invoke(Options);
         return this;
     }
 
+    /// <summary>
+    /// Builds the final table markup including initialization script.
+    /// </summary>
     public override string BuildTable() {
         string tableInside = base.BuildTable();
         string classNames = StyleList.BuildTableStyles();

--- a/HtmlForgeX/Containers/Email/EmailButton.cs
+++ b/HtmlForgeX/Containers/Email/EmailButton.cs
@@ -240,14 +240,31 @@ public class EmailButton : Element {
 /// Enum for email button styles.
 /// </summary>
 public enum EmailButtonStyle {
+    /// <summary>Primary action button.</summary>
     Primary,
+
+    /// <summary>Secondary action button.</summary>
     Secondary,
+
+    /// <summary>Success indication button.</summary>
     Success,
+
+    /// <summary>Danger or error button.</summary>
     Danger,
+
+    /// <summary>Warning indication button.</summary>
     Warning,
+
+    /// <summary>Informational button.</summary>
     Info,
+
+    /// <summary>Light themed button.</summary>
     Light,
+
+    /// <summary>Dark themed button.</summary>
     Dark,
+
+    /// <summary>Button with custom colors.</summary>
     Custom
 }
 
@@ -255,7 +272,12 @@ public enum EmailButtonStyle {
 /// Enum for email button sizes.
 /// </summary>
 public enum EmailButtonSize {
+    /// <summary>Small size button.</summary>
     Small,
+
+    /// <summary>Medium size button.</summary>
     Medium,
+
+    /// <summary>Large size button.</summary>
     Large
 }

--- a/HtmlForgeX/Containers/Email/EmailTable.cs
+++ b/HtmlForgeX/Containers/Email/EmailTable.cs
@@ -344,8 +344,13 @@ public class EmailTable : Element {
 /// Represents a table header in an email table.
 /// </summary>
 public class EmailTableHeader {
+    /// <summary>Header text.</summary>
     public string Text { get; set; } = "";
+
+    /// <summary>Text alignment.</summary>
     public string Align { get; set; } = "left";
+
+    /// <summary>Column span.</summary>
     public int ColSpan { get; set; } = 1;
 }
 
@@ -353,6 +358,7 @@ public class EmailTableHeader {
 /// Represents a table row in an email table.
 /// </summary>
 public class EmailTableRow {
+    /// <summary>Cells contained in this row.</summary>
     public List<EmailTableCell> Cells { get; set; } = new();
 
     /// <summary>
@@ -402,22 +408,40 @@ public class EmailTableRow {
 /// Represents a table cell in an email table.
 /// </summary>
 public class EmailTableCell {
+    /// <summary>Cell text.</summary>
     public string Text { get; set; } = "";
+
+    /// <summary>Text alignment.</summary>
     public string Align { get; set; } = "left";
+
+    /// <summary>Column span.</summary>
     public int ColSpan { get; set; } = 1;
+
+    /// <summary>Width of the cell.</summary>
     public string Width { get; set; } = "";
+
+    /// <summary>Additional CSS class.</summary>
     public string CssClass { get; set; } = "";
+
+    /// <summary>Inline style string.</summary>
     public string InlineStyle { get; set; } = "";
+    /// <summary>Whether to include a top border for this cell.</summary>
     public bool IncludeTopBorder { get; set; } = false;
 
     // Image properties
+    /// <summary>Image source URL.</summary>
     public string ImageSrc { get; set; } = "";
+    /// <summary>Image width in pixels.</summary>
     public int ImageWidth { get; set; } = 0;
+    /// <summary>Image height in pixels.</summary>
     public int ImageHeight { get; set; } = 0;
+    /// <summary>Alternative text for the image.</summary>
     public string ImageAlt { get; set; } = "";
+    /// <summary>Optional hyperlink for the image.</summary>
     public string ImageLink { get; set; } = "";
 
     // Rich content
+    /// <summary>Raw HTML content for the cell.</summary>
     public string HtmlContent { get; set; } = "";
 
     /// <summary>

--- a/HtmlForgeX/Containers/Email/Enums/EmailFontSize.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailFontSize.cs
@@ -22,6 +22,9 @@ public enum EmailFontSize {
     Heading3
 }
 
+/// <summary>
+/// Helper methods for <see cref="EmailFontSize"/> values.
+/// </summary>
 public static class EmailFontSizeExtensions {
     public static string ToCssValue(this EmailFontSize fontSize) {
         return fontSize switch {

--- a/HtmlForgeX/Containers/Email/Enums/EmailSpacing.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailSpacing.cs
@@ -20,6 +20,9 @@ public enum EmailSpacing {
     DoubleExtraLarge
 }
 
+/// <summary>
+/// Extension methods for <see cref="EmailSpacing"/> values.
+/// </summary>
 public static class EmailSpacingExtensions {
     public static string ToCssValue(this EmailSpacing spacing) {
         return spacing switch {

--- a/HtmlForgeX/Containers/Email/Enums/EmailTableStyle.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailTableStyle.cs
@@ -26,6 +26,9 @@ public enum EmailTableStyle {
     Statistics
 }
 
+/// <summary>
+/// Extension helpers for <see cref="EmailTableStyle"/>.
+/// </summary>
 public static class EmailTableStyleExtensions {
     public static (string cssClass, bool striped, bool bordered, string headerStyle, string cellStyle, string borderColor, string stripeColor) GetStyle(this EmailTableStyle style) {
         return style switch {

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbarOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarToolbarOption.cs
@@ -11,30 +11,39 @@ public enum FullCalendarToolbarOption {
     [Description("title")]
     Title,
 
+    /// <summary>Button to navigate to the previous period.</summary>
     [Description("prev")]
     Prev,
 
+    /// <summary>Button to navigate to the next period.</summary>
     [Description("next")]
     Next,
 
+    /// <summary>Button to go to the previous year.</summary>
     [Description("prevYear")]
     PrevYear,
 
+    /// <summary>Button to go to the next year.</summary>
     [Description("nextYear")]
     NextYear,
 
+    /// <summary>Button to navigate to today.</summary>
     [Description("today")]
     Today,
 
+    /// <summary>Switch to month view.</summary>
     [Description("dayGridMonth")]
     DayGridMonth,
 
+    /// <summary>Switch to week view.</summary>
     [Description("timeGridWeek")]
     TimeGridWeek,
 
+    /// <summary>Switch to day view.</summary>
     [Description("timeGridDay")]
     TimeGridDay,
 
+    /// <summary>Switch to agenda list for the month.</summary>
     [Description("listMonth")]
     ListMonth
 }


### PR DESCRIPTION
## Summary
- document public methods in Element builders
- add documentation to enumeration members
- provide docs for DataTables options and language classes
- enhance docs for tabler components and email helpers

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687573d484d4832eb9ebdc7d717af8b3