### PR TITLE
Fix TablerCardActionBuilder enumeration

### DIFF
--- a/HtmlForgeX.Tests/TestTablerCardActions.cs
+++ b/HtmlForgeX.Tests/TestTablerCardActions.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerCardActions {
+    [TestMethod]
+    public void TablerCardActionBuilder_ReturnsSameList() {
+        var builder = new TablerCardActionBuilder()
+            .Button("Action1")
+            .IconButton(TablerIconType.Abacus);
+
+        var actions1 = builder.GetActions();
+        var actions2 = builder.GetActions();
+
+        Assert.AreEqual(2, actions1.Count);
+        Assert.AreSame(actions1, actions2);
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
@@ -11,7 +11,7 @@ public class TablerCardHeader : Element {
     private string? SubtitleText { get; set; }
     private TablerCardHeaderStyle HeaderStyle { get; set; } = TablerCardHeaderStyle.Default;
     private TablerAvatar? HeaderAvatar { get; set; }
-    private List<TablerCardAction> Actions { get; set; } = new List<TablerCardAction>();
+    private IReadOnlyList<TablerCardAction> Actions { get; set; } = new List<TablerCardAction>();
     private TablerCardNavigation? Navigation { get; set; }
 
     /// <summary>
@@ -270,5 +270,5 @@ public class TablerCardActionBuilder {
     /// <summary>
     /// Retrieves the collection of actions configured for the header.
     /// </summary>
-    public List<TablerCardAction> GetActions() => actions;
+    public IReadOnlyList<TablerCardAction> GetActions() => actions;
 }


### PR DESCRIPTION
## Summary
- prevent additional enumeration when retrieving card header actions
- expose actions as `IReadOnlyList`
- add a unit test ensuring action collection is stable

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln --no-build -c Release`
- `dotnet test HtmlForgeX.sln --no-build -c Release --filter TablerCardActionBuilder_ReturnsSameList`

------
https://chatgpt.com/codex/tasks/task_e_6876b937f420832e9507b21e1b68ba38