### PR TITLE
Handle process exit codes in Helpers.Open

### DIFF
--- a/HtmlForgeX/Utilities/Helpers.cs
+++ b/HtmlForgeX/Utilities/Helpers.cs
@@ -30,16 +30,27 @@ internal static class Helpers {
             bool isOsx = PlatformOverride.HasValue ? PlatformOverride.Value == OSPlatform.OSX : RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             bool isLinux = PlatformOverride.HasValue ? PlatformOverride.Value == OSPlatform.Linux : RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
+            Process? process = null;
+
             if (isWindows) {
-                using Process? process = Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{filePath}\"") {
+                process = Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{filePath}\"") {
                     CreateNoWindow = true
                 });
             } else if (isOsx) {
-                using Process? process = Process.Start("open", filePath);
+                process = Process.Start("open", filePath);
             } else if (isLinux) {
-                using Process? process = Process.Start("xdg-open", filePath);
+                process = Process.Start("xdg-open", filePath);
             } else {
                 Document._logger.WriteError($"Unsupported operating system while opening '{filePath}'.");
+                return false;
+            }
+
+            if (process is null) {
+                return false;
+            }
+
+            process.WaitForExit();
+            if (process.ExitCode != 0) {
                 return false;
             }
         } catch (Win32Exception ex) {


### PR DESCRIPTION
## Summary
- check process exit status when opening files
- return `false` when the process fails
- add a test covering the failure case by mocking `xdg-open`

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687754251c68832e8a98fc52f58f9b40