### PR TITLE
Handle invalid colon in Windows paths

### DIFF
--- a/HtmlForgeX.Tests/TestWindowsPaths.cs
+++ b/HtmlForgeX.Tests/TestWindowsPaths.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Runtime.InteropServices;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestWindowsPaths {
+    [TestMethod]
+    public void PathUtilities_Validate_ColonInFilename() {
+        string path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? @"C:\\temp\\file:stream.html"
+            : "/tmp/file:stream.html";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.ThrowsException<ArgumentException>(() => PathUtilities.Validate(path));
+        } else {
+            PathUtilities.Validate(path);
+        }
+    }
+
+    [TestMethod]
+    public void PathUtilities_Validate_DriveColonOnly() {
+        string path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? @"C:\\temp\\file.html"
+            : "/tmp/file.html";
+        PathUtilities.Validate(path);
+    }
+}

--- a/HtmlForgeX/Utilities/PathUtilities.cs
+++ b/HtmlForgeX/Utilities/PathUtilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace HtmlForgeX;
 
@@ -11,6 +12,14 @@ internal static class PathUtilities {
 
         if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0) {
             throw new ArgumentException("Path contains invalid characters.", nameof(path));
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            var trimmed = path.StartsWith("\\\\?\\") ? path.Substring(4) : path;
+            var firstColon = trimmed.IndexOf(':');
+            if ((firstColon >= 0 && firstColon != 1) || trimmed.IndexOf(':', firstColon + 1) >= 0) {
+                throw new ArgumentException("Path contains invalid colon characters.", nameof(path));
+            }
         }
 
         // UNC paths start with two directory separators. Ensure they have at least


### PR DESCRIPTION
## Summary
- validate colon usage in PathUtilities on Windows
- add unit tests for Windows path validation

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687754341a6c832ebd09b88b621daf85