### PR TITLE
Fix duplicate inline CSS/JS

### DIFF
--- a/HtmlForgeX.Tests/TestHeadInline.cs
+++ b/HtmlForgeX.Tests/TestHeadInline.cs
@@ -1,0 +1,23 @@
+using HtmlForgeX;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestHeadInline {
+    [TestMethod]
+    public void AddCssInline_TrimsBeforeDeduplication() {
+        var doc = new Document();
+        doc.Head.AddCssInline("body { color: red; }");
+        doc.Head.AddCssInline(" body { color: red; } ");
+        Assert.AreEqual(1, doc.Head.Styles.Count);
+    }
+
+    [TestMethod]
+    public void AddJsInline_TrimsBeforeDeduplication() {
+        var doc = new Document();
+        doc.Head.AddJsInline("console.log('hi');");
+        doc.Head.AddJsInline(" console.log('hi'); ");
+        Assert.AreEqual(1, doc.Head.Scripts.Count);
+    }
+}

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -370,6 +370,7 @@ public class Head : Element {
     /// </summary>
     /// <param name="css">CSS rules to embed.</param>
     public void AddCssInline(string css) {
+        css = css.Trim();
         if (_cssInlineSet.Add(css)) {
             Styles.Add($"<style>{css}</style>");
         }
@@ -380,12 +381,14 @@ public class Head : Element {
     /// </summary>
     /// <param name="js">JavaScript code to embed.</param>
     public void AddJsInline(string js) {
+        js = js.Trim();
         if (_jsInlineSet.Add(js)) {
             Scripts.Add($"<script>{js}</script>");
         }
     }
 
     private void AddRawScript(string script) {
+        script = script.Trim();
         if (_jsInlineSet.Add(script)) {
             Scripts.Add(script);
         }


### PR DESCRIPTION
## Summary
- trim inline style/script content before deduplicating
- add regression tests for CSS and JS inline trimming

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_687745a40594832ebba92feb5e994ea6