### PR TITLE
Fix EmailBox null child handling

### DIFF
--- a/HtmlForgeX.Tests/TestNullChildFiltering.cs
+++ b/HtmlForgeX.Tests/TestNullChildFiltering.cs
@@ -25,4 +25,15 @@ public class TestNullChildFiltering {
 
         Assert.IsTrue(html.Contains("Inner"));
     }
+
+    [TestMethod]
+    public void EmailBoxToString_IgnoresNullChildren() {
+        var box = new EmailBox();
+        box.Children.Add(null);
+        box.Add(new BasicElement("Inner"));
+
+        var html = box.ToString();
+
+        Assert.IsTrue(html.Contains("Inner"));
+    }
 }

--- a/HtmlForgeX/Containers/Email/EmailBox.cs
+++ b/HtmlForgeX/Containers/Email/EmailBox.cs
@@ -1,3 +1,6 @@
+using System.Linq;
+using HtmlForgeX.Extensions;
+
 namespace HtmlForgeX;
 
 /// <summary>
@@ -308,9 +311,10 @@ public class EmailBox : Element {
 ");
 
             // Add content rows
-            for (int i = 0; i < Children.Count; i++) {
-                var child = Children[i];
-                var isLastChild = i == Children.Count - 1;
+            var nonNullChildren = Children.WhereNotNull().ToList();
+            for (int i = 0; i < nonNullChildren.Count; i++) {
+                var child = nonNullChildren[i];
+                var isLastChild = i == nonNullChildren.Count - 1;
 
                 // Apply consistent spacing or use default padding
                 var cellPadding = UseConsistentSpacing && !isLastChild
@@ -367,9 +371,10 @@ public class EmailBox : Element {
 ");
 
             // Add content rows
-            for (int i = 0; i < Children.Count; i++) {
-                var child = Children[i];
-                var isLastChild = i == Children.Count - 1;
+            var nonNullChildrenVisual = Children.WhereNotNull().ToList();
+            for (int i = 0; i < nonNullChildrenVisual.Count; i++) {
+                var child = nonNullChildrenVisual[i];
+                var isLastChild = i == nonNullChildrenVisual.Count - 1;
 
                 // Apply consistent spacing or use default padding
                 var cellPadding = UseConsistentSpacing && !isLastChild


### PR DESCRIPTION
## Summary
- ensure EmailBox skips null child elements when rendering
- test EmailBox.ToString ignoring null children

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build HtmlForgeX/HtmlForgeX.csproj -f net472 --no-restore` *(fails: reference assemblies missing)*
- `dotnet build HtmlForgeX/HtmlForgeX.csproj -f net8.0 --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6876c90c17d8832ebbddf325086d3571