### PR TITLE
Implement wrap mode method

### DIFF
--- a/HtmlForgeX.Tests/TestWrapModes.cs
+++ b/HtmlForgeX.Tests/TestWrapModes.cs
@@ -1,0 +1,20 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestWrapModes
+{
+    [DataTestMethod]
+    [DataRow(EmailTextWrapMode.Default, "word-wrap: break-word")]
+    [DataRow(EmailTextWrapMode.Natural, "white-space: normal")]
+    [DataRow(EmailTextWrapMode.Aggressive, "word-break: break-all")]
+    [DataRow(EmailTextWrapMode.Preserve, "white-space: pre")]
+    [DataRow(EmailTextWrapMode.Hyphenated, "hyphens: auto")]
+    [DataRow(EmailTextWrapMode.Smart, "letter-spacing: -0.02em")]
+    public void EmailText_WithWrapMode_AddsCss(EmailTextWrapMode mode, string expected)
+    {
+        var html = new EmailText("demo").WithWrapMode(mode).ToString();
+        StringAssert.Contains(html, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Wrap(EmailTextWrapMode)` to set `WrapMode`
- update wrapping example to use `Wrap`
- test wrap modes for expected CSS

## Testing
- `dotnet build`
- `dotnet test --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6876c908ad48832eb1365646ff73b2d7