### PR TITLE
Ensure card children register libraries

### DIFF
--- a/HtmlForgeX.Tests/TestPrismJsCardIntegration.cs
+++ b/HtmlForgeX.Tests/TestPrismJsCardIntegration.cs
@@ -1,0 +1,21 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestPrismJsCardIntegration {
+    [TestMethod]
+    public void PrismCodeBlockInsideCard_ShouldRegisterLibraries() {
+        var doc = new Document(LibraryMode.Online);
+        var card = new TablerCard();
+        card.Body(body => {
+            body.CSharpCode("Console.WriteLine(\"Hello\");");
+        });
+        doc.Body.Add(card);
+
+        var html = doc.ToString();
+
+        Assert.IsTrue(doc.Configuration.Libraries.ContainsKey(Libraries.PrismJs), "PrismJS library should be registered");
+        Assert.IsTrue(html.Contains("prism"), "HTML should contain PrismJS references");
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerCard.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCard.cs
@@ -202,14 +202,17 @@ public class TablerCard : Element {
         if (PrivateHeader != null) {
             PrivateHeader.Document = this.Document;
             PrivateHeader.Email = this.Email;
+            PrivateHeader.OnAddedToDocument();
         }
         if (PrivateBody != null) {
             PrivateBody.Document = this.Document;
             PrivateBody.Email = this.Email;
+            PrivateBody.OnAddedToDocument();
         }
         if (PrivateFooter != null) {
             PrivateFooter.Document = this.Document;
             PrivateFooter.Email = this.Email;
+            PrivateFooter.OnAddedToDocument();
         }
 
         // Now call base implementation to register libraries


### PR DESCRIPTION
## Summary
- propagate document ref and invoke `OnAddedToDocument` on card parts
- test PrismJS code block registration in card body

## Testing
- `dotnet test --no-build --verbosity normal`
- `dotnet build --no-restore`
- `dotnet run --project HtmlForgeX.Examples/HtmlForgeX.Examples.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6876b6d33d40832ea126ef22242d8aef