### PR TITLE
Fix EmailImage base64 streams

### DIFF
--- a/HtmlForgeX.Tests/TestEmailImageBase64Embedding.cs
+++ b/HtmlForgeX.Tests/TestEmailImageBase64Embedding.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HtmlForgeX;
 
 namespace HtmlForgeX.Tests;
 
@@ -46,6 +47,21 @@ public class TestEmailImageBase64Embedding
         Assert.AreEqual("image/png", emailImage.MimeType);
         Assert.IsFalse(string.IsNullOrEmpty(emailImage.Base64Data));
         Assert.IsTrue(emailImage.Source.StartsWith("data:image/png;base64,"));
+    }
+
+    [TestMethod]
+    public void EmailImage_EmbedFromFile_ShouldNotLockFile()
+    {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var filePath = Path.Combine(tempDir, Path.GetRandomFileName() + ".png");
+        File.WriteAllBytes(filePath, _testImageData);
+
+        var emailImage = new EmailImage();
+        emailImage.EmbedFromFile(filePath);
+
+        Assert.IsFalse(filePath.IsFileLocked());
+
+        File.Delete(filePath);
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/Email/EmailImage.cs
+++ b/HtmlForgeX/Containers/Email/EmailImage.cs
@@ -431,7 +431,11 @@ public class EmailImage : Element {
                     return this;
                 }
 
-                var bytes = System.IO.File.ReadAllBytes(filePath);
+                byte[] bytes;
+                using var fileStream = System.IO.File.OpenRead(filePath);
+                using var memoryStream = new System.IO.MemoryStream();
+                fileStream.CopyTo(memoryStream);
+                bytes = memoryStream.ToArray();
                 var extension = System.IO.Path.GetExtension(filePath).ToLower();
 
                 MimeType = GetMimeTypeFromExtension(extension);
@@ -468,7 +472,7 @@ public class EmailImage : Element {
             using var httpClient = new System.Net.Http.HttpClient();
             httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
 
-            var response = httpClient.GetAsync(url).Result;
+            using var response = httpClient.GetAsync(url).Result;
             if (response.IsSuccessStatusCode) {
                 var bytes = response.Content.ReadAsByteArrayAsync().Result;
 
@@ -573,7 +577,7 @@ public class EmailImage : Element {
                     // Download from URL
                     using var httpClient = new System.Net.Http.HttpClient();
                     httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
-                    var response = httpClient.GetAsync(source).Result;
+                    using var response = httpClient.GetAsync(source).Result;
 
                     if (response.IsSuccessStatusCode) {
                         bytes = response.Content.ReadAsByteArrayAsync().Result;
@@ -583,7 +587,10 @@ public class EmailImage : Element {
                     }
                 } else if (System.IO.File.Exists(source)) {
                     // Load from file
-                    bytes = System.IO.File.ReadAllBytes(source);
+                    using var fileStream = System.IO.File.OpenRead(source);
+                    using var memoryStream = new System.IO.MemoryStream();
+                    fileStream.CopyTo(memoryStream);
+                    bytes = memoryStream.ToArray();
                     var extension = System.IO.Path.GetExtension(source).ToLower();
                     mimeType = GetMimeTypeFromExtension(extension);
                 } else {
@@ -591,7 +598,10 @@ public class EmailImage : Element {
                 }
             } else {
                 // Assume file path
-                bytes = System.IO.File.ReadAllBytes(source);
+                using var fileStream = System.IO.File.OpenRead(source);
+                using var memoryStream = new System.IO.MemoryStream();
+                fileStream.CopyTo(memoryStream);
+                bytes = memoryStream.ToArray();
                 var extension = System.IO.Path.GetExtension(source).ToLower();
                 mimeType = GetMimeTypeFromExtension(extension);
             }


### PR DESCRIPTION
## Summary
- wrap file streams in EmailImage when converting to base64
- dispose HttpClient responses when embedding images
- add regression test ensuring files aren't locked after embedding

## Testing
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6876ba67189c832e9264b2ee5db90152