### PR TITLE
Fix null action iteration bug

### DIFF
--- a/HtmlForgeX.Tests/TestTablerCardActions.cs
+++ b/HtmlForgeX.Tests/TestTablerCardActions.cs
@@ -16,4 +16,21 @@ public class TestTablerCardActions {
         Assert.AreEqual(2, actions1.Count);
         Assert.AreSame(actions1, actions2);
     }
+
+    [TestMethod]
+    public void TablerCardHeader_NullActions_DoesNotThrow() {
+        var header = new TablerCardHeader().Title("Title");
+        var prop = typeof(TablerCardHeader).GetProperty("Actions", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        prop!.SetValue(header, null);
+
+        try {
+            var html = header.ToString();
+            StringAssert.Contains(html, "card-header");
+        } catch (Exception ex) {
+            Assert.Fail($"Exception was thrown: {ex.Message}");
+        }
+
+        var valueAfter = prop.GetValue(header);
+        Assert.IsNotNull(valueAfter);
+    }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
@@ -86,6 +86,7 @@ public class TablerCardHeader : Element {
     public override string ToString() {
         // CRITICAL FIX: Ensure all children have proper Document references before rendering
         EnsureChildrenHaveDocumentReference();
+        Actions ??= new List<TablerCardAction>();
 
         // ADDITIONAL FIX: Force library registration for any children that may have missed it
         foreach (var child in Children.WhereNotNull()) {
@@ -214,6 +215,7 @@ public class TablerCardHeader : Element {
     protected internal override void OnAddedToDocument() {
         // Propagate Document reference to all child elements and internal elements
         EnsureChildrenHaveDocumentReference();
+        Actions ??= new List<TablerCardAction>();
 
         // Also propagate to internal element collections
         if (Navigation != null && Navigation.Document == null && this.Document != null) {


### PR DESCRIPTION
## Summary
- ensure Actions list is initialized before iterating
- add regression test for null Actions

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build HtmlForgeX.sln --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6876c915934c832e845b9c2adc06e117