### PR TITLE
Make regexes static and add benchmark

### DIFF
--- a/HtmlForgeX.Benchmarks/HtmlForgeX.Benchmarks.csproj
+++ b/HtmlForgeX.Benchmarks/HtmlForgeX.Benchmarks.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <ProjectReference Include="..\HtmlForgeX\HtmlForgeX.csproj" />
+  </ItemGroup>
+</Project>

--- a/HtmlForgeX.Benchmarks/Program.cs
+++ b/HtmlForgeX.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkRunner.Run<RegexBenchmarks>();

--- a/HtmlForgeX.Benchmarks/RegexBenchmarks.cs
+++ b/HtmlForgeX.Benchmarks/RegexBenchmarks.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+
+using BenchmarkDotNet.Attributes;
+
+using HtmlForgeX;
+
+[MemoryDiagnoser]
+public class RegexBenchmarks {
+    private static readonly Regex StaticRegex = new(@"(\d+)", RegexOptions.Compiled);
+    private const string ColorString = "gray500";
+
+    [Benchmark(Baseline = true)]
+    public string LocalRegex() {
+        var regex = new Regex(@"(\d+)");
+        if (regex.IsMatch(ColorString)) {
+            return regex.Replace(ColorString, "-$1");
+        }
+        return ColorString;
+    }
+
+    [Benchmark]
+    public string StaticRegexBenchmark() {
+        if (StaticRegex.IsMatch(ColorString)) {
+            return StaticRegex.Replace(ColorString, "-$1");
+        }
+        return ColorString;
+    }
+}

--- a/HtmlForgeX.sln
+++ b/HtmlForgeX.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HtmlForgeX.Tests", "HtmlFor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HtmlForgeX.PowerShell", "HtmlForgeX.PowerShell\HtmlForgeX.PowerShell.csproj", "{D17952DB-6D5D-4140-8D6E-D3C5B24F7C70}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HtmlForgeX.Benchmarks", "HtmlForgeX.Benchmarks\HtmlForgeX.Benchmarks.csproj", "{39289B26-245F-494C-93D4-5B397520C405}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{D17952DB-6D5D-4140-8D6E-D3C5B24F7C70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D17952DB-6D5D-4140-8D6E-D3C5B24F7C70}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D17952DB-6D5D-4140-8D6E-D3C5B24F7C70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39289B26-245F-494C-93D4-5B397520C405}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39289B26-245F-494C-93D4-5B397520C405}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39289B26-245F-494C-93D4-5B397520C405}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39289B26-245F-494C-93D4-5B397520C405}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
@@ -270,6 +270,7 @@ public enum TablerColor {
 /// Helper methods for working with <see cref="TablerColor"/> values.
 /// </summary>
 public static class ColorExtensions {
+    private static readonly Regex NumberRegex = new(@"(\d+)", RegexOptions.Compiled);
     /// <summary>
     /// Initializes or configures ToTablerString.
     /// </summary>
@@ -280,9 +281,8 @@ public static class ColorExtensions {
             return colorString.Replace("light", "-lt");
         }
         // if contains numbers add - between colorString and number
-        var regex = new Regex(@"(\d+)");
-        if (regex.IsMatch(colorString)) {
-            return regex.Replace(colorString, "-$1");
+        if (NumberRegex.IsMatch(colorString)) {
+            return NumberRegex.Replace(colorString, "-$1");
         }
 
         return color.ToString().ToLower();

--- a/HtmlForgeX/Utilities/LibraryDownloader.cs
+++ b/HtmlForgeX/Utilities/LibraryDownloader.cs
@@ -14,6 +14,7 @@ namespace HtmlForgeX;
 public class LibraryDownloader {
     private static readonly HttpClient _client = new();
     private static readonly InternalLogger _logger = new();
+    private static readonly Regex IconRegex = new("\\.ti-(.*?):before", RegexOptions.Compiled);
     /// <summary>
     /// Downloads all CSS and JS files for all libraries into given folder for easy inclusion in project
     /// </summary>
@@ -73,8 +74,7 @@ public class LibraryDownloader {
 #endif
         using var reader = new StreamReader(stream);
         cssText = await reader.ReadToEndAsync().ConfigureAwait(false);
-        var regex = new Regex(@"\.ti-(.*?):before", RegexOptions.Compiled);
-        var matches = regex.Matches(cssText);
+        var matches = IconRegex.Matches(cssText);
 
         foreach (Match match in matches) {
             var iconName = match.Groups[1].Value;


### PR DESCRIPTION
## Summary
- make static Regex instances in TablerColor and LibraryDownloader
- add Benchmark project to compare regex approaches

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6876c4fd7580832e9ea6b31ce0fbf3fe