### PR TITLE
Encode email link href

### DIFF
--- a/HtmlForgeX.Examples/Emails/ExampleLinkEncodingEmail.cs
+++ b/HtmlForgeX.Examples/Emails/ExampleLinkEncodingEmail.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace HtmlForgeX.Examples.Emails;
+
+/// <summary>
+/// Demonstrates URL encoding support in <see cref="EmailLink"/>.
+/// </summary>
+public static class ExampleLinkEncodingEmail {
+    public static void Create(bool openInBrowser = false) {
+        Console.WriteLine("Creating link encoding email example...");
+
+        var email = new Email();
+
+        email.Head.AddTitle("Link Encoding Demo")
+                  .AddEmailCoreStyles();
+
+        email.Body.EmailBox(box => {
+            box.EmailContent(content => {
+                content.EmailText("Link with spaces and special characters:")
+                    .WithAlignment(Alignment.Center);
+
+                content.EmailLink(
+                        "Search Now",
+                        "https://example.com/search?q=C# tutorial&lang=en us")
+                    .WithAlignment(Alignment.Center);
+            });
+        });
+
+        email.Save("link-encoding-email.html", openInBrowser);
+        Console.WriteLine("✅ Link encoding email created successfully!");
+    }
+}

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -145,6 +145,9 @@ internal class Program {
         // Welcome email
         ExampleWelcomeEmail.Create(openInBrowser);
 
+        // Link encoding demonstration
+        ExampleLinkEncodingEmail.Create(openInBrowser);
+
         // Base64 embedding examples (if they exist)
         ExampleBase64EmbeddingEmail.Create(openInBrowser);
 

--- a/HtmlForgeX.Tests/TestEmailLinkEncoding.cs
+++ b/HtmlForgeX.Tests/TestEmailLinkEncoding.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailLinkEncoding {
+    [TestMethod]
+    public void EmailLink_EncodesHrefValue() {
+        var link = new EmailLink("Open Search", "https://example.com/search?q=C# tutorial&lang=en us");
+        var html = link.ToString();
+        StringAssert.Contains(html, "href=\"https://example.com/search?q=C%23%20tutorial&amp;lang=en%20us\"");
+    }
+}

--- a/HtmlForgeX/Containers/Email/EmailLink.cs
+++ b/HtmlForgeX/Containers/Email/EmailLink.cs
@@ -429,7 +429,8 @@ public class EmailLink : Element {
 
         // Build link attributes
         var linkAttributes = new List<string>();
-        linkAttributes.Add($"href=\"{Helpers.HtmlEncode(Href)}\"");
+        var encodedHref = Helpers.UrlEncode(Href);
+        linkAttributes.Add($"href=\"{Helpers.HtmlEncode(encodedHref)}\"");
 
         if (OpenInNewWindow) {
             linkAttributes.Add("target=\"_blank\"");

--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -120,4 +120,18 @@ internal static class Helpers {
         return WebUtility.HtmlEncode(value);
     }
 
+    public static string UrlEncode(string url) {
+        if (string.IsNullOrEmpty(url)) {
+            return string.Empty;
+        }
+
+        var encoded = Uri.EscapeDataString(url);
+        encoded = encoded.Replace("%3A", ":")
+                         .Replace("%2F", "/")
+                         .Replace("%3F", "?")
+                         .Replace("%3D", "=")
+                         .Replace("%26", "&");
+        return encoded;
+    }
+
 }


### PR DESCRIPTION
## Summary
- encode href for email links
- add UrlEncode helper method
- add example showing URL encoding
- run new EmailLink encoding test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6876c8cbc82c832e9e919ee171348bd3