### PR TITLE
Trim newlines in output generation

### DIFF
--- a/HtmlForgeX.Tests/Baselines/whitespace_basic.txt
+++ b/HtmlForgeX.Tests/Baselines/whitespace_basic.txt
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body data-bs-theme="light">
+<p>Hello</p>
+</body>
+</html>

--- a/HtmlForgeX.Tests/TestHtmlSpan.cs
+++ b/HtmlForgeX.Tests/TestHtmlSpan.cs
@@ -32,11 +32,9 @@ public class TestHtmlSpan {
             "<head>",
             "\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">",
             "</head>",
-            string.Empty,
             "<body data-bs-theme=\"light\">",
             "<span style=\"color: #FD0E35; text-align: Center\">This is table with DataTables</span><span> continue?</span>",
             "</body>",
-            string.Empty,
             "</html>"
         };
         var expected = string.Join(Environment.NewLine, expectedLines) + Environment.NewLine;

--- a/HtmlForgeX.Tests/TestWhitespaceOutput.cs
+++ b/HtmlForgeX.Tests/TestWhitespaceOutput.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestWhitespaceOutput {
+    [TestMethod]
+    public void Document_ToString_WhitespaceMatchesBaseline() {
+        using var doc = new Document();
+        doc.Body.Add(new HtmlTag("p", "Hello"));
+        var html = doc.ToString();
+
+        string baselinePath = Path.Combine(AppContext.BaseDirectory, "Baselines", "whitespace_basic.txt");
+        bool updateBaselines = Environment.GetEnvironmentVariable("UPDATE_BASELINES")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
+        if (!File.Exists(baselinePath) || updateBaselines) {
+            File.WriteAllText(baselinePath, html);
+        } else {
+            string baseline = File.ReadAllText(baselinePath);
+            Assert.AreEqual(baseline, html, "Generated HTML does not match baseline.");
+        }
+    }
+}

