### PR TITLE
Fix duplicate footer child initialization

### DIFF
--- a/HtmlForgeX.Tests/TestTablerCardFooter.cs
+++ b/HtmlForgeX.Tests/TestTablerCardFooter.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerCardFooter {
+    private class DummyElement : Element {
+        public int AddedCount { get; private set; }
+
+        protected internal override void OnAddedToDocument() {
+            AddedCount++;
+            base.OnAddedToDocument();
+        }
+
+        public override string ToString() => "<span>dummy</span>";
+    }
+
+    [TestMethod]
+    public void EnsureChildrenHaveDocumentReference_CalledMultipleTimes_ShouldNotDuplicateOnAdded() {
+        var dummy = new DummyElement();
+        var card = new TablerCard();
+        card.Footer(f => f.Add(dummy));
+
+        var document = new Document();
+        document.Body.Add(card);
+
+        _ = document.ToString();
+        _ = document.ToString();
+
+        Assert.AreEqual(1, dummy.AddedCount, "OnAddedToDocument should be called once");
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardFooter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 using HtmlForgeX.Extensions;
@@ -12,6 +13,8 @@ public class TablerCardFooter : Element {
     /// Gets or sets optional footer text content.
     /// </summary>
     public string? Content { get; set; }
+
+    private readonly HashSet<Element> _processedChildren = new();
 
     /// <summary>
     /// Initializes or configures SetContent.
@@ -53,14 +56,22 @@ public class TablerCardFooter : Element {
     /// Ensures all children have proper Document and Email references for library registration
     /// </summary>
     private void EnsureChildrenHaveDocumentReference() {
-        if (this.Document == null) return;
+        if (Document == null) {
+            return;
+        }
 
         foreach (var child in Children.WhereNotNull()) {
-            if (child.Document == null) {
-                child.Document = this.Document;
-                child.Email = this.Email;
-                // Call OnAddedToDocument to trigger library registration
+            if (!_processedChildren.Contains(child)) {
+                if (child.Document == null) {
+                    child.Document = Document;
+                    child.Email = Email;
+                }
+
                 child.OnAddedToDocument();
+                _processedChildren.Add(child);
+            } else if (child.Document == null) {
+                child.Document = Document;
+                child.Email = Email;
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent repeated `OnAddedToDocument` for children inside `TablerCardFooter`
- add regression test covering repeated render scenario

## Testing
- `dotnet test HtmlForgeX.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687745c87bcc832e911960fc41ee5c38