### PR TITLE
Fix PrismJS copy button ordering

### DIFF
--- a/HtmlForgeX.Tests/TestPrismJs.cs
+++ b/HtmlForgeX.Tests/TestPrismJs.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestPrismJs
+{
+    [TestMethod]
+    public void PrismJs_CodeBlock_GeneratesExpectedHtml()
+    {
+        var doc = new Document();
+        doc.Body.Add(element =>
+        {
+            element.CSharpCode("Console.WriteLine(\"Hi\");", config => config
+                .EnableLineNumbers()
+                .EnableCopyButton()
+                .SetTitle("Sample"));
+        });
+
+        var html = doc.ToString();
+
+        Assert.IsTrue(html.Contains("prism-core.min.js"), "Prism core library should be included");
+        Assert.IsTrue(doc.Configuration.Libraries.ContainsKey(Libraries.PrismJs), "PrismJs library should be registered");
+
+        var preIndex = html.IndexOf("<pre");
+        Assert.IsTrue(preIndex >= 0 && html.IndexOf("data-prismjs-copy", preIndex) > preIndex, "Copy attribute should be present");
+        Assert.IsTrue(html.Contains("line-numbers"), "Line numbers class should be present");
+
+        var toolbarIndex = html.IndexOf("prism-toolbar.min.js");
+        var copyIndex = html.IndexOf("prism-copy-to-clipboard.min.js");
+        Assert.IsTrue(toolbarIndex < copyIndex, "Toolbar script should come before copy-to-clipboard script");
+    }
+}

--- a/HtmlForgeX/Resources/PrismJsLibrary.cs
+++ b/HtmlForgeX/Resources/PrismJsLibrary.cs
@@ -20,8 +20,8 @@ public class PrismJsLibrary : Library
                 "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js",
                 "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js",
                 "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js",
-                "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js",
-                "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/toolbar/prism-toolbar.min.js"
+                "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/toolbar/prism-toolbar.min.js",
+                "https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"
             ]
         };
 


### PR DESCRIPTION
## Summary
- fix PrismJS library order so toolbar loads before copy-to-clipboard
- add regression test covering PrismJS code block features

## Testing
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6876bb30f238832e8b0983fdf06c48c0