### PR TITLE
Dispose semaphore when last document closed

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentDispose.cs
+++ b/HtmlForgeX.Tests/TestDocumentDispose.cs
@@ -10,4 +10,14 @@ public class TestDocumentDispose {
         doc.Dispose();
         doc.Dispose();
     }
+
+    [TestMethod]
+    public void Dispose_SemaphoreCountRemainsOne() {
+        using var doc = new Document();
+        var path = System.IO.Path.GetTempFileName();
+        doc.Save(path);
+        doc.Dispose();
+        Assert.AreEqual(1, FileWriteLock.Semaphore.CurrentCount);
+        System.IO.File.Delete(path);
+    }
 }

--- a/HtmlForgeX/Containers/Core/Document.Dispose.cs
+++ b/HtmlForgeX/Containers/Core/Document.Dispose.cs
@@ -26,7 +26,10 @@ public partial class Document
 
         if (disposing)
         {
-            // Release managed resources if needed in the future
+            if (System.Threading.Interlocked.Decrement(ref _activeDocuments) == 0)
+            {
+                FileWriteLock.DisposeSemaphore();
+            }
         }
 
         _disposed = true;

--- a/HtmlForgeX/Containers/Core/Document.Main.cs
+++ b/HtmlForgeX/Containers/Core/Document.Main.cs
@@ -10,6 +10,7 @@ namespace HtmlForgeX;
 /// </summary>
 public partial class Document : Element, System.IDisposable {
     internal static readonly InternalLogger _logger = new();
+    private static int _activeDocuments;
 
     /// <summary>
     /// Configuration and state for this document instance.
@@ -71,6 +72,7 @@ public partial class Document : Element, System.IDisposable {
     /// </summary>
     /// <param name="librariesMode">Initial library mode.</param>
     public Document(LibraryMode? librariesMode = null) {
+        System.Threading.Interlocked.Increment(ref _activeDocuments);
         if (librariesMode != null) {
             Configuration.LibraryMode = librariesMode.Value;
         }

--- a/HtmlForgeX/Utilities/FileWriteLock.cs
+++ b/HtmlForgeX/Utilities/FileWriteLock.cs
@@ -1,5 +1,12 @@
 namespace HtmlForgeX;
 
 internal static class FileWriteLock {
-    internal static readonly System.Threading.SemaphoreSlim Semaphore = new(1, 1);
+    private static System.Threading.SemaphoreSlim _semaphore = new(1, 1);
+
+    internal static System.Threading.SemaphoreSlim Semaphore => _semaphore;
+
+    internal static void DisposeSemaphore() {
+        _semaphore.Dispose();
+        _semaphore = new System.Threading.SemaphoreSlim(1, 1);
+    }
 }


### PR DESCRIPTION
## Summary
- dispose `FileWriteLock` semaphore once all `Document` instances are gone
- ensure disposing after save keeps the semaphore count at one

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877e8ecb440832eb4f0a49d60b17039