### PR TITLE
Fix jpg mime detection

### DIFF
--- a/HtmlForgeX.Tests/TestEmailImageMimeType.cs
+++ b/HtmlForgeX.Tests/TestEmailImageMimeType.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailImageMimeType
+{
+    [TestMethod]
+    public void GetExtensionFromMimeType_ShouldHandleImageJpg()
+    {
+        var method = typeof(EmailImage).GetMethod("GetExtensionFromMimeType", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        var result = (string?)method!.Invoke(null, new object[] { "image/jpg" });
+        Assert.AreEqual(".jpg", result);
+    }
+}

--- a/HtmlForgeX/Containers/Email/EmailImage.cs
+++ b/HtmlForgeX/Containers/Email/EmailImage.cs
@@ -765,7 +765,7 @@ public class EmailImage : Element {
     /// <returns>The file extension.</returns>
     private static string GetExtensionFromMimeType(string mimeType) {
         return mimeType.ToLower() switch {
-            "image/jpeg" => ".jpg",
+            "image/jpeg" or "image/jpg" => ".jpg",
             "image/png" => ".png",
             "image/gif" => ".gif",
             "image/svg+xml" => ".svg",


### PR DESCRIPTION
## Summary
- support `image/jpg` MIME type in `EmailImage`
- add test verifying jpg detection

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6876b928ae5c832e8fa8a86de5b21381