### PR TITLE
Implement IDisposable for Document and update usage

### DIFF
--- a/HtmlForgeX.Examples/ByHand/BasicHtmlBuilding.cs
+++ b/HtmlForgeX.Examples/ByHand/BasicHtmlBuilding.cs
@@ -14,7 +14,7 @@ namespace HtmlForgeX.Examples.ByHand
         {
             HelpersSpectre.PrintTitle("Basic Html Building 1");
 
-            Document document = new Document();
+            using Document document = new Document();
             document.Head.Title = "Basic Html Building 1";
             document.Head.Author = "Przemysław Kłys";
             document.Head.Revised = DateTime.Now;
@@ -95,7 +95,7 @@ namespace HtmlForgeX.Examples.ByHand
         {
             HelpersSpectre.PrintTitle("Basic Html Building 2");
 
-            Document document = new Document();
+            using Document document = new Document();
 
             document.AddLibrary(new Bootstrap());
 
@@ -185,7 +185,7 @@ namespace HtmlForgeX.Examples.ByHand
         {
             HelpersSpectre.PrintTitle("Analytics Example");
 
-            var document = new Document();
+            using var document = new Document();
             document.Head.AddTitle("Analytics Demo");
             document.Head.AddAnalytics(AnalyticsProvider.GoogleAnalytics, "G-XXXXXXX");
 

--- a/HtmlForgeX.Examples/Containers/BasicApexCharts.cs
+++ b/HtmlForgeX.Examples/Containers/BasicApexCharts.cs
@@ -7,7 +7,7 @@ internal class BasicApexCharts {
     public static void Demo(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("ApexCharts Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = { Title = "ApexCharts Demo", Author = "HtmlForgeX" },
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light

--- a/HtmlForgeX.Examples/Containers/BasicChartJs.cs
+++ b/HtmlForgeX.Examples/Containers/BasicChartJs.cs
@@ -4,7 +4,7 @@ internal class BasicChartJs {
     public static void Demo(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("ChartJs Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = { Title = "ChartJs Demo", Author = "HtmlForgeX" },
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light

--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer01.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer01.cs
@@ -23,7 +23,7 @@ internal class BasicHtmlContainer01 {
             new { Name = "Jane", Age = 28, Occupation = "Doctor" },
         };
 
-        Document document = new Document {
+        using Document document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer02.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer02.cs
@@ -30,7 +30,7 @@ internal class BasicHtmlContainer02 {
             new { Name = "Jane", Age = 28, Occupation = "Doctor" },
         };
 
-        Document document = new Document {
+        using Document document = new Document {
             Head = {
                 Title = "Basic Demo Document Container 2", Author = "Przemysław Kłys", Revised = DateTime.Now
             },

--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer03.cs
@@ -23,7 +23,7 @@ internal class BasicHtmlContainer03 {
             new { Name = "Jane", Age = 28, Occupation = "Doctor" },
         };
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Basic Demo Document Container 3", Author = "Przemysław Kłys", Revised = DateTime.Now
             },

--- a/HtmlForgeX.Examples/Containers/BasicHtmlContainer04.cs
+++ b/HtmlForgeX.Examples/Containers/BasicHtmlContainer04.cs
@@ -27,7 +27,7 @@ internal class BasicHtmlContainer04 {
             Return keyword           operation_timedout
             """;
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Basic Demo Document Container 4", Author = "Przemysław Kłys", Revised = DateTime.Now,
                 AutoRefresh = 30

--- a/HtmlForgeX.Examples/Containers/BasicQuillEditor.cs
+++ b/HtmlForgeX.Examples/Containers/BasicQuillEditor.cs
@@ -4,7 +4,7 @@ internal class BasicQuillEditor {
     public static void Demo(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Quill Editor Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = { Title = "Quill Demo", Author = "HtmlForgeX" },
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light

--- a/HtmlForgeX.Examples/Containers/BasicScrollingText.cs
+++ b/HtmlForgeX.Examples/Containers/BasicScrollingText.cs
@@ -11,7 +11,7 @@ internal class BasicScrollingText {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Basic Demo Scrolling Text");
 
-        var document = new Document {
+        using var document = new Document {
             Head = { Title = "Basic Demo Scrolling Text", Author = "Przemysław Kłys", Revised = DateTime.Now },
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light

--- a/HtmlForgeX.Examples/Containers/BasicVisNetwork.cs
+++ b/HtmlForgeX.Examples/Containers/BasicVisNetwork.cs
@@ -4,7 +4,7 @@ internal class BasicVisNetwork {
     public static void Demo(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("VisNetwork Image Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = { Title = "VisNetwork Image Demo", Author = "HtmlForgeX" },
             LibraryMode = LibraryMode.Offline,
             ThemeMode = ThemeMode.Light

--- a/HtmlForgeX.Examples/Containers/DomainHealthCheck.cs
+++ b/HtmlForgeX.Examples/Containers/DomainHealthCheck.cs
@@ -33,7 +33,7 @@ internal class DomainHealthCheck {
             Return keyword           operation_timedout
             """;
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Enhanced Domain Health Check",
                 Author = "Przemysław Kłys",

--- a/HtmlForgeX.Examples/Containers/EnhancedAccordionStepsShowcase.cs
+++ b/HtmlForgeX.Examples/Containers/EnhancedAccordionStepsShowcase.cs
@@ -4,7 +4,7 @@ internal class EnhancedAccordionStepsShowcase {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Enhanced Accordion & Steps Showcase - Complete Feature Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Enhanced Accordion & Steps - Complete Feature Showcase",
                 Author = "HtmlForgeX",

--- a/HtmlForgeX.Examples/Containers/EnhancedDataGridDemo.cs
+++ b/HtmlForgeX.Examples/Containers/EnhancedDataGridDemo.cs
@@ -11,7 +11,7 @@ internal class EnhancedDataGridDemo {
     public static void Create(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Enhanced DataGrid - Complete Feature Demonstration");
 
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/Containers/InfocardsCleanDemo.cs
+++ b/HtmlForgeX.Examples/Containers/InfocardsCleanDemo.cs
@@ -10,7 +10,7 @@ internal class InfocardsCleanDemo {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Clean Infocards Demo - Predefined RGBColor Constants");
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Clean Infocards Demo - RGBColor Constants",
                 Author = "HtmlForgeX",

--- a/HtmlForgeX.Examples/Containers/InfocardsDemo.cs
+++ b/HtmlForgeX.Examples/Containers/InfocardsDemo.cs
@@ -10,7 +10,7 @@ internal class InfocardsDemo {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Infocards Demo - Custom RGBColor Backgrounds & Avatars");
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Infocards Demo - Custom Colors",
                 Author = "HtmlForgeX",

--- a/HtmlForgeX.Examples/Containers/TablerCardsCompleteDemo.cs
+++ b/HtmlForgeX.Examples/Containers/TablerCardsCompleteDemo.cs
@@ -11,7 +11,7 @@ internal class TablerCardsCompleteDemo {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Complete Tabler Cards Demo - ALL Features with Proper C# API");
 
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/Containers/TablerCardsEnhancedDemo.cs
+++ b/HtmlForgeX.Examples/Containers/TablerCardsEnhancedDemo.cs
@@ -10,7 +10,7 @@ internal class TablerCardsEnhancedDemo {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Enhanced Tabler Cards Demo - Proper C# API");
 
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/Containers/TablerCardsProperDemo.cs
+++ b/HtmlForgeX.Examples/Containers/TablerCardsProperDemo.cs
@@ -10,7 +10,7 @@ internal class TablerCardsProperDemo {
     public static void Demo01(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Proper Tabler Cards Demo - Zero HTML, Pure C# API");
 
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/Experimenting/ExampleHeadlessRendering.cs
+++ b/HtmlForgeX.Examples/Experimenting/ExampleHeadlessRendering.cs
@@ -7,7 +7,7 @@ namespace HtmlForgeX.Examples.Experimenting;
 
 internal class ExampleHeadlessRendering {
     public static async Task CreateAsync(bool openInBrowser = false) {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.Title = "Headless Rendering Example";
         doc.Body.Add(new HtmlTag("h1", "Hello from Headless Browser"));
         var path = Path.Combine(Path.GetTempPath(), "headless_example.html");

--- a/HtmlForgeX.Examples/Experimenting/ExampleThreadSafeErrors.cs
+++ b/HtmlForgeX.Examples/Experimenting/ExampleThreadSafeErrors.cs
@@ -6,7 +6,7 @@ namespace HtmlForgeX.Examples.Experimenting;
 
 internal static class ExampleThreadSafeErrors {
     public static void Create() {
-        var document = new Document();
+        using var document = new Document();
         var tasks = new List<Task>();
         for (int i = 0; i < 5; i++) {
             int copy = i;

--- a/HtmlForgeX.Examples/Experimenting/Experiments01.cs
+++ b/HtmlForgeX.Examples/Experimenting/Experiments01.cs
@@ -20,7 +20,7 @@ internal class Experiments01 {
 
         //Console.WriteLine("----");
 
-        var value2 = new Document();
+        using var value2 = new Document();
         value2.Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
             .WithColor(RGBColor.TractorRed).AppendContent(" continue?");
 
@@ -28,14 +28,14 @@ internal class Experiments01 {
 
         Console.WriteLine("----");
 
-        var value3 = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
+        using var value3 = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
             .WithColor(RGBColor.TractorRed).AppendContent(" continue?");
 
         Console.WriteLine(value3);
 
         Console.WriteLine("----");
 
-        var span = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
+        using var span = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
             .WithColor(RGBColor.TractorRed).AppendContent(" continue?");
         var value4 = span;
         Console.WriteLine(value4);

--- a/HtmlForgeX.Examples/Experimenting/Experiments01.cs
+++ b/HtmlForgeX.Examples/Experimenting/Experiments01.cs
@@ -28,14 +28,14 @@ internal class Experiments01 {
 
         Console.WriteLine("----");
 
-        using var value3 = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
+        var value3 = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
             .WithColor(RGBColor.TractorRed).AppendContent(" continue?");
 
         Console.WriteLine(value3);
 
         Console.WriteLine("----");
 
-        using var span = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
+        var span = new Document().Body.Span("This is table with DataTables").WithAlignment(Alignment.Center)
             .WithColor(RGBColor.TractorRed).AppendContent(" continue?");
         var value4 = span;
         Console.WriteLine(value4);

--- a/HtmlForgeX.Examples/Forms/ExampleTablerForm.cs
+++ b/HtmlForgeX.Examples/Forms/ExampleTablerForm.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Forms;
 
 internal static class ExampleTablerForm {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Form Demo" } };
+        using var document = new Document { Head = { Title = "Form Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/PrismJs/DataTablesDocumentationDemo.cs
+++ b/HtmlForgeX.Examples/PrismJs/DataTablesDocumentationDemo.cs
@@ -9,7 +9,7 @@ public class DataTablesDocumentationDemo
 {
     public static void RunDemo()
     {
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "DataTables API Documentation",
@@ -213,7 +213,7 @@ document.Configuration.DataTables.EnableDeferredRendering = true;", PrismJsLangu
             page.Text("Putting it all together:");
 
             page.CSharpCode(@"
-var document = new Document {
+using var document = new Document {
     Head = { Title = ""Product Catalog"" }
 };
 

--- a/HtmlForgeX.Examples/PrismJs/PrismJsDemo.cs
+++ b/HtmlForgeX.Examples/PrismJs/PrismJsDemo.cs
@@ -9,7 +9,7 @@ public class PrismJsDemo
 {
     public static void RunDemo()
     {
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "PrismJS Syntax Highlighting Demo",

--- a/HtmlForgeX.Examples/Tables/AdvancedDataTablesDemo.cs
+++ b/HtmlForgeX.Examples/Tables/AdvancedDataTablesDemo.cs
@@ -9,7 +9,7 @@ internal class AdvancedDataTablesDemo
     {
         HelpersSpectre.PrintTitle("🚀 Advanced DataTables Features Demo");
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "Advanced DataTables Features Demo",

--- a/HtmlForgeX.Examples/Tables/BasicHtmlTable01.cs
+++ b/HtmlForgeX.Examples/Tables/BasicHtmlTable01.cs
@@ -6,7 +6,7 @@ internal class BasicHtmlTable01 {
         HelpersSpectre.PrintTitle("Basic Demo Document with Tables 1");
 
         // Create a new document with the title and author
-        Document document = new Document {
+        using Document document = new Document {
             Head = {
                 Title = "Basic Demo Document with Tables 1",
                 Author = "Przemysław Kłys",

--- a/HtmlForgeX.Examples/Tables/BasicHtmlTable02.cs
+++ b/HtmlForgeX.Examples/Tables/BasicHtmlTable02.cs
@@ -4,7 +4,7 @@ internal class BasicHtmlTable02 {
     public static void Create(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("DataTables Options Demo");
 
-        Document document = new Document {
+        using Document document = new Document {
             Head = {
                 Title = "DataTables Options Demo",
                 Author = "Przemysław Kłys",

--- a/HtmlForgeX.Examples/Tables/BasicHtmlTable03.cs
+++ b/HtmlForgeX.Examples/Tables/BasicHtmlTable03.cs
@@ -10,7 +10,7 @@ internal class BasicHtmlTable03 {
     public static void Create(bool openInBrowser = false) {
         HelpersSpectre.PrintTitle("Typed Objects Table Demo");
 
-        var document = new Document {
+        using var document = new Document {
             Head = {
                 Title = "Typed Objects Table Demo",
                 Author = "Przemysław Kłys",

--- a/HtmlForgeX.Examples/Tables/BasicHtmlTable04.cs
+++ b/HtmlForgeX.Examples/Tables/BasicHtmlTable04.cs
@@ -6,7 +6,7 @@ internal class BasicHtmlTable04 {
         HelpersSpectre.PrintTitle("Tabler Table Styling Demo");
 
         // Create a new document with the title and author
-        Document document = new Document {
+        using Document document = new Document {
             Head = {
                 Title = "Tabler Table Styling Demo",
                 Author = "Przemysław Kłys",

--- a/HtmlForgeX.Examples/Tables/DataTablesExtensionsDemo.cs
+++ b/HtmlForgeX.Examples/Tables/DataTablesExtensionsDemo.cs
@@ -11,7 +11,7 @@ internal class DataTablesExtensionsDemo
     {
         HelpersSpectre.PrintTitle("🚀 DataTables Extensions Demo");
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "DataTables Extensions Demo",

--- a/HtmlForgeX.Examples/Tables/DataTablesFeatureTest.cs
+++ b/HtmlForgeX.Examples/Tables/DataTablesFeatureTest.cs
@@ -9,7 +9,7 @@ internal class DataTablesFeatureTest
     {
         HelpersSpectre.PrintTitle("🧪 DataTables Feature Test Suite");
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "DataTables Feature Test Suite",

--- a/HtmlForgeX.Examples/Tables/DataTablesQuickStart.cs
+++ b/HtmlForgeX.Examples/Tables/DataTablesQuickStart.cs
@@ -11,7 +11,7 @@ internal class DataTablesQuickStart
     {
         HelpersSpectre.PrintTitle("⚡ DataTables Quick Start Guide");
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "DataTables Quick Start Guide",

--- a/HtmlForgeX.Examples/Tables/DataTablesRenderingDemo.cs
+++ b/HtmlForgeX.Examples/Tables/DataTablesRenderingDemo.cs
@@ -19,7 +19,7 @@ internal class DataTablesRenderingDemo
         var mediumDataset = GenerateProducts(500);
         var largeDataset = GenerateProducts(2000);
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "DataTables Rendering Modes Demo",

--- a/HtmlForgeX.Examples/Tags/ExampleTablerAlerts.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerAlerts.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerAlerts {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Alerts Demo" } };
+        using var document = new Document { Head = { Title = "Alerts Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerLogs.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerLogs.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerLogs {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Logs Demo" } };
+        using var document = new Document { Head = { Title = "Logs Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerProgressBarShowcase.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerProgressBarShowcase.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerProgressBarShowcase {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Progress Bar Showcase" } };
+        using var document = new Document { Head = { Title = "Progress Bar Showcase" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerTag.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerTag.cs
@@ -4,7 +4,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerTag {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Tag Demo" } };
+        using var document = new Document { Head = { Title = "Tag Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerTimeline.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerTimeline.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerTimeline {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Timeline Demo" } };
+        using var document = new Document { Head = { Title = "Timeline Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerToast.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerToast.cs
@@ -2,7 +2,7 @@ namespace HtmlForgeX.Examples.Tags;
 
 internal static class ExampleTablerToast {
     public static void Create(bool openInBrowser = false) {
-        var document = new Document { Head = { Title = "Toast Demo" } };
+        using var document = new Document { Head = { Title = "Toast Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/Tags/ExampleTablerToastAdvanced.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerToastAdvanced.cs
@@ -7,7 +7,7 @@ internal static class ExampleTablerToastAdvanced {
             new { Name = "Bob", Age = 25 }
         };
 
-        var document = new Document { Head = { Title = "Advanced Toast Demo" } };
+        using var document = new Document { Head = { Title = "Advanced Toast Demo" } };
         document.Body.Page(page => {
             page.Row(row => {
                 row.Column(column => {

--- a/HtmlForgeX.Examples/TestContainerFix.cs
+++ b/HtmlForgeX.Examples/TestContainerFix.cs
@@ -34,7 +34,7 @@ public static class TestContainerFix
     {
         Console.WriteLine("🔗 Test 1: Document Reference Propagation");
 
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
         var card = new TablerCard();
 
@@ -53,7 +53,7 @@ public static class TestContainerFix
     {
         Console.WriteLine("🔧 Test 2: Library Registration");
 
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var data = new[] {
             new { Name = "John", Age = 30 },
             new { Name = "Jane", Age = 28 }
@@ -90,7 +90,7 @@ public static class TestContainerFix
     {
         Console.WriteLine("🌐 Test 3: HTML Output Validation");
 
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
 
         document.Body.Add(page);
@@ -116,7 +116,7 @@ public static class TestContainerFix
         Console.WriteLine("🔄 Test 4: Regression Test (BasicHtmlContainer01 scenario)");
 
         // Recreate the exact scenario that was failing
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Examples/TestPrismJsDebug.cs
+++ b/HtmlForgeX.Examples/TestPrismJsDebug.cs
@@ -11,7 +11,7 @@ public class TestPrismJsDebug
     {
         Console.WriteLine("=== PrismJS Debug Test ===");
 
-        var document = new Document
+        using var document = new Document
         {
             Head = {
                 Title = "PrismJS Debug Test"

--- a/HtmlForgeX.Tests/TestAddLibraryErrors.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryErrors.cs
@@ -29,7 +29,7 @@ public class TestAddLibraryErrors {
         File.WriteAllText(cssPath, "body {}", System.Text.Encoding.UTF8);
         using (File.Open(cssPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
             var lib = new Library { Header = new LibraryLinks { Css = [cssPath] } };
-            var doc = new Document { LibraryMode = LibraryMode.Offline };
+            using var doc = new Document { LibraryMode = LibraryMode.Offline };
             doc.AddLibrary(lib);
         }
 
@@ -51,7 +51,7 @@ public class TestAddLibraryErrors {
         File.WriteAllText(jsPath, "console.log('hi');", System.Text.Encoding.UTF8);
         using (File.Open(jsPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
             var lib = new Library { Header = new LibraryLinks { Js = [jsPath] } };
-            var doc = new Document { LibraryMode = LibraryMode.Offline };
+            using var doc = new Document { LibraryMode = LibraryMode.Offline };
             doc.AddLibrary(lib);
         }
 

--- a/HtmlForgeX.Tests/TestAddLibraryRelativePaths.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryRelativePaths.cs
@@ -25,7 +25,7 @@ public class TestAddLibraryRelativePaths {
             }
         };
 
-        var doc = new Document { LibraryMode = LibraryMode.Offline, Path = baseDir };
+        using var doc = new Document { LibraryMode = LibraryMode.Offline, Path = baseDir };
         doc.AddLibrary(lib);
         var html = doc.ToString();
 

--- a/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
@@ -25,7 +25,7 @@ public class TestAddLibraryUtf8 {
                 Js = [jsPath]
             }
         };
-        var doc = new Document { LibraryMode = LibraryMode.Offline };
+        using var doc = new Document { LibraryMode = LibraryMode.Offline };
         doc.AddLibrary(lib);
         var headHtml = doc.Head.ToString();
 

--- a/HtmlForgeX.Tests/TestChartJs.cs
+++ b/HtmlForgeX.Tests/TestChartJs.cs
@@ -20,7 +20,7 @@ public class TestChartJs {
 
     [TestMethod]
     public void ChartJs_RegistersLibrary() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(element => {
             element.ChartJs(c => c.AddData("A", 1));
         });

--- a/HtmlForgeX.Tests/TestComponentInteractions.cs
+++ b/HtmlForgeX.Tests/TestComponentInteractions.cs
@@ -11,7 +11,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void MultipleComponents_AllLibrariesIncluded() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Add multiple different components
         doc.Body.Add(element => {
@@ -50,7 +50,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void ComponentsWithTabler_Integration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Combine components with Tabler UI
         var card = new TablerCard();
@@ -81,7 +81,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void NestedComponents_WithVisNetwork() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Create a complex layout with nested components
         var row = new TablerRow();
@@ -172,7 +172,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void ComponentLibraryConflicts_Prevention() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Add the same component type multiple times
         doc.Body.Add(element => {
@@ -211,7 +211,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void ComplexDashboard_AllComponents() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddTitle("Complex Dashboard");
         
         // Create a complex dashboard with all components
@@ -284,7 +284,7 @@ public class TestComponentInteractions {
 
     [TestMethod]
     public void ComponentEventHandling_Integration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Test components that might have JavaScript interactions
         doc.Body.Add(element => {

--- a/HtmlForgeX.Tests/TestContainerLibraryRegistration.cs
+++ b/HtmlForgeX.Tests/TestContainerLibraryRegistration.cs
@@ -13,7 +13,7 @@ public class TestContainerLibraryRegistration
     public void TablerPage_ShouldRegisterBootstrapAndTablerLibraries()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
 
         // Act
@@ -37,7 +37,7 @@ public class TestContainerLibraryRegistration
     public void DataTablesTable_ShouldRegisterRequiredLibraries()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var data = new[] {
             new { Name = "John", Age = 30 },
             new { Name = "Jane", Age = 28 }
@@ -66,7 +66,7 @@ public class TestContainerLibraryRegistration
     public void TablerTable_ShouldRegisterBootstrapAndTablerLibraries()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var data = new[] {
             new { Name = "John", Age = 30 },
             new { Name = "Jane", Age = 28 }
@@ -93,7 +93,7 @@ public class TestContainerLibraryRegistration
     public void DocumentReference_ShouldPropagate_ToChildElements()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
         var card = new TablerCard();
 
@@ -112,7 +112,7 @@ public class TestContainerLibraryRegistration
     public void NestedComponents_ShouldAllRegisterLibraries()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var data = new[] {
             new { Name = "John", Age = 30 },
             new { Name = "Jane", Age = 28 }
@@ -160,7 +160,7 @@ public class TestContainerLibraryRegistration
     public void LibraryMode_Offline_ShouldIncludeInlineStyles()
     {
         // Arrange
-        var document = new Document(LibraryMode.Offline);
+        using var document = new Document(LibraryMode.Offline);
         var page = new TablerPage();
 
         // Act
@@ -178,7 +178,7 @@ public class TestContainerLibraryRegistration
     public void LibraryMode_Online_ShouldIncludeCDNLinks()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
 
         // Act
@@ -198,7 +198,7 @@ public class TestContainerLibraryRegistration
     public void Document_WithOfflineLibraryMode_ShouldNotIncludeLibraries()
     {
         // Arrange
-        var document = new Document();
+        using var document = new Document();
         document.LibraryMode = LibraryMode.Offline; // Explicitly set offline mode
         var page = new TablerPage();
 
@@ -220,7 +220,7 @@ public class TestContainerLibraryRegistration
     public void ComplexContainerExample_ShouldWorkCorrectly()
     {
         // Arrange
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Tests/TestDefaultStyles.cs
+++ b/HtmlForgeX.Tests/TestDefaultStyles.cs
@@ -13,7 +13,7 @@ namespace HtmlForgeX.Tests;
 public class TestDefaultStyles {
     [TestMethod]
     public void DefaultStyles_ShouldParseCss() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddDefaultStyles();
         string headHtml = doc.Head.ToString();
         var match = Regex.Match(headHtml, "<style.*?>(.*?)</style>", RegexOptions.Singleline);

--- a/HtmlForgeX.Tests/TestDocumentDispose.cs
+++ b/HtmlForgeX.Tests/TestDocumentDispose.cs
@@ -1,0 +1,13 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDocumentDispose {
+    [TestMethod]
+    public void Dispose_MultipleCalls_DoesNotThrow() {
+        using var doc = new Document();
+        doc.Dispose();
+        doc.Dispose();
+    }
+}

--- a/HtmlForgeX.Tests/TestDocumentReferencePropagation.cs
+++ b/HtmlForgeX.Tests/TestDocumentReferencePropagation.cs
@@ -12,7 +12,7 @@ public class TestDocumentReferencePropagation
     public void Element_Add_ShouldPropagate_DocumentReference()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var parentElement = new TablerPage();
         var childElement = new TablerCard();
 
@@ -50,7 +50,7 @@ public class TestDocumentReferencePropagation
     public void DeepNesting_ShouldPropagate_DocumentReference()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var page = new TablerPage();
         var row = new TablerRow();
         var column = new TablerColumn();
@@ -73,7 +73,7 @@ public class TestDocumentReferencePropagation
     public void ConfigDelegate_ShouldHave_DocumentReference()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
 
         // Act
         document.Body.Page(page =>
@@ -101,7 +101,7 @@ public class TestDocumentReferencePropagation
     public void FluentAPI_ShouldPropagate_DocumentReference()
     {
         // Arrange
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
         var data = new[] { new { Name = "Test", Value = 123 } };
 
         // Act - Use fluent API like in examples
@@ -147,7 +147,7 @@ public class TestDocumentReferencePropagation
         Assert.IsNull(card.Document, "Card should not have Document reference");
 
         // Create a document separately to test
-        var document = new Document(LibraryMode.Online);
+        using var document = new Document(LibraryMode.Online);
 
         // Libraries should not be registered in this document
         Assert.IsFalse(document.Configuration.Libraries.ContainsKey(Libraries.Bootstrap),
@@ -160,7 +160,7 @@ public class TestDocumentReferencePropagation
     public void RegressionTest_BasicHtmlContainer01_ShouldWork()
     {
         // Arrange - Simulate the exact scenario from BasicHtmlContainer01
-        var document = new Document {
+        using var document = new Document {
             LibraryMode = LibraryMode.Online,
             ThemeMode = ThemeMode.Light
         };

--- a/HtmlForgeX.Tests/TestDocumentSave.cs
+++ b/HtmlForgeX.Tests/TestDocumentSave.cs
@@ -14,7 +14,7 @@ public class TestDocumentSave {
 
     [TestMethod]
     public void Save_CreatesDirectoryAndWritesUtf8() {
-        var doc = new Document();
+        using var doc = new Document();
         string tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString());
         string dir = Path.Combine(tempDir, "subDirectory");
         string path = Path.Combine(dir, "testSubDirectory.html");
@@ -27,7 +27,7 @@ public class TestDocumentSave {
 
     [TestMethod]
     public async Task SaveAsync_WritesFile() {
-        var doc = new Document();
+        using var doc = new Document();
         var tempPath = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"file_{Guid.NewGuid():N}.html");
 
         await doc.SaveAsync(tempPath);
@@ -39,7 +39,7 @@ public class TestDocumentSave {
 
     [TestMethod]
     public async Task SaveAsync_InvalidPath_ThrowsArgumentException() {
-        var doc = new Document();
+        using var doc = new Document();
         await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await doc.SaveAsync("invalid\0path.html"));
     }
 }

--- a/HtmlForgeX.Tests/TestDocumentSaveBasic.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveBasic.cs
@@ -10,7 +10,7 @@ namespace HtmlForgeX.Tests;
 public class TestDocumentSaveBasic {
     [TestMethod]
     public void Document_SaveCreatesFile() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(new HtmlTag("p", "Hello"));
         var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
         doc.Save(path, false);

--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -25,7 +25,7 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        using var doc = new Document();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var dir = Path.Combine(tempDir, Guid.NewGuid().ToString());
         try {
@@ -46,7 +46,7 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        using var doc = new Document();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid()}.html");
         using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
@@ -64,7 +64,7 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        using var doc = new Document();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid():N}.html");
         using (File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None)) {
@@ -82,7 +82,7 @@ public class TestDocumentSaveErrors {
         string? received = null;
         EventHandler<LogEventArgs> handler = (_, e) => received ??= e.FullMessage;
         logger.OnErrorMessage += handler;
-        var doc = new Document();
+        using var doc = new Document();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var dirPath = Path.Combine(tempDir, $"dir_{Guid.NewGuid()}");
         File.WriteAllText(dirPath, string.Empty);
@@ -96,7 +96,7 @@ public class TestDocumentSaveErrors {
 
     [TestMethod]
     public void Save_UnwritableLocation_ReleasesSemaphore() {
-        var doc = new Document();
+        using var doc = new Document();
         var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
         var path = Path.Combine(tempDir, $"file_{Guid.NewGuid():N}.html");
         using var stream = File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None);

--- a/HtmlForgeX.Tests/TestDocumentSaveMultithreaded.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveMultithreaded.cs
@@ -13,7 +13,7 @@ namespace HtmlForgeX.Tests;
 public class TestDocumentSaveMultithreaded {
     [TestMethod]
     public void Save_MultipleThreads_OneFileProduced() {
-        var doc = new Document();
+        using var doc = new Document();
         var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
 
         var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => doc.Save(path)));
@@ -29,7 +29,7 @@ public class TestDocumentSaveMultithreaded {
 
     [TestMethod]
     public async Task SaveAsync_MultipleThreads_OneFileProduced() {
-        var doc = new Document();
+        using var doc = new Document();
         var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Path.GetRandomFileName() + ".html");
 
         var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() => doc.SaveAsync(path)));

--- a/HtmlForgeX.Tests/TestDocumentSaveUIContext.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveUIContext.cs
@@ -22,7 +22,7 @@ public class TestDocumentSaveUIContext {
         var previous = SynchronizationContext.Current;
         SynchronizationContext.SetSynchronizationContext(new NoOpSynchronizationContext());
         try {
-            var doc = new Document();
+            using var doc = new Document();
             var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"ui_{Guid.NewGuid():N}.html");
             doc.SaveAsync(path).GetAwaiter().GetResult();
             Assert.IsTrue(File.Exists(path));

--- a/HtmlForgeX.Tests/TestDocumentWorkflow.cs
+++ b/HtmlForgeX.Tests/TestDocumentWorkflow.cs
@@ -14,7 +14,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_BasicCreation() {
-        var doc = new Document();
+        using var doc = new Document();
         
         Assert.IsNotNull(doc.Head);
         Assert.IsNotNull(doc.Body);
@@ -25,7 +25,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_ConfigurationProperties() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.LibraryMode = LibraryMode.Offline;
         doc.ThemeMode = ThemeMode.Dark;
@@ -42,7 +42,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_AddLibrary() {
-        var doc = new Document();
+        using var doc = new Document();
         var customLibrary = new Library {
             Header = new LibraryLinks {
                 CssLink = ["https://example.com/custom.css"],
@@ -59,7 +59,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_ToStringContainsBasicStructure() {
-        var doc = new Document();
+        using var doc = new Document();
         var html = doc.ToString();
         
         Assert.IsTrue(html.Contains("<!DOCTYPE html>"));
@@ -73,7 +73,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_WithContentInBody() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(new HtmlTag("p", "Hello World"));
         
         var html = doc.ToString();
@@ -82,7 +82,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_WithHeadTitle() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddTitle("Test Page");
 
         var html = doc.ToString();
@@ -91,7 +91,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_AddTitle_EncodesInput() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddTitle("<b>Title & Test</b>");
 
         Assert.AreEqual("&lt;b&gt;Title &amp; Test&lt;/b&gt;", doc.Head.Title);
@@ -99,7 +99,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_SaveToFile() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(new HtmlTag("p", "Test content"));
         
         var tempFile = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"test_{System.Guid.NewGuid()}.html");
@@ -115,7 +115,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public async Task Document_SaveAsyncToFile() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(new HtmlTag("p", "Async test content"));
         
         var tempFile = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"async_test_{System.Guid.NewGuid()}.html");
@@ -131,7 +131,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_MultipleLibraries() {
-        var doc = new Document();
+        using var doc = new Document();
         
         var lib1 = new Library {
             Header = new LibraryLinks {
@@ -155,7 +155,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_DuplicateCustomLibrariesSkipped() {
-        var doc = new Document();
+        using var doc = new Document();
 
         var customLibrary = new Library {
             Header = new LibraryLinks {
@@ -178,7 +178,7 @@ public class TestDocumentWorkflow {
 
     [TestMethod]
     public void Document_ErrorHandling() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Configuration.Errors.Add("Test error");
         

--- a/HtmlForgeX.Tests/TestFullCalendarComponent.cs
+++ b/HtmlForgeX.Tests/TestFullCalendarComponent.cs
@@ -11,7 +11,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_BasicCreation() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -31,7 +31,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_WithEvents() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -61,7 +61,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_EventWithTimeRange() {
-        var doc = new Document();
+        using var doc = new Document();
         var startTime = DateTime.Today.AddHours(14);
         var endTime = DateTime.Today.AddHours(16);
         
@@ -83,7 +83,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_Configuration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -106,7 +106,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_Toolbar() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -131,7 +131,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_MultipleEvents() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -151,7 +151,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_EventWithColor() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -169,7 +169,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_OnlineMode_LibraryInclusion() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Online;
         
         doc.Body.Add(element => {
@@ -187,7 +187,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_OfflineMode_NoExternalCDN() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Offline;
         
         try {
@@ -210,7 +210,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_LibraryRegistration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Before adding calendar
         Assert.IsFalse(doc.Configuration.Libraries.ContainsKey(Libraries.FullCalendar), 
@@ -232,7 +232,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_AllDayEvent() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -249,7 +249,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_RecurringEvent() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {
@@ -267,7 +267,7 @@ public class TestFullCalendarComponent {
 
     [TestMethod]
     public void FullCalendar_EventHandlersSerialized() {
-        var doc = new Document();
+        using var doc = new Document();
 
         doc.Body.Add(element => {
             element.FullCalendar(calendar => {

--- a/HtmlForgeX.Tests/TestHeadAnalytics.cs
+++ b/HtmlForgeX.Tests/TestHeadAnalytics.cs
@@ -11,7 +11,7 @@ public class TestHeadAnalytics
     [TestMethod]
     public void AddAnalytics_Google_ShouldIncludeScript()
     {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddAnalytics(AnalyticsProvider.GoogleAnalytics, "G-TEST");
         var html = doc.Head.ToString();
         StringAssert.Contains(html, "googletagmanager.com/gtag/js?id=G-TEST");
@@ -21,7 +21,7 @@ public class TestHeadAnalytics
     [TestMethod]
     public void AddAnalytics_Cloudflare_ShouldIncludeScript()
     {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.AddAnalytics(AnalyticsProvider.CloudflareInsights, "token-123");
         var html = doc.Head.ToString();
         StringAssert.Contains(html, "static.cloudflareinsights.com/beacon.min.js");

--- a/HtmlForgeX.Tests/TestHeadlessRendering.cs
+++ b/HtmlForgeX.Tests/TestHeadlessRendering.cs
@@ -17,7 +17,7 @@ public class TestHeadlessRendering {
         Directory.CreateDirectory(tempDir);
         string htmlPath = Path.Combine(tempDir, "index.html");
 
-        var doc = new Document();
+        using var doc = new Document();
         doc.Head.Title = "Integration Test";
         doc.Body.Add(new HtmlTag("h1", "Hello world!"));
         doc.Save(htmlPath);

--- a/HtmlForgeX.Tests/TestLibraryIntegration.cs
+++ b/HtmlForgeX.Tests/TestLibraryIntegration.cs
@@ -14,7 +14,7 @@ public class TestLibraryIntegration {
         };
 
         GlobalStorage.LibraryMode = LibraryMode.Online;
-        var doc = new Document();
+        using var doc = new Document();
         doc.AddLibrary(customLibrary);
         var html = doc.ToString();
 

--- a/HtmlForgeX.Tests/TestLibraryPlacement.cs
+++ b/HtmlForgeX.Tests/TestLibraryPlacement.cs
@@ -8,7 +8,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_OnlineMode_ContainsCdnLinks() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Online;
         
         // Add a component that requires libraries
@@ -25,7 +25,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_OfflineMode_ContainsEmbeddedResources() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Offline;
         
         // Add a component that requires libraries
@@ -43,7 +43,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_MultipleLibraries_PlacedInCorrectSections() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Online;
         
         // Add multiple components requiring different libraries
@@ -75,7 +75,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_CustomLibrary_PlacedCorrectly() {
-        var doc = new Document();
+        using var doc = new Document();
         
         var customLibrary = new Library {
             Header = new LibraryLinks {
@@ -102,7 +102,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_DeferredScripts_EnabledCorrectly() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Configuration.EnableDeferredScripts = true;
         
         doc.Body.Add(element => {
@@ -118,11 +118,11 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_ThemeMode_AffectsOutput() {
-        var doc1 = new Document();
+        using var doc1 = new Document();
         doc1.ThemeMode = ThemeMode.Light;
         var html1 = doc1.ToString();
         
-        var doc2 = new Document();
+        using var doc2 = new Document();
         doc2.ThemeMode = ThemeMode.Dark;
         var html2 = doc2.ToString();
         
@@ -134,7 +134,7 @@ public class TestLibraryPlacement {
 
     [TestMethod]
     public void Document_LibraryRegistration_IsIdempotent() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Add the same component type multiple times
         doc.Body.Add(element => {

--- a/HtmlForgeX.Tests/TestNullChildFiltering.cs
+++ b/HtmlForgeX.Tests/TestNullChildFiltering.cs
@@ -6,7 +6,7 @@ namespace HtmlForgeX.Tests;
 public class TestNullChildFiltering {
     [TestMethod]
     public void DocumentToString_IgnoresNullChildren() {
-        var document = new Document();
+        using var document = new Document();
         document.Body.Children.Add(null);
         document.Body.Children.Add(new Span().AddContent("Test"));
 

--- a/HtmlForgeX.Tests/TestParallelDocuments.cs
+++ b/HtmlForgeX.Tests/TestParallelDocuments.cs
@@ -17,7 +17,7 @@ public class TestParallelDocuments {
         
         // Create multiple documents in parallel with different configurations
         var tasks = Enumerable.Range(0, documentCount).Select(async i => {
-            var doc = new Document();
+            using var doc = new Document();
             doc.LibraryMode = i % 2 == 0 ? LibraryMode.Online : LibraryMode.Offline;
             doc.ThemeMode = i % 3 == 0 ? ThemeMode.Light : ThemeMode.Dark;
             
@@ -65,7 +65,7 @@ public class TestParallelDocuments {
         var results = new ConcurrentBag<(string id, int errorCount, int libraryCount, LibraryMode mode)>();
         
         var tasks = Enumerable.Range(0, documentCount).Select(async i => {
-            var doc = new Document();
+            using var doc = new Document();
             var randomId = doc.Configuration.GenerateRandomId($"test{i}");
             
             // Configure each document differently
@@ -129,7 +129,7 @@ public class TestParallelDocuments {
         var memoryBefore = GC.GetTotalMemory(true);
         
         var tasks = Enumerable.Range(0, documentCount).Select(async i => {
-            var doc = new Document();
+            using var doc = new Document();
             doc.LibraryMode = LibraryMode.Online; // Use online mode for memory efficiency
             
             // Add a moderate amount of content
@@ -171,7 +171,7 @@ public class TestParallelDocuments {
         var tasks = Enumerable.Range(0, threadCount).Select(async threadId => {
             try {
                 for (int docId = 0; docId < documentsPerThread; docId++) {
-                    var doc = new Document();
+                    using var doc = new Document();
                     var uniqueId = $"thread{threadId}_doc{docId}";
                     
                     doc.Head.AddTitle($"Thread {threadId} Document {docId}");

--- a/HtmlForgeX.Tests/TestPrismJs.cs
+++ b/HtmlForgeX.Tests/TestPrismJs.cs
@@ -8,7 +8,7 @@ public class TestPrismJs
     [TestMethod]
     public void PrismJs_CodeBlock_GeneratesExpectedHtml()
     {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(element =>
         {
             element.CSharpCode("Console.WriteLine(\"Hi\");", config => config

--- a/HtmlForgeX.Tests/TestPrismJsCardIntegration.cs
+++ b/HtmlForgeX.Tests/TestPrismJsCardIntegration.cs
@@ -6,7 +6,7 @@ namespace HtmlForgeX.Tests;
 public class TestPrismJsCardIntegration {
     [TestMethod]
     public void PrismCodeBlockInsideCard_ShouldRegisterLibraries() {
-        var doc = new Document(LibraryMode.Online);
+        using var doc = new Document(LibraryMode.Online);
         var card = new TablerCard();
         card.Body(body => {
             body.CSharpCode("Console.WriteLine(\"Hello\");");

--- a/HtmlForgeX.Tests/TestQRCodeComponent.cs
+++ b/HtmlForgeX.Tests/TestQRCodeComponent.cs
@@ -9,7 +9,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_BasicCreation() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.QRCode("https://evotec.xyz");
@@ -25,7 +25,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_MultipleInstances() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.QRCode("https://example1.com");
@@ -48,7 +48,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_OnlineMode_UsesCDN() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Online;
         
         doc.Body.Add(element => {
@@ -64,7 +64,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_OfflineMode_EmbedLibrary() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Offline;
         
         doc.Body.Add(element => {
@@ -81,7 +81,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_WithSpecialCharacters() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.QRCode("Hello, World! 特殊字符 🎉");
@@ -96,7 +96,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_EmptyString() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.QRCode("");
@@ -111,7 +111,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_LongURL() {
-        var doc = new Document();
+        using var doc = new Document();
         var longUrl = "https://example.com/very/long/path/with/many/parameters?param1=value1&param2=value2&param3=value3&param4=value4&param5=value5&param6=value6";
         
         doc.Body.Add(element => {
@@ -127,7 +127,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_UniqueIDs() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.QRCode("QR1");
@@ -151,7 +151,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_TextWithQuotesAndNewlines() {
-        var doc = new Document();
+        using var doc = new Document();
 
         doc.Body.Add(element => {
             element.QRCode("Line1\n\"Quoted\"");
@@ -167,7 +167,7 @@ public class TestQRCodeComponent {
 
     [TestMethod]
     public void QRCode_LibraryRegistration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Before adding QR code
         Assert.IsFalse(doc.Configuration.Libraries.ContainsKey(Libraries.EasyQRCode), 

--- a/HtmlForgeX.Tests/TestQuillEditor.cs
+++ b/HtmlForgeX.Tests/TestQuillEditor.cs
@@ -32,7 +32,7 @@ public class TestQuillEditor {
 
     [TestMethod]
     public void QuillEditor_RegistersLibrary() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.Body.Add(el => {
             el.QuillEditor();
         });

--- a/HtmlForgeX.Tests/TestSpanFluentAPI.cs
+++ b/HtmlForgeX.Tests/TestSpanFluentAPI.cs
@@ -8,7 +8,7 @@ public class TestSpanFluentAPI {
     [TestMethod]
     public void SpanFluentAPI_UserExample_AppendContentWithColors() {
         // Test case from user's example - this should show the issue
-        var document = new Document();
+        using var document = new Document();
 
         var span4 = new Span()
             .AppendContent("Should be RED").WithColor(RGBColor.Red)
@@ -55,7 +55,7 @@ public class TestSpanFluentAPI {
     [TestMethod]
     public void SpanFluentAPI_BodySpan_WithColor() {
         // Test Body.Span() method
-        var document = new Document();
+        using var document = new Document();
 
         document.Body.Span("Hello World").WithColor(RGBColor.Red).WithFontSize("20px");
 
@@ -71,7 +71,7 @@ public class TestSpanFluentAPI {
     [TestMethod]
     public void SpanFluentAPI_DirectSpan_WithColor() {
         // Test direct span creation
-        var document = new Document();
+        using var document = new Document();
 
         var span = new Span { Content = "Direct span" };
         span.WithColor(RGBColor.Blue);
@@ -103,7 +103,7 @@ public class TestSpanFluentAPI {
     [TestMethod]
     public void Element_Text_SimpleAPI() {
         // Test the new simplified Text API
-        var document = new Document();
+        using var document = new Document();
 
         // Test simple text with color
         document.Body.Text("Red Text", RGBColor.Red);
@@ -125,7 +125,7 @@ public class TestSpanFluentAPI {
     [TestMethod]
     public void SpanFluentAPI_AddStyledText() {
         // Test the new AddStyledText method
-        var document = new Document();
+        using var document = new Document();
 
         var span = new Span()
             .AddStyledText("Bold Red", RGBColor.Red, "16px", FontWeight.Bold)

--- a/HtmlForgeX.Tests/TestSpanFluentAPIFixes.cs
+++ b/HtmlForgeX.Tests/TestSpanFluentAPIFixes.cs
@@ -48,7 +48,7 @@ public class TestSpanFluentAPIFixes {
         var span2 = span1.AddContent(" Content2").WithColor(RGBColor.Blue);
         var span3 = span2.AddContent(" Content3").WithColor(RGBColor.Green);
 
-        var document = new Document();
+        using var document = new Document();
 
         // Act - Add same reference multiple times (user might do this accidentally)
         document.Body.Add(span1);
@@ -105,7 +105,7 @@ public class TestSpanFluentAPIFixes {
         var span2 = span1.AppendContent(" Content2").WithColor(RGBColor.Blue);
         var span3 = span2.AppendContent(" Content3").WithColor(RGBColor.Green);
 
-        var document = new Document();
+        using var document = new Document();
 
         // Act
         document.Body.Add(span1);

--- a/HtmlForgeX.Tests/TestUncPaths.cs
+++ b/HtmlForgeX.Tests/TestUncPaths.cs
@@ -17,7 +17,7 @@ public class TestUncPaths {
 
     [TestMethod]
     public void Document_Save_UncStylePath() {
-        var doc = new Document();
+        using var doc = new Document();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             string local = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString(), "file.html");
             Directory.CreateDirectory(Path.GetDirectoryName(local)!);

--- a/HtmlForgeX.Tests/TestVisNetworkComponent.cs
+++ b/HtmlForgeX.Tests/TestVisNetworkComponent.cs
@@ -9,7 +9,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_BasicCreation() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -30,7 +30,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_WithOptions() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -58,7 +58,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_LoadingBar() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -76,7 +76,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_MultipleNodes() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -101,7 +101,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_HierarchicalLayout() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -134,7 +134,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_NodeGroups() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -165,7 +165,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_InteractiveOptions() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -200,7 +200,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_OnlineMode_LibraryInclusion() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Online;
         
         doc.Body.Add(element => {
@@ -218,7 +218,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_OfflineMode_EmbeddedLibrary() {
-        var doc = new Document();
+        using var doc = new Document();
         doc.LibraryMode = LibraryMode.Offline;
         
         doc.Body.Add(element => {
@@ -236,7 +236,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_LibraryRegistration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         // Before adding network
         Assert.IsFalse(doc.Configuration.Libraries.ContainsKey(Libraries.VisNetwork), 
@@ -258,7 +258,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_ComplexEdges() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -297,7 +297,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_EmptyNetwork() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -313,7 +313,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_LoadingBarRegistration() {
-        var doc = new Document();
+        using var doc = new Document();
         
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -334,7 +334,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_NodeImages() {
-        var doc = new Document();
+        using var doc = new Document();
 
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -361,7 +361,7 @@ public class TestVisNetworkComponent {
         var path = Path.GetTempFileName();
         File.WriteAllBytes(path, imgData);
 
-        var doc = new Document { LibraryMode = LibraryMode.Offline };
+        using var doc = new Document { LibraryMode = LibraryMode.Offline };
 
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {
@@ -385,7 +385,7 @@ public class TestVisNetworkComponent {
         var path = Path.GetTempFileName();
         File.WriteAllBytes(path, imgData);
 
-        var doc = new Document { LibraryMode = LibraryMode.Offline };
+        using var doc = new Document { LibraryMode = LibraryMode.Offline };
 
         doc.Body.Add(el => {
             el.DiagramNetwork(net => {
@@ -411,7 +411,7 @@ public class TestVisNetworkComponent {
 
     [TestMethod]
     public void VisNetwork_FluentNodeCreation() {
-        var doc = new Document();
+        using var doc = new Document();
 
         doc.Body.Add(element => {
             element.DiagramNetwork(network => {

--- a/HtmlForgeX/Containers/Core/Document.Dispose.cs
+++ b/HtmlForgeX/Containers/Core/Document.Dispose.cs
@@ -1,0 +1,42 @@
+namespace HtmlForgeX;
+
+public partial class Document
+{
+    private bool _disposed;
+
+    /// <summary>
+    /// Releases resources used by the <see cref="Document"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        System.GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes managed and unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">Whether managed resources should be disposed.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            // Release managed resources if needed in the future
+        }
+
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Finalizer to ensure resources are released.
+    /// </summary>
+    ~Document()
+    {
+        Dispose(false);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Document.Main.cs
+++ b/HtmlForgeX/Containers/Core/Document.Main.cs
@@ -8,7 +8,7 @@ namespace HtmlForgeX;
 /// <summary>
 /// Represents an HTML document.
 /// </summary>
-public partial class Document : Element {
+public partial class Document : Element, System.IDisposable {
     internal static readonly InternalLogger _logger = new();
 
     /// <summary>


### PR DESCRIPTION
## Summary
- implement IDisposable for Document
- add disposal test for Document
- update examples to use `using` pattern
- update tests to use `using` pattern

## Testing
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68773edf0464832e8fd0269d1b03cd72