### PR TITLE
Add URL validation for TablerCardButton

### DIFF
--- a/HtmlForgeX.Examples/Containers/TablerCardsProperDemo.cs
+++ b/HtmlForgeX.Examples/Containers/TablerCardsProperDemo.cs
@@ -75,7 +75,9 @@ internal class TablerCardsProperDemo {
                         card.Header(header => {
                             header.Title("Card with Actions");
                             header.WithActions(actions => {
-                                actions.Button("Add New", btn => btn.Style(TablerButtonVariant.Primary));
+                                actions.Button("Add New", btn => btn
+                                    .Style(TablerButtonVariant.Primary)
+                                    .Url("https://example.com"));
                                 actions.IconButton(TablerIconType.Phone, btn => btn.AsActionButton());
                                 actions.IconButton(TablerIconType.Mail, btn => btn.AsActionButton());
                             });

--- a/HtmlForgeX.Tests/TestTablerCardActions.cs
+++ b/HtmlForgeX.Tests/TestTablerCardActions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HtmlForgeX.Tests;
@@ -32,5 +33,17 @@ public class TestTablerCardActions {
 
         var valueAfter = prop.GetValue(header);
         Assert.IsNotNull(valueAfter);
+    }
+
+    [TestMethod]
+    public void TablerCardButtonUrl_ThrowsOnNull() {
+        var button = new TablerCardButton();
+        Assert.ThrowsException<ArgumentException>(() => button.Url(null!));
+    }
+
+    [TestMethod]
+    public void TablerCardButtonUrl_ThrowsOnWhitespace() {
+        var button = new TablerCardButton();
+        Assert.ThrowsException<ArgumentException>(() => button.Url(" "));
     }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerCardAction.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardAction.cs
@@ -44,6 +44,10 @@ public class TablerCardButton : TablerCardAction {
     /// Initializes or configures Url.
     /// </summary>
     public TablerCardButton Url(string url) {
+        if (string.IsNullOrWhiteSpace(url)) {
+            throw new ArgumentException("URL cannot be null or whitespace.", nameof(url));
+        }
+
         ButtonUrl = url;
         return this;
     }


### PR DESCRIPTION
## Summary
- throw when `TablerCardButton.Url` receives null or whitespace
- document Url usage in existing demo
- remove redundant demo file
- add tests for Url validation

## Testing
- `dotnet build HtmlForgeX.sln -c Debug`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687754149aa8832e9b21deb65c1f5edc