### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,6 +5,7 @@
 [![license](https://img.shields.io/github/license/EvotecIT/HtmlForgeX.svg)](#)
 [![Test .NET Libraries](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml/badge.svg?branch=master)](https://github.com/EvotecIT/HtmlForgeX/actions/workflows/test-dotnet.yml)
 [![codecov](https://codecov.io/gh/EvotecIT/HtmlForgeX/branch/master/graph/badge.svg)](https://codecov.io/gh/EvotecIT/HtmlForgeX)
+[![Discord](https://img.shields.io/discord/508328927853281280?style=flat-square&label=discord%20chat)](https://evo.yt/discord)
 
 If you would like to contact me you can do so via Twitter or LinkedIn.
 


### PR DESCRIPTION
## Summary
- link to EvoTech's Discord server using a badge in README

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6877a6b8d2f0832e9fdafc3dfcdf9d9e