### PR TITLE
Fix document propagation order and update tests

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentReferencePropagation.cs
+++ b/HtmlForgeX.Tests/TestDocumentReferencePropagation.cs
@@ -70,6 +70,34 @@ public class TestDocumentReferencePropagation
     }
 
     [TestMethod]
+    public void ConfigDelegate_ShouldHave_DocumentReference()
+    {
+        // Arrange
+        var document = new Document(LibraryMode.Online);
+
+        // Act
+        document.Body.Page(page =>
+        {
+            Assert.AreSame(document, page.Document, "Page config should have Document reference");
+
+            page.Row(row =>
+            {
+                Assert.AreSame(document, row.Document, "Row config should have Document reference");
+
+                row.Column(TablerColumnNumber.Twelve, column =>
+                {
+                    Assert.AreSame(document, column.Document, "Column config should have Document reference");
+
+                    column.Card(card =>
+                    {
+                        Assert.AreSame(document, card.Document, "Card config should have Document reference");
+                    });
+                });
+            });
+        });
+    }
+
+    [TestMethod]
     public void FluentAPI_ShouldPropagate_DocumentReference()
     {
         // Arrange

--- a/HtmlForgeX/Containers/Core/Body.Page.cs
+++ b/HtmlForgeX/Containers/Core/Body.Page.cs
@@ -18,8 +18,8 @@ public partial class Body : Element {
     /// <returns>The created <see cref="TablerPage"/>.</returns>
     public TablerPage Page(Action<TablerPage> config) {
         var page = new TablerPage();
-        config(page);
         this.Add(page);
+        config(page);
         return page;
     }
 }

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -367,6 +367,8 @@ public class DataTablesTable : Table {
 
     /// <summary>Registers the required libraries for DataTables based on features used.</summary>
     protected internal override void RegisterLibraries() {
+        base.RegisterLibraries();
+
         // Always register base DataTables and jQuery
         Document?.Configuration.Libraries.TryAdd(Libraries.JQuery, 0);
         Document?.Configuration.Libraries.TryAdd(Libraries.DataTables, 0);

--- a/HtmlForgeX/Containers/Tabler/TablerColumn.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerColumn.cs
@@ -69,8 +69,8 @@ public class TablerColumn : Element {
     /// </summary>
     public TablerCard Card(Action<TablerCard> config) {
         var card = new TablerCard();
-        config(card);
         this.Add(card);
+        config(card);
         return card;
     }
 
@@ -79,8 +79,8 @@ public class TablerColumn : Element {
     /// </summary>
     public new TablerCard Card(int count, Action<TablerCard> config) {
         var card = new TablerCard(count);
-        config(card);
         this.Add(card);
+        config(card);
         return card;
     }
 

--- a/HtmlForgeX/Containers/Tabler/TablerPage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerPage.cs
@@ -30,8 +30,8 @@ public class TablerPage : Element {
         var row = new TablerRow(TablerRowType.Cards, TablerRowType.Deck);
         // Automatically add bottom spacing to separate rows visually
         row.WithBottomSpacing(TablerSpacing.Medium);
-        config(row);
         this.Add(row);
+        config(row);
         return row;
     }
 

--- a/HtmlForgeX/Containers/Tabler/TablerRow.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerRow.cs
@@ -181,8 +181,8 @@ public class TablerRow : Element {
     /// </summary>
     public TablerColumn Column(Action<TablerColumn> config) {
         var column = new TablerColumn();
-        config(column);
         this.Add(column);
+        config(column);
         return column;
     }
 
@@ -191,8 +191,8 @@ public class TablerRow : Element {
     /// </summary>
     public TablerColumn Column(TablerColumnNumber number, Action<TablerColumn> config) {
         var column = new TablerColumn(number);
-        config(column);
         this.Add(column);
+        config(column);
         return column;
     }
 }


### PR DESCRIPTION
## Summary
- ensure Tabler builder methods add children before invoking configuration actions
- propagate document context during configuration callbacks
- fix DataTables library registration to include Bootstrap
- add regression test for document reference during configuration

## Testing
- `dotnet test --no-build`
- `dotnet run --project PrismTest/PrismTest.csproj` (manual PrismJS registration test)

------
https://chatgpt.com/codex/tasks/task_e_6876aab00828832e9aaebdaebe357b7d