### PR TITLE
Allow decimal margins in emails

### DIFF
--- a/HtmlForgeX.Examples/Emails/ExampleDecimalMarginEmail.cs
+++ b/HtmlForgeX.Examples/Emails/ExampleDecimalMarginEmail.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace HtmlForgeX.Examples.Emails;
+
+/// <summary>
+/// Demonstrates using decimal margin values in email components.
+/// </summary>
+public static class ExampleDecimalMarginEmail {
+    public static void Create(bool openInBrowser = false) {
+        Console.WriteLine("Creating decimal margin email example...");
+
+        var email = new Email();
+
+        email.Head.AddTitle("Decimal Margin Demo")
+                  .AddEmailCoreStyles();
+
+        email.Body.EmailBox(box => {
+            box.SetOuterMargin("0 auto 1.5em auto").SetMaxWidth("600px");
+            box.EmailContent(content => {
+                content.EmailText("This paragraph uses decimal margin values.")
+                    .WithMargin("1.5em 0");
+            });
+        });
+
+        email.Save("decimal-margin-email.html", openInBrowser);
+        Console.WriteLine("✅ Decimal margin email created successfully!");
+        Console.WriteLine("📧 Demonstrates: Using decimal margins (1.5em).\n");
+    }
+}

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -148,6 +148,9 @@ internal class Program {
         // Base64 embedding examples (if they exist)
         ExampleBase64EmbeddingEmail.Create(openInBrowser);
 
+        // Decimal margin demonstration
+        ExampleDecimalMarginEmail.Create(openInBrowser);
+
         // Layout configuration demonstration - NEW enum-based configuration system!
         ExampleLayoutConfigurationDemo.Create(openInBrowser);
 

--- a/HtmlForgeX.Tests/TestMarginValidation.cs
+++ b/HtmlForgeX.Tests/TestMarginValidation.cs
@@ -12,4 +12,16 @@ public class TestMarginValidation {
         Assert.ThrowsException<ArgumentException>(() => new EmailBox().CenterWithMargin("invalid"));
         Assert.ThrowsException<ArgumentException>(() => new EmailBox().SetOuterMargin("invalid"));
     }
+
+    [TestMethod]
+    public void WithMargin_DecimalValue_Accepts() {
+        var text = new EmailText().WithMargin("1.5em");
+        Assert.AreEqual("1.5em", text.Margin);
+
+        var link = new EmailLink("demo", "#").WithMargin("0 1.5em");
+        Assert.AreEqual("0 1.5em", link.Margin);
+
+        var box = new EmailBox().SetOuterMargin("0 auto 1.5em auto");
+        Assert.AreEqual("0 auto 1.5em auto", box.OuterMargin);
+    }
 }

--- a/HtmlForgeX/Containers/Email/EmailMarginExtensions.cs
+++ b/HtmlForgeX/Containers/Email/EmailMarginExtensions.cs
@@ -5,7 +5,7 @@ namespace HtmlForgeX;
 /// </summary>
 public static class EmailMarginExtensions {
     private static readonly System.Text.RegularExpressions.Regex MarginRegex = new(
-        "^(0|auto|[0-9]+(px|em|%))( (0|auto|[0-9]+(px|em|%))){0,3}$",
+        "^(0|auto|[0-9]+(\\.[0-9]+)?(px|em|%))( (0|auto|[0-9]+(\\.[0-9]+)?(px|em|%))){0,3}$",
         System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- support decimal numbers in `EmailMarginExtensions` regex
- cover decimal margins in tests
- add decimal margin example and call it from Program

## Testing
- `dotnet test HtmlForgeX.sln -c Release --no-build`
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6876bdf1218c832eb000db035046a420