### PR TITLE
Support UNC paths in save routines

### DIFF
--- a/HtmlForgeX.Tests/TestUncPaths.cs
+++ b/HtmlForgeX.Tests/TestUncPaths.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestUncPaths {
+    [TestMethod]
+    public void PathUtilities_Validate_UncPath() {
+        string path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "\\\\server\\share\\file.html"
+            : "//server/share/file.html";
+        PathUtilities.Validate(path);
+    }
+
+    [TestMethod]
+    public void Document_Save_UncStylePath() {
+        var doc = new Document();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            string local = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString(), "file.html");
+            Directory.CreateDirectory(Path.GetDirectoryName(local)!);
+            string uncPath = "\\\\?\\" + local;
+            doc.Save(uncPath);
+            Assert.IsTrue(File.Exists(uncPath));
+            File.Delete(uncPath);
+        } else {
+            string path = Path.Combine("//", Path.GetTempFileName());
+            doc.Save(path);
+            Assert.IsTrue(File.Exists(path));
+            File.Delete(path);
+        }
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.Save.cs
+++ b/HtmlForgeX/Containers/Core/Document.Save.cs
@@ -17,7 +17,7 @@ public partial class Document
     public void Save(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "")
     {
         PathUtilities.Validate(path);
-        path = Path.GetFullPath(path);
+        path = System.IO.Path.GetFullPath(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath))
         {
@@ -79,7 +79,7 @@ public partial class Document
     public async Task SaveAsync(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "")
     {
         PathUtilities.Validate(path);
-        path = Path.GetFullPath(path);
+        path = System.IO.Path.GetFullPath(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath))
         {
@@ -148,8 +148,8 @@ public partial class Document
             return false;
         }
 
-        var unc = directory.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return unc.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Length == 2;
+        var unc = directory.TrimStart(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+        return unc.Split(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Length == 2;
     }
 }
 

--- a/HtmlForgeX/Containers/Core/Document.Save.cs
+++ b/HtmlForgeX/Containers/Core/Document.Save.cs
@@ -17,6 +17,7 @@ public partial class Document
     public void Save(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "")
     {
         PathUtilities.Validate(path);
+        path = Path.GetFullPath(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath))
         {
@@ -39,7 +40,10 @@ public partial class Document
         {
             try
             {
-                System.IO.Directory.CreateDirectory(directory);
+                if (!IsUncRoot(directory))
+                {
+                    System.IO.Directory.CreateDirectory(directory);
+                }
             }
             catch (Exception ex)
             {
@@ -75,6 +79,7 @@ public partial class Document
     public async Task SaveAsync(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "")
     {
         PathUtilities.Validate(path);
+        path = Path.GetFullPath(path);
         Configuration.Path = path;
         if (!string.IsNullOrEmpty(scriptPath))
         {
@@ -97,7 +102,10 @@ public partial class Document
         {
             try
             {
-                System.IO.Directory.CreateDirectory(directory);
+                if (!IsUncRoot(directory))
+                {
+                    System.IO.Directory.CreateDirectory(directory);
+                }
             }
             catch (Exception ex)
             {
@@ -126,6 +134,22 @@ public partial class Document
         {
             _logger.WriteError($"Failed to open file '{path}' using the default application.");
         }
+    }
+
+    private static bool IsUncRoot(string directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+        {
+            return false;
+        }
+
+        if (!(directory.StartsWith("\\") || directory.StartsWith("//")))
+        {
+            return false;
+        }
+
+        var unc = directory.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return unc.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Length == 2;
     }
 }
 

--- a/HtmlForgeX/Utilities/PathUtilities.cs
+++ b/HtmlForgeX/Utilities/PathUtilities.cs
@@ -12,5 +12,14 @@ internal static class PathUtilities {
         if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0) {
             throw new ArgumentException("Path contains invalid characters.", nameof(path));
         }
+
+        // UNC paths start with two directory separators. Ensure they have at least
+        // a server and share specified before treating them as valid.
+        if (path.StartsWith("\\") || path.StartsWith("//")) {
+            var unc = path.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (unc.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).Length < 2) {
+                throw new ArgumentException("UNC path must include a server and share name.", nameof(path));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow UNC segments in `PathUtilities.Validate`
- normalize file paths and skip UNC roots when saving documents
- test UNC path handling across platforms

## Testing
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6876b9775fbc832e89f0845cb2620a68