### PR TITLE
Add RawHtml sanitization option

### DIFF
--- a/HtmlForgeX.Examples/ByHand/BasicHtmlBuilding.cs
+++ b/HtmlForgeX.Examples/ByHand/BasicHtmlBuilding.cs
@@ -193,5 +193,20 @@ namespace HtmlForgeX.Examples.ByHand
 
             document.Save("AnalyticsDemo.html", openInBrowser);
         }
+
+        public static void DemoSanitizedRawHtml(bool openInBrowser = false)
+        {
+            HelpersSpectre.PrintTitle("Sanitized RawHtml Example");
+
+            var document = new Document();
+            document.Head.AddTitle("Sanitized RawHtml Demo");
+
+            var div = new HtmlTag("div")
+                .ValueRaw("<script>alert('x')</script><span>Safe</span>", true);
+
+            document.Body.Add(div);
+
+            document.Save("SanitizedRawHtml.html", openInBrowser);
+        }
     }
 }

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -50,6 +50,7 @@ internal class Program {
         BasicHtmlBuilding.Demo1(openInBrowser);
         BasicHtmlBuilding.Demo2(openInBrowser);
         BasicHtmlBuilding.DemoAnalytics(openInBrowser);
+        BasicHtmlBuilding.DemoSanitizedRawHtml(openInBrowser);
 
         // Toast examples
         ExampleTablerToast.Create(openInBrowser);

--- a/HtmlForgeX.Tests/TestRawHtmlSanitization.cs
+++ b/HtmlForgeX.Tests/TestRawHtmlSanitization.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestRawHtmlSanitization {
+    [TestMethod]
+    public void RawHtml_RemovesScriptTags_WhenSanitizeEnabled() {
+        var raw = new RawHtml("<script>alert('x')</script><p>ok</p>", true);
+        Assert.AreEqual("<p>ok</p>", raw.ToString());
+    }
+
+    [TestMethod]
+    public void HtmlTag_ValueRaw_SanitizesContent() {
+        var tag = new HtmlTag("div").ValueRaw("<script>alert('x')</script><span>hi</span>", true);
+        Assert.AreEqual("<div><span>hi</span></div>", tag.ToString());
+    }
+}

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -271,6 +271,19 @@ public class HtmlTag : Element {
     }
 
     /// <summary>
+    /// Appends raw HTML content to the tag with optional sanitization.
+    /// </summary>
+    /// <param name="value">Raw HTML string.</param>
+    /// <param name="sanitize">Whether to sanitize the HTML.</param>
+    /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
+    public HtmlTag ValueRaw(string? value, bool sanitize = false) {
+        if (value is not null) {
+            Children.Add(new RawHtml(value, sanitize));
+        }
+        return this;
+    }
+
+    /// <summary>
     /// Appends multiple string values to the tag.
     /// </summary>
     /// <param name="value">String values to append.</param>

--- a/HtmlForgeX/Utilities/HtmlSanitizer.cs
+++ b/HtmlForgeX/Utilities/HtmlSanitizer.cs
@@ -1,0 +1,15 @@
+using System.Text.RegularExpressions;
+
+namespace HtmlForgeX;
+
+internal static class HtmlSanitizer {
+    private static readonly Regex ScriptTagRegex = new("<script.*?>.*?</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    public static string Sanitize(string? html) {
+        if (string.IsNullOrEmpty(html)) {
+            return string.Empty;
+        }
+
+        return ScriptTagRegex.Replace(html, string.Empty);
+    }
+}

--- a/HtmlForgeX/Utilities/RawHtml.cs
+++ b/HtmlForgeX/Utilities/RawHtml.cs
@@ -7,9 +7,9 @@ internal class RawHtml
 {
     public string Content { get; }
 
-    public RawHtml(string content)
+    public RawHtml(string content, bool sanitize = false)
     {
-        Content = content;
+        Content = sanitize ? HtmlSanitizer.Sanitize(content) : content;
     }
 
     public override string ToString()


### PR DESCRIPTION
## Summary
- add new `HtmlSanitizer` utility
- allow `RawHtml` constructor to sanitize
- support raw HTML via `HtmlTag.ValueRaw`
- add sanitized RawHtml example
- add tests for sanitization

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68773e4934f0832eb8c6ab40a5c052f8