### PR TITLE
Clamp progress bar value

### DIFF
--- a/HtmlForgeX.Examples/Tags/ExampleTablerProgressBarShowcase.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerProgressBarShowcase.cs
@@ -53,6 +53,10 @@ internal static class ExampleTablerProgressBarShowcase {
                         card.LineBreak();
                         card.Add(new TablerProgressBar().Item(TablerColor.Black, 100, "Complete"));
                         card.LineBreak();
+                        card.Add(new TablerProgressBar().Item(TablerColor.Primary, -20, "Negative clamped"));
+                        card.LineBreak();
+                        card.Add(new TablerProgressBar().Item(TablerColor.Success, 120, "Over 100% clamped"));
+                        card.LineBreak();
                         card.ProgressBar(TablerProgressBarType.Separated)
                             .Item(TablerColor.Green, 25, "A")
                             .Item(TablerColor.Red, 75, "B");

--- a/HtmlForgeX.Tests/TestTablerProgressBarItem.cs
+++ b/HtmlForgeX.Tests/TestTablerProgressBarItem.cs
@@ -5,12 +5,14 @@ namespace HtmlForgeX.Tests;
 [TestClass]
 public class TestTablerProgressBarItem {
     [TestMethod]
-    public void ConstructorThrowsWhenProgressBelowZero() {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new TablerProgressBarItem(TablerColor.Primary, -1));
+    public void ProgressBelowZero_IsClampedToZero() {
+        var item = new TablerProgressBarItem(TablerColor.Primary, -1);
+        StringAssert.Contains(item.ToString(), "width: 0%");
     }
 
     [TestMethod]
-    public void ConstructorThrowsWhenProgressAboveHundred() {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new TablerProgressBarItem(TablerColor.Primary, 101));
+    public void ProgressAboveHundred_IsClampedToHundred() {
+        var item = new TablerProgressBarItem(TablerColor.Primary, 101);
+        StringAssert.Contains(item.ToString(), "width: 100%");
     }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerProgressBar.cs
@@ -21,12 +21,8 @@ public class TablerProgressBarItem : Element {
     /// <param name="background">Background color for the progress bar segment.</param>
     /// <param name="progress">Progress percentage.</param>
     public TablerProgressBarItem(TablerColor background, int progress) {
-        if (progress is < 0 or > 100) {
-            throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
-        }
-
         Background = background;
-        Progress = progress;
+        Progress = Clamp(progress);
     }
 
     /// <summary>
@@ -39,16 +35,20 @@ public class TablerProgressBarItem : Element {
     /// <param name="valueMin">Optional minimum value.</param>
     /// <param name="valueMax">Optional maximum value.</param>
     public TablerProgressBarItem(TablerColor background, int progress, string label, int? valueNow = null, int? valueMin = null, int? valueMax = null) {
-        if (progress is < 0 or > 100) {
-            throw new ArgumentOutOfRangeException(nameof(progress), progress, null);
-        }
-
         Background = background;
-        Progress = progress;
+        Progress = Clamp(progress);
         PrivateLabel = label;
         AriaValueNow = valueNow;
         AriaValueMin = valueMin;
         AriaValueMax = valueMax;
+    }
+
+    private static int Clamp(int progress) {
+        if (progress < 0) {
+            return 0;
+        }
+
+        return progress > 100 ? 100 : progress;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- clamp TablerProgressBarItem `progress` between 0-100
- test progress bar item clamping logic
- show clamped progress in example app

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6876bdfac328832eb11bf676c2302998