### PR TITLE
Add XML docs to suppress CS1591 warnings

### DIFF
--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -20,16 +20,37 @@ public class Email : Element {
     /// </summary>
     public DocumentConfiguration Configuration { get; } = new();
 
+    /// <summary>
+    /// Gets the <see cref="EmailHead"/> section where metadata and styles are defined.
+    /// </summary>
     public EmailHead Head { get; }
+
+    /// <summary>
+    /// Gets the <see cref="EmailBody"/> containing the main message content.
+    /// </summary>
     public EmailBody Body { get; }
+
+    /// <summary>
+    /// Gets the header area rendered at the top of the email.
+    /// </summary>
     public EmailHeader Header { get; }
+
+    /// <summary>
+    /// Gets the footer area rendered at the bottom of the email.
+    /// </summary>
     public EmailFooter Footer { get; }
 
+    /// <summary>
+    /// Gets or sets the library mode for the email. Only inline mode is supported.
+    /// </summary>
     public EmailLibraryMode LibraryMode {
         get => Configuration.Email.AutoEmbedImages ? EmailLibraryMode.InlineOnly : EmailLibraryMode.InlineOnly; // Email only supports inline
         set { /* Email only supports inline mode */ }
     }
 
+    /// <summary>
+    /// Gets or sets the file system path where the email will be saved.
+    /// </summary>
     public string Path {
         get => Configuration.Email.DefaultPadding; // Reuse for path storage
         set => Configuration.Email.DefaultPadding = value;

--- a/HtmlForgeX/Containers/Core/Enums/Display.cs
+++ b/HtmlForgeX/Containers/Core/Enums/Display.cs
@@ -95,6 +95,11 @@ public enum Display {
 /// Extension methods for the <see cref="Display"/> enum.
 /// </summary>
 public static class DisplayExtensions {
+    /// <summary>
+    /// Converts the enum value to its lowercase CSS string representation.
+    /// </summary>
+    /// <param name="value">Display enumeration value.</param>
+    /// <returns>The CSS text for the display value.</returns>
     public static string EnumToString(this Display value) {
         var fieldInfo = value.GetType().GetField(value.ToString());
         var attributes = (DescriptionAttribute[])fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);

--- a/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
+++ b/HtmlForgeX/Containers/Core/Enums/FontWeight.cs
@@ -28,6 +28,11 @@ public enum FontWeight {
 /// Extension methods for the <see cref="FontWeight"/> enum.
 /// </summary>
 public static class FontWeightExtensions {
+    /// <summary>
+    /// Converts the enum value to the numeric CSS weight string.
+    /// </summary>
+    /// <param name="value">Font weight value.</param>
+    /// <returns>Numeric CSS representation of the weight.</returns>
     public static string EnumToString(this FontWeight value) {
         return value switch {
             FontWeight.Thin => "100",

--- a/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
+++ b/HtmlForgeX/Containers/Core/Enums/HeaderLevelTag.cs
@@ -26,7 +26,10 @@ public enum HeaderLevelTag {
 /// Extension methods for the <see cref="HeaderLevelTag"/> enum.
 /// </summary>
 public static class HeaderLevelTagExtensions {
-    public static string EnumToString(this HeaderLevelTag tag) {
-        return tag.ToString().ToLower();
-    }
+    /// <summary>
+    /// Converts the heading level to the lowercase HTML tag name.
+    /// </summary>
+    /// <param name="tag">Heading level value.</param>
+    /// <returns>String such as <c>h1</c> or <c>h2</c>.</returns>
+    public static string EnumToString(this HeaderLevelTag tag) => tag.ToString().ToLower();
 }

--- a/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
+++ b/HtmlForgeX/Containers/Core/Enums/TextDecoration.cs
@@ -27,6 +27,11 @@ public enum TextDecoration {
 /// Extension methods for the <see cref="TextDecoration"/> enum.
 /// </summary>
 public static class TextDecorationExtensions {
+    /// <summary>
+    /// Converts the text decoration to its CSS string value.
+    /// </summary>
+    /// <param name="value">Decoration value.</param>
+    /// <returns>CSS representation of the decoration.</returns>
     public static string EnumToString(this TextDecoration value) {
         return value switch {
             TextDecoration.None => "none",

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -321,6 +321,10 @@ public class Head : Element {
         return StringBuilderCache.GetStringAndRelease(head);
     }
 
+    /// <summary>
+    /// Adds a set of minimal default styles used by many generated documents.
+    /// </summary>
+    /// <returns>The current <see cref="Head"/> instance.</returns>
     public Head AddDefaultStyles() {
         Styles.Add(
             """
@@ -341,24 +345,40 @@ public class Head : Element {
         return this;
     }
 
+    /// <summary>
+    /// Registers an external CSS link if it has not already been added.
+    /// </summary>
+    /// <param name="link">URL to the stylesheet.</param>
     public void AddCssLink(string link) {
         if (_cssLinkSet.Add(link)) {
             CssLinks.Add($"<link rel=\"stylesheet\" href=\"{link}\">");
         }
     }
 
+    /// <summary>
+    /// Registers an external JavaScript link if it has not already been added.
+    /// </summary>
+    /// <param name="link">URL to the script.</param>
     public void AddJsLink(string link) {
         if (_jsLinkSet.Add(link)) {
             JsLinks.Add($"<script src=\"{link}\"></script>");
         }
     }
 
+    /// <summary>
+    /// Adds inline CSS content to the document head.
+    /// </summary>
+    /// <param name="css">CSS rules to embed.</param>
     public void AddCssInline(string css) {
         if (_cssInlineSet.Add(css)) {
             Styles.Add($"<style>{css}</style>");
         }
     }
 
+    /// <summary>
+    /// Adds inline JavaScript to the document head.
+    /// </summary>
+    /// <param name="js">JavaScript code to embed.</param>
     public void AddJsInline(string js) {
         if (_jsInlineSet.Add(js)) {
             Scripts.Add($"<script>{js}</script>");
@@ -397,6 +417,10 @@ gtag('config', '{identifier}');
         return this;
     }
 
+    /// <summary>
+    /// Adds a <see cref="Style"/> object to the list of styles.
+    /// </summary>
+    /// <param name="style">Style instance to include.</param>
     public void AddCssStyle(Style style) {
         Styles.Add(style);
     }

--- a/HtmlForgeX/Containers/Core/Table.cs
+++ b/HtmlForgeX/Containers/Core/Table.cs
@@ -33,11 +33,20 @@ public class Table : Element {
         return Array.Find(GetCachedProperties(type), p => p.Name == name);
     }
 
+    /// <summary>
+    /// Initializes a new empty table instance.
+    /// </summary>
+    /// <param name="library">Optional table style library.</param>
     public Table(TableType? library = null) {
         Library = library;
         // Libraries will be registered via RegisterLibraries method
     }
 
+    /// <summary>
+    /// Initializes a table from the provided objects.
+    /// </summary>
+    /// <param name="objects">Objects representing each row.</param>
+    /// <param name="library">Optional table style library.</param>
     public Table(IEnumerable<object> objects, TableType? library = null) {
         Library = library;
         // Libraries will be registered via RegisterLibraries method
@@ -101,6 +110,12 @@ public class Table : Element {
         return this;
     }
 
+    /// <summary>
+    /// Adds rows to the table using public properties of the supplied objects.
+    /// </summary>
+    /// <param name="objects">Collection of objects to read values from.</param>
+    /// <param name="addFooter">When true, footer cells are generated from property names.</param>
+    /// <returns>The current table instance.</returns>
     public Table AddObjects(IEnumerable<object> objects, bool addFooter = false) {
         if (objects == null || !objects.Any()) return this;
 
@@ -275,10 +290,18 @@ public class Table : Element {
 
 
 
+    /// <summary>
+    /// Returns the generated HTML table markup.
+    /// </summary>
+    /// <returns>HTML markup for the table.</returns>
     public override string ToString() {
         return BuildTable();
     }
 
+    /// <summary>
+    /// Builds the table markup using the configured headers, rows and footers.
+    /// </summary>
+    /// <returns>HTML markup for the table.</returns>
     public virtual string BuildTable() {
         var html = StringBuilderCache.Acquire();
         // Add table headers
@@ -315,6 +338,12 @@ public class Table : Element {
         return StringBuilderCache.GetStringAndRelease(html);
     }
 
+    /// <summary>
+    /// Creates a table instance using the specified objects and table type.
+    /// </summary>
+    /// <param name="objects">Source objects to populate the table.</param>
+    /// <param name="tableType">Desired table style.</param>
+    /// <returns>Concrete <see cref="Table"/> implementation.</returns>
     public static Table Create(IEnumerable<object> objects, TableType tableType) {
         Table table;
         switch (tableType) {
@@ -333,6 +362,12 @@ public class Table : Element {
         return table;
     }
 
+    /// <summary>
+    /// Creates a table from a single object or collection.
+    /// </summary>
+    /// <param name="obj">Object or collection to convert.</param>
+    /// <param name="tableType">Desired table style.</param>
+    /// <returns>Concrete <see cref="Table"/> implementation.</returns>
     public static Table Create(object obj, TableType tableType) {
         if (obj is IEnumerable enumerable && obj is not string && obj is not IDictionary) {
             return Create(enumerable.Cast<object>(), tableType);

--- a/HtmlForgeX/Containers/Email/Enums/EmailFontSize.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailFontSize.cs
@@ -26,6 +26,11 @@ public enum EmailFontSize {
 /// Helper methods for <see cref="EmailFontSize"/> values.
 /// </summary>
 public static class EmailFontSizeExtensions {
+    /// <summary>
+    /// Converts the enum to an absolute CSS <c>px</c> value.
+    /// </summary>
+    /// <param name="fontSize">Font size value.</param>
+    /// <returns>Pixel size string.</returns>
     public static string ToCssValue(this EmailFontSize fontSize) {
         return fontSize switch {
             EmailFontSize.Small => "12px",

--- a/HtmlForgeX/Containers/Email/Enums/EmailSpacing.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailSpacing.cs
@@ -24,6 +24,11 @@ public enum EmailSpacing {
 /// Extension methods for <see cref="EmailSpacing"/> values.
 /// </summary>
 public static class EmailSpacingExtensions {
+    /// <summary>
+    /// Converts the spacing value to a CSS <c>px</c> value.
+    /// </summary>
+    /// <param name="spacing">Spacing option.</param>
+    /// <returns>Pixel string representation.</returns>
     public static string ToCssValue(this EmailSpacing spacing) {
         return spacing switch {
             EmailSpacing.None => "0",

--- a/HtmlForgeX/Containers/Email/Enums/EmailTableStyle.cs
+++ b/HtmlForgeX/Containers/Email/Enums/EmailTableStyle.cs
@@ -30,6 +30,11 @@ public enum EmailTableStyle {
 /// Extension helpers for <see cref="EmailTableStyle"/>.
 /// </summary>
 public static class EmailTableStyleExtensions {
+    /// <summary>
+    /// Retrieves layout information associated with a predefined table style.
+    /// </summary>
+    /// <param name="style">The table style to evaluate.</param>
+    /// <returns>Tuple containing class name and additional style metadata.</returns>
     public static (string cssClass, bool striped, bool bordered, string headerStyle, string cellStyle, string borderColor, string stripeColor) GetStyle(this EmailTableStyle style) {
         return style switch {
             EmailTableStyle.Simple => (

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarViewOption.cs
@@ -14,12 +14,15 @@ public enum FullCalendarViewOption {
     [Description("listWeek")]
     ListWeek,
 
+    /// <summary>List events for a month.</summary>
     [Description("listMonth")]
     ListMonth,
 
+    /// <summary>List events for an entire year.</summary>
     [Description("listYear")]
     ListYear,
 
+    /// <summary>List events for a single day.</summary>
     [Description("listDay")]
     ListDay
 }

--- a/HtmlForgeX/Containers/Quill/QuillEnums.cs
+++ b/HtmlForgeX/Containers/Quill/QuillEnums.cs
@@ -8,7 +8,9 @@ namespace HtmlForgeX;
 /// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<QuillTheme>))]
 public enum QuillTheme {
+    /// <summary>Standard "snow" theme.</summary>
     [Description("snow")] Snow,
+    /// <summary>Minimal "bubble" theme.</summary>
     [Description("bubble")] Bubble
 }
 
@@ -17,25 +19,46 @@ public enum QuillTheme {
 /// </summary>
 [JsonConverter(typeof(DescriptionEnumConverter<QuillFormat>))]
 public enum QuillFormat {
+    /// <summary>Background color styling.</summary>
     [Description("background")] Background,
+    /// <summary>Bold text.</summary>
     [Description("bold")] Bold,
+    /// <summary>Font color styling.</summary>
     [Description("color")] Color,
+    /// <summary>Font family selection.</summary>
     [Description("font")] Font,
+    /// <summary>Inline code formatting.</summary>
     [Description("code")] Code,
+    /// <summary>Italic text.</summary>
     [Description("italic")] Italic,
+    /// <summary>Hyperlink formatting.</summary>
     [Description("link")] Link,
+    /// <summary>Font size selection.</summary>
     [Description("size")] Size,
+    /// <summary>Strike-through text.</summary>
     [Description("strike")] Strike,
+    /// <summary>Super or subscript text.</summary>
     [Description("script")] Script,
+    /// <summary>Underlined text.</summary>
     [Description("underline")] Underline,
+    /// <summary>Block quote formatting.</summary>
     [Description("blockquote")] Blockquote,
+    /// <summary>Heading levels.</summary>
     [Description("header")] Header,
+    /// <summary>Indentation level.</summary>
     [Description("indent")] Indent,
+    /// <summary>Ordered or bullet lists.</summary>
     [Description("list")] List,
+    /// <summary>Text alignment.</summary>
     [Description("align")] Align,
+    /// <summary>Text directionality.</summary>
     [Description("direction")] Direction,
+    /// <summary>Code block styling.</summary>
     [Description("code-block")] CodeBlock,
+    /// <summary>LaTeX formula embedding.</summary>
     [Description("formula")] Formula,
+    /// <summary>Image embedding.</summary>
     [Description("image")] Image,
+    /// <summary>Video embedding.</summary>
     [Description("video")] Video
 }

--- a/HtmlForgeX/Containers/Tabler/Card/TablerCardEnhanced.cs
+++ b/HtmlForgeX/Containers/Tabler/Card/TablerCardEnhanced.cs
@@ -10,28 +10,47 @@ namespace HtmlForgeX;
 /// </summary>
 public partial class TablerCardEnhanced : TablerCard {
     // Card header properties
+    /// <summary>Primary title displayed in the card header.</summary>
     public string HeaderTitle { get; set; } = string.Empty;
+    /// <summary>Secondary title displayed beneath the header title.</summary>
     public string HeaderSubtitle { get; set; } = string.Empty;
+    /// <summary>Optional avatar shown in the header.</summary>
     public TablerAvatar HeaderAvatar { get; set; }
+    /// <summary>Action elements such as buttons shown in the header.</summary>
     public List<Element> HeaderActions { get; set; } = new List<Element>();
+    /// <summary>Whether the header uses a light background color.</summary>
     public bool HeaderLightBackground { get; set; }
+    /// <summary>Indicates if navigation tabs are present in the header.</summary>
     public bool HasHeaderTabs { get; set; }
+    /// <summary>Indicates if pill-style navigation is present in the header.</summary>
     public bool HasHeaderPills { get; set; }
+    /// <summary>Navigation items rendered within the header.</summary>
     public List<TablerNavItem> HeaderNavItems { get; set; } = new List<TablerNavItem>();
 
     // Card image properties
+    /// <summary>URL of the card image.</summary>
     public string ImageUrl { get; set; } = string.Empty;
+    /// <summary>Position of the image relative to the card.</summary>
     public string ImagePosition { get; set; } = "top"; // top, bottom, left, right
+    /// <summary>Alternate text for the image.</summary>
     public string ImageAlt { get; set; } = string.Empty;
+    /// <summary>Whether the image should be responsive.</summary>
     public bool ImageResponsive { get; set; } = true;
+    /// <summary>Aspect ratio used when cropping the image.</summary>
     public string ImageAspectRatio { get; set; } = "21x9";
 
     // Enhanced footer properties
+    /// <summary>Action elements displayed in the footer.</summary>
     public List<Element> FooterActions { get; set; } = new List<Element>();
+    /// <summary>Avatars displayed within the footer.</summary>
     public List<TablerAvatar> FooterAvatars { get; set; } = new List<TablerAvatar>();
+    /// <summary>Text content displayed in the footer.</summary>
     public string FooterText { get; set; } = string.Empty;
+    /// <summary>Whether the footer background is transparent.</summary>
     public bool FooterTransparent { get; set; }
+    /// <summary>Whether the footer contains a toggle switch.</summary>
     public bool FooterHasSwitch { get; set; }
+    /// <summary>Initial checked state of the footer switch.</summary>
     public bool FooterSwitchChecked { get; set; }
 
     /// <summary>

--- a/HtmlForgeX/Containers/Tabler/Enums/AvatarSize.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/AvatarSize.cs
@@ -4,10 +4,15 @@ namespace HtmlForgeX;
 /// Defines the available avatar sizes.
 /// </summary>
 public enum AvatarSize {
+    /// <summary>Extra small avatar.</summary>
     XS,
+    /// <summary>Small avatar.</summary>
     SM,
+    /// <summary>Medium avatar.</summary>
     MD,
+    /// <summary>Large avatar.</summary>
     LG,
+    /// <summary>Extra large avatar.</summary>
     XL
 }
 
@@ -16,8 +21,10 @@ public enum AvatarSize {
 /// </summary>
 public static class AvatarSizeExtensions {
     /// <summary>
-    /// Initializes or configures EnumToString.
+    /// Converts the avatar size to the corresponding Tabler CSS class.
     /// </summary>
+    /// <param name="size">Avatar size value.</param>
+    /// <returns>CSS class string.</returns>
     public static string EnumToString(this AvatarSize size) {
         return "avatar-" + size.ToString().ToLower();
     }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerAlertType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerAlertType.cs
@@ -4,6 +4,8 @@ namespace HtmlForgeX;
 /// Defines available alert behaviors.
 /// </summary>
 public enum TablerAlertType {
+    /// <summary>Static alert without close button.</summary>
     Regular,
+    /// <summary>Alert that can be dismissed by the user.</summary>
     Dismissible
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerBadgeStyle.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerBadgeStyle.cs
@@ -4,7 +4,10 @@ namespace HtmlForgeX;
 /// Represents the style of a badge.
 /// </summary>
 public enum TablerBadgeStyle {
+    /// <summary>Standard solid badge.</summary>
     Normal,
+    /// <summary>Outlined badge variant.</summary>
     Outline,
+    /// <summary>Pill-shaped badge.</summary>
     Pill
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerCardStyles.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerCardStyles.cs
@@ -81,7 +81,7 @@ public enum TablerCardSize {
 /// </summary>
 public static class TablerCardStyleExtensions {
     /// <summary>
-    /// Initializes or configures ToTablerCardStateClass.
+    /// Converts a card state to its corresponding CSS class.
     /// </summary>
     public static string ToTablerCardStateClass(this TablerCardState state) {
         return state switch {
@@ -94,7 +94,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardLayoutClass.
+    /// Converts a card layout option to its CSS class.
     /// </summary>
     public static string ToTablerCardLayoutClass(this TablerCardLayout layout) {
         return layout switch {
@@ -107,7 +107,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardHeaderClass.
+    /// Converts a header style value to its Tabler CSS class.
     /// </summary>
     public static string ToTablerCardHeaderClass(this TablerCardHeaderStyle style) {
         return style switch {
@@ -120,7 +120,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardFooterClass.
+    /// Converts a footer style value to its Tabler CSS class.
     /// </summary>
     public static string ToTablerCardFooterClass(this TablerCardFooterStyle style) {
         return style switch {
@@ -133,7 +133,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardImageClass.
+    /// Gets the CSS class for positioning a card image.
     /// </summary>
     public static string ToTablerCardImageClass(this TablerCardImagePosition position) {
         return position switch {
@@ -148,7 +148,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardAlignmentClass.
+    /// Converts an alignment option to the respective text or layout class.
     /// </summary>
     public static string ToTablerCardAlignmentClass(this TablerCardAlignment alignment) {
         return alignment switch {
@@ -161,7 +161,7 @@ public static class TablerCardStyleExtensions {
     }
 
     /// <summary>
-    /// Initializes or configures ToTablerCardSizeClass.
+    /// Converts a card size value to its Tabler CSS class.
     /// </summary>
     public static string ToTablerCardSizeClass(this TablerCardSize size) {
         return size switch {

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerFontWeight.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerFontWeight.cs
@@ -4,6 +4,7 @@ namespace HtmlForgeX;
 /// Specifies font weight options.
 /// </summary>
 public enum TablerFontWeight {
+    /// <summary>Default medium weight.</summary>
     Medium,
     // Add more options here as needed
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerProgressBarType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerProgressBarType.cs
@@ -15,8 +15,10 @@ public enum TablerProgressBarType {
 /// </summary>
 public static class TablerProgressBarTypeExtensions {
     /// <summary>
-    /// Initializes or configures ToClassString.
+    /// Converts the progress bar type to a Tabler CSS class string.
     /// </summary>
+    /// <param name="type">Progress bar style.</param>
+    /// <returns>CSS class name.</returns>
     public static string ToClassString(this TablerProgressBarType type) {
         return type switch {
             TablerProgressBarType.Separated => "progress-separated",

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerRowType.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerRowType.cs
@@ -14,8 +14,10 @@ public enum TablerRowType {
 /// </summary>
 public static class TablerRowTypeExtensions {
     /// <summary>
-    /// Initializes or configures EnumToString.
+    /// Converts the row type value to its Tabler CSS class.
     /// </summary>
+    /// <param name="rowType">Row layout option.</param>
+    /// <returns>CSS class string.</returns>
     public static string EnumToString(this TablerRowType rowType) {
         return rowType switch {
             TablerRowType.Default => "row",

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerStepsOrientation.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerStepsOrientation.cs
@@ -18,8 +18,10 @@ public enum StepsOrientation {
 /// </summary>
 public static class StepsOrientationExtensions {
     /// <summary>
-    /// Initializes or configures EnumToString.
+    /// Converts the orientation to the corresponding Tabler class.
     /// </summary>
+    /// <param name="orientation">Steps orientation.</param>
+    /// <returns>CSS class string.</returns>
     public static string EnumToString(this StepsOrientation orientation) {
         return orientation switch {
             StepsOrientation.Horizontal => "steps-horizontal",

--- a/HtmlForgeX/Containers/Tabler/Forms/TablerFormEnums.cs
+++ b/HtmlForgeX/Containers/Tabler/Forms/TablerFormEnums.cs
@@ -36,6 +36,9 @@ public enum ValidationState {
     Warning
 }
 
+/// <summary>
+/// Extension methods for the <see cref="InputType"/> enum.
+/// </summary>
 public static class InputTypeExtensions {
     /// <summary>
     /// Converts the <see cref="InputType"/> value to its HTML <c>type</c> attribute value.
@@ -54,6 +57,9 @@ public static class InputTypeExtensions {
     };
 }
 
+/// <summary>
+/// Extension methods for the <see cref="ValidationState"/> enum.
+/// </summary>
 public static class ValidationStateExtensions {
     /// <summary>
     /// Returns the CSS class name that represents the validation state for an input element.

--- a/HtmlForgeX/Containers/Tabler/Icons/TablerIcon.cs
+++ b/HtmlForgeX/Containers/Tabler/Icons/TablerIcon.cs
@@ -11,10 +11,15 @@ namespace HtmlForgeX;
 /// Represents an SVG icon with full styling and positioning flexibility
 /// </summary>
 public class TablerIcon : Element {
+    /// <summary>Raw SVG markup for the icon.</summary>
     public string SvgContent { get; set; }
+    /// <summary>HTML attributes applied to the SVG element.</summary>
     public Dictionary<string, string> SvgAttributes { get; set; } = new Dictionary<string, string>();
+    /// <summary>CSS style properties applied directly to the SVG element.</summary>
     public Dictionary<string, string> SvgStyles { get; set; } = new Dictionary<string, string>();
+    /// <summary>Inline styles applied to the container element.</summary>
     public Dictionary<string, string> ContainerStyles { get; set; } = new Dictionary<string, string>();
+    /// <summary>Additional CSS classes applied to the container element.</summary>
     public string ContainerClasses { get; set; } = "";
 
     /// <summary>

--- a/HtmlForgeX/Containers/Tabler/Icons/TablerIconElement.cs
+++ b/HtmlForgeX/Containers/Tabler/Icons/TablerIconElement.cs
@@ -18,6 +18,9 @@ namespace HtmlForgeX;
 /// Replaces the old CSS-based TablerIcon system with native SVG rendering.
 /// </summary>
 public partial class TablerIconElement : Element {
+    /// <summary>
+    /// Identifier of the icon to display.
+    /// </summary>
     public TablerIconType Icon { get; set; }
     private TablerIcon _svgIcon;
 

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -12,10 +12,11 @@ public class DocumentConfiguration {
     private string _path = System.IO.Path.GetTempPath();
     private string _stylePath = string.Empty;
     private string _scriptPath = string.Empty;
+    private LibraryMode _libraryMode = LibraryMode.Online;
+
     /// <summary>
     /// Gets or sets the library mode for this document.
     /// </summary>
-    private LibraryMode _libraryMode = LibraryMode.Online;
     public LibraryMode LibraryMode {
         get => _libraryMode;
         set {


### PR DESCRIPTION
## Summary
- document Email properties
- document enum extension methods
- update Tabler card classes and examples with XML docs
- document table helpers and utilities
- fix library mode comment placement

## Testing
- `dotnet build HtmlForgeX.sln -v:m`

------
https://chatgpt.com/codex/tasks/task_e_6875f3841108832e9089a77c1b66ce4e