### PR TITLE
Make Codecov upload non-blocking

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -58,6 +58,8 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
+                  verbose: true
 
     test-ubuntu:
         name: 'Ubuntu'
@@ -90,6 +92,8 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
+                  verbose: true
 
     test-macos:
         name: 'macOS'
@@ -122,3 +126,5 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
+                  verbose: true


### PR DESCRIPTION
## Summary
- ensure Codecov uploads do not fail the pipeline
- enable verbose output for Codecov step

## Testing
- `dotnet restore HtmlForgeX.sln`
- `dotnet build HtmlForgeX.sln --configuration Release --no-restore`
- `dotnet test HtmlForgeX.sln --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687644c42ad8832ebe24047d8ce38a6a