### PR TITLE
Fix font filtering in Head

### DIFF
--- a/HtmlForgeX.Tests/TestAddFontLink.cs
+++ b/HtmlForgeX.Tests/TestAddFontLink.cs
@@ -67,6 +67,16 @@ public class TestAddFontLink
         StringAssert.Contains(html, "font-family: Lobster, cursive;");
     }
 
+    [TestMethod]
+    public void SetBodyFontFamily_IgnoresEmptyValues()
+    {
+        var doc = new Document();
+        doc.Head.SetBodyFontFamily("Roboto", string.Empty, "  ", null, "sans-serif");
+
+        var html = doc.Head.ToString();
+        StringAssert.Contains(html, "font-family: Roboto, sans-serif;");
+    }
+
     private static int CountOccurrences(string text, string pattern)
     {
         int count = 0;

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -410,7 +410,9 @@ public class Head : Element {
     }
 
     private static string FormatFonts(IEnumerable<string> fonts) {
-        return string.Join(", ", fonts.Select(QuoteFontIfNeeded));
+        return string.Join(", ",
+            fonts.Where(font => !string.IsNullOrWhiteSpace(font))
+                 .Select(QuoteFontIfNeeded));
     }
 
     private static string QuoteFontIfNeeded(string font) {


### PR DESCRIPTION
## Summary
- filter out whitespace-only font names in `FormatFonts`
- add test for empty font values

## Testing
- `dotnet test --logger "trx;LogFileName=test_results.trx"`

------
https://chatgpt.com/codex/tasks/task_e_6877c697f8a8832e8a5fc9297b3ccada