### PR TITLE
Add SearchBuilder groups and operators

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -167,5 +167,6 @@ internal class Program {
         DataTablesExtensionsDemo.Create(openInBrowser);
         DataTablesFeatureTest.RunAllTests(openInBrowser);
         DataTablesRenderingDemo.Create(openInBrowser);
+        DataTablesInteractiveFilteringDemo.Create(openInBrowser);
     }
 }

--- a/HtmlForgeX.Examples/Tables/DataTablesInteractiveFilteringDemo.cs
+++ b/HtmlForgeX.Examples/Tables/DataTablesInteractiveFilteringDemo.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace HtmlForgeX.Examples.Tables;
+
+/// <summary>
+/// Demonstrates complex condition groups and custom operators in SearchBuilder.
+/// </summary>
+internal class DataTablesInteractiveFilteringDemo {
+    public static void Create(bool openInBrowser = false) {
+        HelpersSpectre.PrintTitle("🔍 DataTables Interactive Filtering");
+
+        var sales = new List<dynamic> {
+            new { Product = "Laptop", Category = "Electronics", Amount = 1500, Region = "Europe" },
+            new { Product = "Phone", Category = "Electronics", Amount = 800, Region = "North America" },
+            new { Product = "Desk", Category = "Furniture", Amount = 300, Region = "Europe" },
+            new { Product = "Chair", Category = "Furniture", Amount = 120, Region = "Asia" },
+            new { Product = "Camera", Category = "Electronics", Amount = 600, Region = "Europe" }
+        };
+
+        var document = new Document {
+            Head = {
+                Title = "DataTables Interactive Filtering",
+                Author = "HtmlForgeX Team",
+                Description = "Demo with SearchBuilder condition groups and custom operators",
+                Keywords = "datatable, searchbuilder, interactive filtering"
+            }
+        };
+
+        document.Body.Page(page => {
+            page.Layout = TablerLayout.Fluid;
+            page.Add(new HeaderLevel(HeaderLevelTag.H1, "Interactive Filtering"));
+            page.Text("SearchBuilder with predefined groups and a custom operator:");
+            page.DataTable(sales, table => {
+                table.ConfigureSearchBuilder(sb => sb
+                    .Group(g => g
+                        .Logic("OR")
+                        .Criterion("Region", "equals", "Europe")
+                        .Criterion("Amount", ">", 1000))
+                    .CustomOperator("startsWith", "function(value, input){ return value.startsWith(input); }")
+                );
+            });
+        });
+
+        document.Save("DataTablesInteractiveFilteringDemo.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Tests/TestDataTablesSearchBuilder.cs
+++ b/HtmlForgeX.Tests/TestDataTablesSearchBuilder.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace HtmlForgeX.Tests;
+
+/// <summary>
+/// Tests serialization of SearchBuilder advanced features.
+/// </summary>
+[TestClass]
+public class TestDataTablesSearchBuilder {
+    [TestMethod]
+    public void SearchBuilder_SerializesConditionGroupsAndCustomOperators() {
+        var table = new DataTablesTable();
+        table.ConfigureSearchBuilder(sb => sb
+            .Group(g => g
+                .Logic("AND")
+                .Criterion("Amount", ">", 100))
+            .CustomOperator("startsWith", "function(v,i){ return v.startsWith(i); }")
+        );
+
+        var html = table.ToString();
+        StringAssert.Contains(html, "\"conditionGroups\"");
+        StringAssert.Contains(html, "startsWith");
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/Builders/DataTablesSearchBuilderBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Builders/DataTablesSearchBuilderBuilder.cs
@@ -1,0 +1,112 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Fluent builder for configuring DataTables SearchBuilder.
+/// </summary>
+public class DataTablesSearchBuilderBuilder
+{
+    private readonly DataTablesSearchBuilder _searchBuilder = new();
+    private readonly List<DataTablesSearchGroup> _groups = new();
+    private readonly Dictionary<string, string> _operators = new();
+
+    /// <summary>Enable or disable SearchBuilder.</summary>
+    public DataTablesSearchBuilderBuilder Enable(bool enable = true)
+    {
+        _searchBuilder.Enable = enable;
+        return this;
+    }
+
+    /// <summary>Set group logic for top level.</summary>
+    public DataTablesSearchBuilderBuilder Logic(string logic)
+    {
+        _searchBuilder.Logic = logic;
+        return this;
+    }
+
+    /// <summary>Set default number of conditions.</summary>
+    public DataTablesSearchBuilderBuilder Conditions(int count)
+    {
+        _searchBuilder.Conditions = count;
+        return this;
+    }
+
+    /// <summary>Enable grey scale.</summary>
+    public DataTablesSearchBuilderBuilder Greyscale(bool greyscale = true)
+    {
+        _searchBuilder.Greyscale = greyscale;
+        return this;
+    }
+
+    /// <summary>Set predefined configuration object.</summary>
+    public DataTablesSearchBuilderBuilder PreDefined(object predefined)
+    {
+        _searchBuilder.PreDefined = predefined;
+        return this;
+    }
+
+    /// <summary>Add a condition group.</summary>
+    public DataTablesSearchBuilderBuilder Group(Action<DataTablesSearchGroupBuilder> configure)
+    {
+        var builder = new DataTablesSearchGroupBuilder();
+        configure(builder);
+        _groups.Add(builder.Build());
+        return this;
+    }
+
+    /// <summary>Add a custom operator.</summary>
+    public DataTablesSearchBuilderBuilder CustomOperator(string name, string javascript)
+    {
+        _operators[name] = javascript;
+        return this;
+    }
+
+    internal DataTablesSearchBuilder Build()
+    {
+        if (_groups.Count > 0)
+        {
+            _searchBuilder.ConditionGroups = _groups;
+        }
+
+        if (_operators.Count > 0)
+        {
+            _searchBuilder.CustomOperators = _operators;
+        }
+
+        if (_searchBuilder.Enable is null)
+        {
+            _searchBuilder.Enable = true;
+        }
+
+        return _searchBuilder;
+    }
+}
+
+/// <summary>
+/// Fluent builder for a SearchBuilder condition group.
+/// </summary>
+public class DataTablesSearchGroupBuilder
+{
+    private readonly DataTablesSearchGroup _group = new();
+
+    /// <summary>Set logic for the group (AND/OR).</summary>
+    public DataTablesSearchGroupBuilder Logic(string logic)
+    {
+        _group.Logic = logic;
+        return this;
+    }
+
+    /// <summary>Add a criterion to the group.</summary>
+    public DataTablesSearchGroupBuilder Criterion(string data, string condition, params object[] values)
+    {
+        _group.Criteria ??= new List<DataTablesSearchCriterion>();
+        _group.Criteria.Add(new DataTablesSearchCriterion
+        {
+            Data = data,
+            Condition = condition,
+            Value = values
+        });
+        return this;
+    }
+
+    internal DataTablesSearchGroup Build() => _group;
+}

--- a/HtmlForgeX/Containers/DataTables/Configuration/DataTablesSearchBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Configuration/DataTablesSearchBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
 
 namespace HtmlForgeX;
 
@@ -31,4 +32,51 @@ public class DataTablesSearchBuilder
     [JsonPropertyName("preDefined")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public object? PreDefined { get; set; }
+
+    /// <summary>Complex condition groups used for pre-defined filtering.</summary>
+    [JsonPropertyName("conditionGroups")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<DataTablesSearchGroup>? ConditionGroups { get; set; }
+
+    /// <summary>Custom operators for filtering logic.</summary>
+    [JsonPropertyName("customOperators")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, string>? CustomOperators { get; set; }
+}
+
+/// <summary>
+/// Represents a group of conditions in SearchBuilder.
+/// </summary>
+public class DataTablesSearchGroup
+{
+    /// <summary>Group logic (AND/OR).</summary>
+    [JsonPropertyName("logic")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Logic { get; set; }
+
+    /// <summary>List of criteria in the group.</summary>
+    [JsonPropertyName("criteria")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<DataTablesSearchCriterion>? Criteria { get; set; }
+}
+
+/// <summary>
+/// Represents single filtering criterion.
+/// </summary>
+public class DataTablesSearchCriterion
+{
+    /// <summary>Column data source.</summary>
+    [JsonPropertyName("data")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Data { get; set; }
+
+    /// <summary>Condition operator.</summary>
+    [JsonPropertyName("condition")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Condition { get; set; }
+
+    /// <summary>Value used for filtering.</summary>
+    [JsonPropertyName("value")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object[]? Value { get; set; }
 }

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -218,6 +218,14 @@ public class DataTablesTable : Table {
         return this;
     }
 
+    /// <summary>Configure SearchBuilder using a fluent builder.</summary>
+    public DataTablesTable ConfigureSearchBuilder(Action<DataTablesSearchBuilderBuilder> configure) {
+        var builder = new DataTablesSearchBuilderBuilder();
+        configure(builder);
+        Options.SearchBuilder = builder.Build();
+        return this;
+    }
+
     /// <summary>Enable search panes.</summary>
     public DataTablesTable EnableSearchPanes(Action<DataTablesSearchPanes>? configure = null) {
         Options.SearchPanes = new DataTablesSearchPanes { Enable = true };


### PR DESCRIPTION
## Summary
- add complex SearchBuilder condition groups and custom operators
- add interactive filtering example
- add unit test for SearchBuilder serialization
- expose a fluent SearchBuilder builder to keep API consistent

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6876bdc73178832eb87c7c1de459bdaa