### PR TITLE
Use Uri escaping for analytics identifier

### DIFF
--- a/HtmlForgeX.Tests/TestHeadAnalytics.cs
+++ b/HtmlForgeX.Tests/TestHeadAnalytics.cs
@@ -34,8 +34,8 @@ public class TestHeadAnalytics
         var doc = new Document();
         doc.Head.AddAnalytics(AnalyticsProvider.GoogleAnalytics, "G-\"A&B<C>'");
         var html = doc.Head.ToString();
-        StringAssert.Contains(html, "googletagmanager.com/gtag/js?id=G-&quot;A&amp;B&lt;C&gt;&#39;");
-        StringAssert.Contains(html, "gtag('config', 'G-&quot;A&amp;B&lt;C&gt;&#39;');");
+        StringAssert.Contains(html, "googletagmanager.com/gtag/js?id=G-%22A%26B%3CC%3E%27");
+        StringAssert.Contains(html, "gtag('config', 'G-%22A%26B%3CC%3E%27');");
     }
 
     [TestMethod]
@@ -44,7 +44,7 @@ public class TestHeadAnalytics
         var doc = new Document();
         doc.Head.AddAnalytics(AnalyticsProvider.CloudflareInsights, "tok'en\"<>");
         var html = doc.Head.ToString();
-        StringAssert.Contains(html, "tok&#39;en&quot;&lt;&gt;");
+        StringAssert.Contains(html, "tok%27en%22%3C%3E");
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -465,7 +465,7 @@ public class Head : Element {
     /// <param name="identifier">Tracking or token identifier.</param>
     /// <returns>The <see cref="Head"/> instance for chaining.</returns>
     public Head AddAnalytics(AnalyticsProvider provider, string identifier) {
-        var encodedIdentifier = Helpers.HtmlEncode(identifier);
+        var encodedIdentifier = Uri.EscapeDataString(identifier);
         switch (provider) {
             case AnalyticsProvider.GoogleAnalytics:
                 AddRawScript($"<script async src=\"https://www.googletagmanager.com/gtag/js?id={encodedIdentifier}\"></script>");


### PR DESCRIPTION
## Summary
- replace HtmlEncode with Uri.EscapeDataString in `Head.AddAnalytics`
- update tests for new URI escaping behavior

## Testing
- `dotnet test HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68789f85661c832eab925183142fe2d2