### PR TITLE
Add framework specific temp path utility

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentConfiguration.cs
+++ b/HtmlForgeX.Tests/TestDocumentConfiguration.cs
@@ -17,7 +17,7 @@ public class TestDocumentConfiguration {
         Assert.AreEqual(ThemeMode.System, config.ThemeMode);
         Assert.AreEqual(LibraryMode.Online, config.LibraryMode);
         Assert.AreEqual(false, config.EnableDeferredScripts);
-        Assert.AreEqual(System.IO.Path.GetTempPath(), config.Path);
+        Assert.AreEqual(TempPath.Get(), config.Path);
         Assert.AreEqual("", config.StylePath);
         Assert.AreEqual("", config.ScriptPath);
         Assert.IsNotNull(config.Libraries);

--- a/HtmlForgeX.Tests/TestTempPath.cs
+++ b/HtmlForgeX.Tests/TestTempPath.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTempPath
+{
+    [TestMethod]
+    public void Get_ReturnsExistingFrameworkFolder()
+    {
+        var path = TempPath.Get();
+        Assert.IsTrue(Directory.Exists(path));
+        StringAssert.Contains(path, "HtmlForgeX");
+#if NET472
+        StringAssert.Contains(path, "net472");
+#elif NET8_0
+        StringAssert.Contains(path, "net8.0");
+#elif NET9_0
+        StringAssert.Contains(path, "net9.0");
+#endif
+    }
+}

--- a/HtmlForgeX/DocumentConfiguration.cs
+++ b/HtmlForgeX/DocumentConfiguration.cs
@@ -9,7 +9,7 @@ namespace HtmlForgeX;
 /// </summary>
 public class DocumentConfiguration {
     private readonly object _syncRoot = new();
-    private string _path = System.IO.Path.GetTempPath();
+    private string _path = TempPath.Get();
     private string _stylePath = string.Empty;
     private string _scriptPath = string.Empty;
     private LibraryMode _libraryMode = LibraryMode.Online;

--- a/HtmlForgeX/DocumentState.cs
+++ b/HtmlForgeX/DocumentState.cs
@@ -37,7 +37,7 @@ internal class DocumentState {
     /// <summary>
     /// Gets or sets the path for saving documents and related files.
     /// </summary>
-    public string Path { get; set; } = System.IO.Path.GetTempPath();
+    public string Path { get; set; } = TempPath.Get();
 
     /// <summary>Location for CSS resources.</summary>
     public string StylePath { get; set; } = "";

--- a/HtmlForgeX/Utilities/TempPath.cs
+++ b/HtmlForgeX/Utilities/TempPath.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+
+namespace HtmlForgeX;
+
+internal static class TempPath
+{
+    /// <summary>
+    /// Returns a temporary path unique to the current framework.
+    /// </summary>
+    public static string Get()
+    {
+        var frameworkId =
+#if NET472
+            "net472";
+#elif NET8_0
+            "net8.0";
+#elif NET9_0
+            "net9.0";
+#else
+            "unknown";
+#endif
+        var tempPath = Path.Combine(Path.GetTempPath(), "HtmlForgeX", frameworkId);
+        if (!Directory.Exists(tempPath))
+        {
+            try
+            {
+                Directory.CreateDirectory(tempPath);
+            }
+            catch (Exception ex)
+            {
+                Document._logger.WriteError($"Failed to create directory '{tempPath}'. {ex.Message}");
+            }
+        }
+        return tempPath;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize temp path retrieval with new `TempPath` utility
- default document configuration uses new temp folder
- adjust tests and add coverage for `TempPath`

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6876c2deeecc832e8605a7d846cbefad