### PR TITLE
Implement FullCalendar toolbar deserialization

### DIFF
--- a/HtmlForgeX.Tests/TestFullCalendarToolbarConverter.cs
+++ b/HtmlForgeX.Tests/TestFullCalendarToolbarConverter.cs
@@ -1,0 +1,46 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestFullCalendarToolbarConverter {
+    [TestMethod]
+    public void FullCalendarToolbar_SerializesAndDeserializes() {
+        var toolbar = new FullCalendarToolbar()
+            .Left(FullCalendarToolbarOption.Prev, FullCalendarToolbarOption.Next)
+            .Center(FullCalendarToolbarOption.Title)
+            .Right(FullCalendarToolbarOption.DayGridMonth, FullCalendarToolbarOption.TimeGridWeek);
+
+        var opts = new JsonSerializerOptions();
+        opts.Converters.Add(new FullCalendarToolbarConverter());
+
+        var json = JsonSerializer.Serialize(toolbar, opts);
+        var back = JsonSerializer.Deserialize<FullCalendarToolbar>(json, opts);
+
+        Assert.IsNotNull(back);
+        CollectionAssert.AreEqual(toolbar.LeftOptions, back.LeftOptions);
+        CollectionAssert.AreEqual(toolbar.CenterOptions, back.CenterOptions);
+        CollectionAssert.AreEqual(toolbar.RightOptions, back.RightOptions);
+    }
+
+    [TestMethod]
+    public void FullCalendarToolbar_DeserializesFromString() {
+        const string json = "{\"left\":\"prev,next\",\"center\":\"title\",\"right\":\"dayGridMonth\"}";
+        var opts = new JsonSerializerOptions();
+        opts.Converters.Add(new FullCalendarToolbarConverter());
+
+        var toolbar = JsonSerializer.Deserialize<FullCalendarToolbar>(json, opts);
+
+        Assert.IsNotNull(toolbar);
+        CollectionAssert.AreEqual(
+            new List<FullCalendarToolbarOption> { FullCalendarToolbarOption.Prev, FullCalendarToolbarOption.Next },
+            toolbar!.LeftOptions);
+        CollectionAssert.AreEqual(
+            new List<FullCalendarToolbarOption> { FullCalendarToolbarOption.Title },
+            toolbar.CenterOptions);
+        CollectionAssert.AreEqual(
+            new List<FullCalendarToolbarOption> { FullCalendarToolbarOption.DayGridMonth },
+            toolbar.RightOptions);
+    }
+}

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
@@ -105,7 +105,7 @@ public class FullCalendarToolbarConverter : JsonConverter<FullCalendarToolbar> {
             reader.Read();
 
             var raw = reader.GetString() ?? string.Empty;
-            var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var parts = raw.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             var values = new List<FullCalendarToolbarOption>();
 
             foreach (var part in parts) {

--- a/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
+++ b/HtmlForgeX/Containers/FullCalendar/FullCalendarJsonConverters.cs
@@ -86,7 +86,51 @@ public class ViewOptionDictionaryConverter : JsonConverter<Dictionary<FullCalend
 public class FullCalendarToolbarConverter : JsonConverter<FullCalendarToolbar> {
     /// <inheritdoc />
     public override FullCalendarToolbar Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
-        throw new NotImplementedException();
+        if (reader.TokenType != JsonTokenType.StartObject) {
+            throw new JsonException();
+        }
+
+        var toolbar = new FullCalendarToolbar();
+
+        while (reader.Read()) {
+            if (reader.TokenType == JsonTokenType.EndObject) {
+                return toolbar;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName) {
+                throw new JsonException();
+            }
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            var raw = reader.GetString() ?? string.Empty;
+            var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var values = new List<FullCalendarToolbarOption>();
+
+            foreach (var part in parts) {
+                var option = ((FullCalendarToolbarOption[])Enum.GetValues(typeof(FullCalendarToolbarOption)))
+                    .First(e => GetEnumDescription(e) == part);
+                values.Add(option);
+            }
+
+            switch (propertyName) {
+                case "left":
+                    toolbar.LeftOptions = values;
+                    break;
+                case "center":
+                    toolbar.CenterOptions = values;
+                    break;
+                case "right":
+                    toolbar.RightOptions = values;
+                    break;
+                default:
+                    // Skip unknown properties
+                    break;
+            }
+        }
+
+        throw new JsonException();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- add JSON parsing for `FullCalendarToolbar` using `Utf8JsonReader`
- map option strings back to `FullCalendarToolbarOption` enums
- add tests validating toolbar converter

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68789f50d168832e92c3815ab7e439e4