### PR TITLE
Fix Quill modules serialization

### DIFF
--- a/HtmlForgeX.Tests/TestQuillEditor.cs
+++ b/HtmlForgeX.Tests/TestQuillEditor.cs
@@ -31,6 +31,13 @@ public class TestQuillEditor {
     }
 
     [TestMethod]
+    public void QuillEditor_DefaultModulesIncluded() {
+        var editor = new QuillEditor();
+        var html = editor.ToString();
+        Assert.IsTrue(html.Contains("\"modules\""));
+    }
+
+    [TestMethod]
     public void QuillEditor_RegistersLibrary() {
         var doc = new Document();
         doc.Body.Add(el => {

--- a/HtmlForgeX/Containers/Quill/QuillEditorOptions.cs
+++ b/HtmlForgeX/Containers/Quill/QuillEditorOptions.cs
@@ -30,8 +30,7 @@ public class QuillEditorOptions {
     /// Gets or sets module configuration.
     /// </summary>
     [JsonPropertyName("modules")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public QuillModules? Modules { get; set; }
+    public QuillModules Modules { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the enabled formatting options.


### PR DESCRIPTION
## Summary
- keep QuillModules initialized in `QuillEditorOptions`
- check that empty modules are serialized in `QuillEditor` HTML output

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68774614bc90832e9c127e254171d5e8