### PR TITLE
Fix TablerCardHeader document propagation

### DIFF
--- a/HtmlForgeX.Tests/TestTablerCardHeader.cs
+++ b/HtmlForgeX.Tests/TestTablerCardHeader.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerCardHeader {
+    [TestMethod]
+    public void TablerCardHeader_NoAvatar_Renders() {
+        var header = new TablerCardHeader().Title("Test");
+        var html = header.ToString();
+        Assert.IsTrue(html.Contains("card-header"));
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardHeader.cs
@@ -196,14 +196,36 @@ public class TablerCardHeader : Element {
     /// Ensures all children have proper Document and Email references for library registration
     /// </summary>
     private void EnsureChildrenHaveDocumentReference() {
-        if (this.Document == null) return;
+        if (Document == null) {
+            return;
+        }
 
         foreach (var child in Children.WhereNotNull()) {
             if (child.Document == null) {
-                child.Document = this.Document;
-                child.Email = this.Email;
+                child.Document = Document;
+                child.Email = Email;
                 // Call OnAddedToDocument to trigger library registration
                 child.OnAddedToDocument();
+            }
+        }
+
+        if (Navigation != null && Navigation.Document == null) {
+            Navigation.Document = Document;
+            Navigation.Email = Email;
+            Navigation.OnAddedToDocument();
+        }
+
+        if (HeaderAvatar != null && HeaderAvatar.Document == null) {
+            HeaderAvatar.Document = Document;
+            HeaderAvatar.Email = Email;
+            HeaderAvatar.OnAddedToDocument();
+        }
+
+        foreach (var action in Actions) {
+            if (action.Document == null) {
+                action.Document = Document;
+                action.Email = Email;
+                action.OnAddedToDocument();
             }
         }
     }


### PR DESCRIPTION
## Summary
- propagate Document to internal header elements and null-check avatar
- add test for header without avatar

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6876c8ace1a0832e862d9e91cd1b65dd