### PR TITLE
Ensure semaphore is released when Save fails

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -93,4 +93,16 @@ public class TestDocumentSaveErrors {
         Assert.IsNotNull(received);
         StringAssert.Contains(received!, dirPath);
     }
+
+    [TestMethod]
+    public void Save_UnwritableLocation_ReleasesSemaphore() {
+        var doc = new Document();
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var path = Path.Combine(tempDir, $"file_{Guid.NewGuid():N}.html");
+        using var stream = File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        doc.Save(path);
+        Assert.AreEqual(1, FileWriteLock.Semaphore.CurrentCount);
+        stream.Dispose();
+        File.Delete(path);
+    }
 }

--- a/HtmlForgeX/Containers/Core/Document.Save.cs
+++ b/HtmlForgeX/Containers/Core/Document.Save.cs
@@ -50,9 +50,9 @@ public partial class Document
                 _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
             }
         }
+        FileWriteLock.Semaphore.Wait();
         try
         {
-            FileWriteLock.Semaphore.Wait();
             File.WriteAllText(path, ToString(), Encoding.UTF8);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- avoid releasing `FileWriteLock` when the wait fails by moving the wait outside the try/catch
- add a unit test ensuring the semaphore is released even if `File.WriteAllText` throws

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6876c8c3ed38832e866e11d761b22df5