### PR TITLE
Encode QRCode text before embedding

### DIFF
--- a/HtmlForgeX.Tests/TestQRCodeComponent.cs
+++ b/HtmlForgeX.Tests/TestQRCodeComponent.cs
@@ -159,10 +159,31 @@ public class TestQRCodeComponent {
 
         var html = doc.ToString();
 
-        var encoded = JsonSerializer.Serialize("Line1\n\"Quoted\"",
+        var encoded = JsonSerializer.Serialize(
+            Helpers.HtmlEncode("Line1\n\"Quoted\""),
             new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
 
         Assert.IsTrue(html.Contains(encoded), "QR data should be JSON-encoded with escaped characters");
+    }
+
+    [TestMethod]
+    public void QRCode_HtmlTextIsEncoded() {
+        using var doc = new Document();
+
+        const string raw = "<div>QR & text</div>";
+
+        doc.Body.Add(element => {
+            element.QRCode(raw);
+        });
+
+        var html = doc.ToString();
+
+        var encoded = JsonSerializer.Serialize(
+            Helpers.HtmlEncode(raw),
+            new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }
+        );
+
+        Assert.IsTrue(html.Contains(encoded), "QR data should be HTML-encoded inside JSON string");
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
+++ b/HtmlForgeX/Containers/EasyQRCode/EasyQRCodeElement.cs
@@ -37,8 +37,10 @@ public class EasyQRCodeElement : Element {
     public override string ToString() {
         var divTag = new HtmlTag("div").Class("qrcode").Id(Id);
 
+        var encodedText = Helpers.HtmlEncode(PrivateText);
+
         var serializedText = JsonSerializer.Serialize(
-            PrivateText,
+            encodedText,
             new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }
         );
 


### PR DESCRIPTION
## Summary
- html encode QRCode text when generating script
- adjust quoting test for new behavior
- add test verifying encoded QRCode text

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68789fb06da0832e9c49be400bf46d30