### PR TITLE
Improve font family demo and tests

### DIFF
--- a/HtmlForgeX.Examples/ByHand/GoogleFontExample.cs
+++ b/HtmlForgeX.Examples/ByHand/GoogleFontExample.cs
@@ -1,0 +1,23 @@
+using HtmlForgeX.Examples;
+
+namespace HtmlForgeX.Examples.ByHand;
+
+internal class GoogleFontExample
+{
+    public static void Demo(bool openInBrowser = false)
+    {
+        HelpersSpectre.PrintTitle("Google Font Example");
+
+        var document = new Document();
+        document.Head.AddTitle("Google Font Example");
+        document.Head.AddFontLink("https://fonts.googleapis.com/css2?family=Roboto&display=swap");
+        document.Head.AddFontLink("https://fonts.googleapis.com/css2?family=Lobster&display=swap");
+        document.Head.SetBodyFontFamily("Roboto", "Lobster", "sans-serif");
+
+        document.Body.Span("Hello with Google Font!");
+        document.Body.Span("Fallback to Lobster if Roboto missing")
+            .WithFontFamily("Lobster, cursive");
+
+        document.Save("GoogleFontExample.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -50,6 +50,7 @@ internal class Program {
         BasicHtmlBuilding.Demo1(openInBrowser);
         BasicHtmlBuilding.Demo2(openInBrowser);
         BasicHtmlBuilding.DemoAnalytics(openInBrowser);
+        GoogleFontExample.Demo(openInBrowser);
 
         // Toast examples
         ExampleTablerToast.Create(openInBrowser);

--- a/HtmlForgeX.Tests/TestAddFontLink.cs
+++ b/HtmlForgeX.Tests/TestAddFontLink.cs
@@ -1,0 +1,81 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestAddFontLink
+{
+    [TestMethod]
+    public void AddFontLink_DeduplicatesAndRendersCorrectly()
+    {
+        var doc = new Document();
+        const string url = "https://fonts.googleapis.com/css2?family=Open+Sans";
+        doc.Head.AddFontLink(url);
+        doc.Head.AddFontLink(url); // duplicate
+
+        var html = doc.Head.ToString();
+        var count = CountOccurrences(html, url);
+        Assert.AreEqual(1, count);
+        StringAssert.Contains(html, url);
+    }
+
+    [TestMethod]
+    public void AddFontLink_AllowsMultipleUrls()
+    {
+        var doc = new Document();
+        const string url1 = "https://fonts.example.com/a.css";
+        const string url2 = "https://fonts.example.com/b.css";
+        doc.Head.AddFontLink(url1);
+        doc.Head.AddFontLink(url2);
+
+        var html = doc.Head.ToString();
+        StringAssert.Contains(html, url1);
+        StringAssert.Contains(html, url2);
+    }
+
+    [TestMethod]
+    public void SetBodyFontFamily_AddsCssOnce()
+    {
+        var doc = new Document();
+        const string expected = "Roboto, sans-serif";
+        doc.Head.SetBodyFontFamily("Roboto", "sans-serif");
+        doc.Head.SetBodyFontFamily("Roboto", "sans-serif"); // duplicate
+
+        var html = doc.Head.ToString();
+        var count = CountOccurrences(html, expected);
+        Assert.AreEqual(1, count);
+        StringAssert.Contains(html, expected);
+    }
+
+    [TestMethod]
+    public void SetBodyFontFamily_QuotesFontsWithSpaces()
+    {
+        var doc = new Document();
+        doc.Head.SetBodyFontFamily("Open Sans", "Arial", "sans-serif");
+
+        var html = doc.Head.ToString();
+        StringAssert.Contains(html, "'Open Sans', Arial, sans-serif");
+    }
+
+    [TestMethod]
+    public void SetBodyFontFamily_MultipleFonts()
+    {
+        var doc = new Document();
+        doc.Head.SetBodyFontFamily("Lobster", "cursive");
+
+        var html = doc.Head.ToString();
+        StringAssert.Contains(html, "font-family: Lobster, cursive;");
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, System.StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -114,8 +114,13 @@ public class Head : Element {
     /// External JavaScript links to include in the head.
     /// </summary>
     public List<string> JsLinks { get; set; } = new List<string>();
+    /// <summary>
+    /// External font links to include in the head.
+    /// </summary>
+    public List<string> FontLinks { get; set; } = new List<string>();
     private readonly HashSet<string> _cssLinkSet = new();
     private readonly HashSet<string> _jsLinkSet = new();
+    private readonly HashSet<string> _fontLinkSet = new();
     private readonly HashSet<string> _cssInlineSet = new();
     private readonly HashSet<string> _jsInlineSet = new();
     /// <summary>
@@ -283,6 +288,10 @@ public class Head : Element {
             head.AppendLine($"\t{metaTag.ToString()}");
         }
 
+        foreach (var link in FontLinks) {
+            head.AppendLine($"\t{link}");
+        }
+
         foreach (var link in CssLinks) {
             head.AppendLine($"\t{link}");
         }
@@ -363,6 +372,55 @@ public class Head : Element {
         if (_jsLinkSet.Add(link)) {
             JsLinks.Add($"<script src=\"{link}\"></script>");
         }
+    }
+
+    /// <summary>
+    /// Registers an external font link if it has not already been added.
+    /// </summary>
+    /// <param name="link">URL to the font stylesheet.</param>
+    public void AddFontLink(string link) {
+        if (_fontLinkSet.Add(link)) {
+            FontLinks.Add($"<link href=\"{link}\" rel=\"stylesheet\">");
+        }
+    }
+
+    /// <summary>
+    /// Sets the font-family for the specified CSS selector.
+    /// </summary>
+    /// <param name="selector">CSS selector to apply the font to.</param>
+    /// <param name="fonts">Font families in preferred order.</param>
+    public void SetFontFamily(string selector, params string[] fonts) {
+        if (fonts == null || fonts.Length == 0) {
+            return;
+        }
+        var formatted = FormatFonts(fonts);
+        AddCssInline($"{selector} {{ font-family: {formatted}; }}");
+    }
+
+    /// <summary>
+    /// Sets the font-family for the document body.
+    /// </summary>
+    /// <param name="fonts">Font families in preferred order.</param>
+    public void SetBodyFontFamily(params string[] fonts) {
+        SetFontFamily("body", fonts);
+    }
+
+    private static string FormatFonts(IEnumerable<string> fonts) {
+        return string.Join(", ", fonts.Select(QuoteFontIfNeeded));
+    }
+
+    private static string QuoteFontIfNeeded(string font) {
+        if (string.IsNullOrWhiteSpace(font)) {
+            return font;
+        }
+
+        var trimmed = font.Trim();
+
+        if (trimmed.Contains(' ') && !(trimmed.StartsWith("\"") || trimmed.StartsWith("'"))) {
+            return $"'{trimmed}'";
+        }
+
+        return trimmed;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add a second font demo span showing Lobster fallback
- extend font unit tests for multiple urls and multiple fonts

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68773e695fac832e94a7909d90319152