### PR TITLE
Handle null for Element.Table

### DIFF
--- a/HtmlForgeX.Tests/TestTableNullHandling.cs
+++ b/HtmlForgeX.Tests/TestTableNullHandling.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTableNullHandling {
+    [TestMethod]
+    public void TableFromEnumerable_Null_ReturnsEmptyTable() {
+        using var document = new Document();
+
+        IEnumerable<object>? data = null;
+        var table = document.Body.Table(data!, TableType.BootstrapTable);
+
+        Assert.IsNotNull(table);
+        Assert.AreEqual(0, table.TableRows.Count);
+    }
+
+    [TestMethod]
+    public void TableFromObject_Null_ThrowsArgumentNullException() {
+        using var document = new Document();
+
+        Assert.ThrowsException<ArgumentNullException>(() => document.Body.Table((object)null!, TableType.BootstrapTable));
+    }
+}

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using HtmlForgeX.Tags;
 using HtmlForgeX.Extensions;
@@ -159,7 +160,9 @@ public abstract partial class Element {
     /// <param name="tableType">Table library type.</param>
     /// <returns>The created table element.</returns>
     public Table Table(IEnumerable<object> objects, TableType tableType) {
-        var table = HtmlForgeX.Table.Create(objects, tableType);
+        var table = objects is null
+            ? HtmlForgeX.Table.Create(Array.Empty<object>(), tableType)
+            : HtmlForgeX.Table.Create(objects, tableType);
         this.Add(table);
         return table;
     }
@@ -171,6 +174,10 @@ public abstract partial class Element {
     /// <param name="tableType">Table library type.</param>
     /// <returns>The created table element.</returns>
     public Table Table(object objects, TableType tableType) {
+        if (objects is null) {
+            throw new ArgumentNullException(nameof(objects));
+        }
+
         var table = HtmlForgeX.Table.Create(objects, tableType);
         this.Add(table);
         return table;


### PR DESCRIPTION
## Summary
- guard `Element.Table` overloads against null values
- return an empty table for null collections
- throw `ArgumentNullException` when a null object is passed
- add unit tests for the new behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68789f332d08832eb68d7d429bdedc43