### PR TITLE
Handle invalid analytics providers

### DIFF
--- a/HtmlForgeX.Tests/TestHeadAnalytics.cs
+++ b/HtmlForgeX.Tests/TestHeadAnalytics.cs
@@ -46,4 +46,12 @@ public class TestHeadAnalytics
         var html = doc.Head.ToString();
         StringAssert.Contains(html, "tok&#39;en&quot;&lt;&gt;");
     }
+
+    [TestMethod]
+    public void AddAnalytics_InvalidProvider_ShouldThrow()
+    {
+        using var doc = new Document();
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => doc.Head.AddAnalytics((AnalyticsProvider)int.MaxValue, "id"));
+    }
 }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -478,7 +478,7 @@ gtag('config', '{encodedIdentifier}');
                 AddRawScript($"<script defer src=\"https://static.cloudflareinsights.com/beacon.min.js\" data-cf-beacon='{{\"token\": \"{encodedIdentifier}\"}}'></script>");
                 break;
             default:
-                break;
+                throw new ArgumentOutOfRangeException(nameof(provider), provider, null);
         }
         return this;
     }


### PR DESCRIPTION
## Summary
- ensure invalid `AnalyticsProvider` values throw in `Head.AddAnalytics`
- test that invalid providers raise exceptions

## Testing
- `dotnet test HtmlForgeX.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877c6819220832ebfcef7e85bda3a05