--- a/HtmlForgeX/Containers/Core/Body.Core.cs
+++ b/HtmlForgeX/Containers/Core/Body.Core.cs
@@ -34,12 +34,12 @@ public partial class Body : Element {
         if (!string.IsNullOrEmpty(bodyScripts.Trim())) {
             bodyBuilder.AppendLine();
             bodyBuilder.AppendLine("\t<!-- Body Scripts -->");
-            bodyBuilder.Append(bodyScripts);
+            bodyBuilder.Append(bodyScripts.TrimEnd('\r', '\n'));
         }
 
         // Add the HTML of the child elements
         foreach (var child in Children.WhereNotNull()) {
-            bodyBuilder.AppendLine(child.ToString());
+            bodyBuilder.AppendLine(child.ToString().TrimEnd('\r', '\n'));
         }
 
         // Add footer scripts (from library Footer sections) before closing body tag
@@ -47,7 +47,7 @@ public partial class Body : Element {
         if (!string.IsNullOrEmpty(footerScripts.Trim())) {
             bodyBuilder.AppendLine();
             bodyBuilder.AppendLine("\t<!-- Footer Scripts -->");
-            bodyBuilder.Append(footerScripts);
+            bodyBuilder.Append(footerScripts.TrimEnd('\r', '\n'));
         }
 
         bodyBuilder.AppendLine("</body>");

--- a/HtmlForgeX/Containers/Core/Document.Main.cs
+++ b/HtmlForgeX/Containers/Core/Document.Main.cs
@@ -101,10 +101,15 @@ public partial class Document : Element, System.IDisposable {
         var html = StringBuilderCache.Acquire();
         html.AppendLine("<!DOCTYPE html>");
         html.AppendLine("<html>");
-        html.Append(Head.ToString());
+
+        var headString = Head.ToString().TrimEnd('\r', '\n');
+        html.Append(headString);
         html.AppendLine();
-        html.Append(Body.ToString());
+
+        var bodyString = Body.ToString().TrimEnd('\r', '\n');
+        html.Append(bodyString);
         html.AppendLine();
+
         html.AppendLine("</html>");
         return StringBuilderCache.GetStringAndRelease(html);
     }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -289,7 +289,7 @@ public class Head : Element {
         head.Append(MetaTagString("revised", Revised?.ToString()));
 
         foreach (var metaTag in MetaTags) {
-            head.AppendLine($"\t{metaTag.ToString()}");
+            head.AppendLine($"\t{metaTag.ToString().TrimEnd('\r', '\n')}");
         }
 
         foreach (var link in FontLinks) {
@@ -308,10 +308,10 @@ public class Head : Element {
             foreach (var style in Styles) {
                 string styleStr = style.ToString();
                 if (styleStr.Trim().StartsWith("<style") && styleStr.Trim().EndsWith("</style>")) {
-                    head.AppendLine(styleStr);
+                    head.AppendLine(styleStr.TrimEnd('\r', '\n'));
                 } else {
                     head.AppendLine("<style type=\"text/css\">");
-                    head.AppendLine(styleStr);
+                    head.AppendLine(styleStr.TrimEnd('\r', '\n'));
                     head.AppendLine("</style>");
                 }
             }
@@ -613,7 +613,7 @@ gtag('config', '{encodedIdentifier}');
         // Process inline CSS styles (consistent with Header processing)
         foreach (var style in libraryLinks.CssStyle) {
             output.AppendLine($"\t<style type=\"text/css\">");
-            output.AppendLine(style.ToString());
+            output.AppendLine(style.ToString().TrimEnd('\r', '\n'));
             output.AppendLine($"\t</style>");
         }
 

--- a/HtmlForgeX/Containers/Email/EmailContent.cs
+++ b/HtmlForgeX/Containers/Email/EmailContent.cs
@@ -114,7 +114,7 @@ public class EmailContent : Element {
 
         // Render all child elements
         foreach (var element in _elements) {
-            html.AppendLine(element.ToString());
+            html.AppendLine(element.ToString().TrimEnd('\r', '\n'));
         }
 
         html.AppendLine("</td>");

--- a/HtmlForgeX/Containers/Email/EmailFooter.cs
+++ b/HtmlForgeX/Containers/Email/EmailFooter.cs
@@ -68,7 +68,7 @@ public class EmailFooter : Element {
         var html = StringBuilderCache.Acquire();
 
         html.AppendLine($@"<!-- FOOTER -->");
-        html.AppendLine(FooterBox.ToString());
+        html.AppendLine(FooterBox.ToString().TrimEnd('\r', '\n'));
         html.AppendLine($@"<!-- /FOOTER -->");
 
         return StringBuilderCache.GetStringAndRelease(html);

--- a/HtmlForgeX/Containers/Email/EmailHeader.cs
+++ b/HtmlForgeX/Containers/Email/EmailHeader.cs
@@ -173,7 +173,7 @@ public class EmailHeader : Element {
         html.AppendLine($@"    <td style=""padding: {Padding};"">");
 
         foreach (var child in base.Children.WhereNotNull()) {
-            html.AppendLine(child.ToString());
+            html.AppendLine(child.ToString().TrimEnd('\r', '\n'));
         }
 
         html.AppendLine($@"    </td>");

--- a/HtmlForgeX/Containers/Email/EmailList.cs
+++ b/HtmlForgeX/Containers/Email/EmailList.cs
@@ -164,12 +164,12 @@ public class EmailList : Element {
 
         // Render items
         foreach (var item in Items.WhereNotNull()) {
-            html.AppendLine(item.ToString());
+            html.AppendLine(item.ToString().TrimEnd('\r', '\n'));
         }
 
         // Render child elements (nested lists, etc.)
         foreach (var child in Children.WhereNotNull()) {
-            html.AppendLine(child.ToString());
+            html.AppendLine(child.ToString().TrimEnd('\r', '\n'));
         }
 
         html.AppendLine($@"

--- a/HtmlForgeX/Containers/Email/EmailTextBox.cs
+++ b/HtmlForgeX/Containers/Email/EmailTextBox.cs
@@ -252,7 +252,7 @@ public class EmailTextBox : Element {
 
         // Render child elements (nested content)
         foreach (var child in Children.WhereNotNull()) {
-            html.AppendLine(child.ToString());
+            html.AppendLine(child.ToString().TrimEnd('\r', '\n'));
         }
 
         html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>");


### PR DESCRIPTION
## Summary
- trim trailing line endings in `Document.ToString` and several element `ToString` implementations
- adjust head processing to trim line endings
- update email rendering helpers
- add baseline whitespace test and fix span test expectations

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68789f0d4968832e956ea012c6d95038