### PR TITLE
Fix DataTables column index tracking

### DIFF
--- a/HtmlForgeX.Tests/TestDataTablesColumnBuilder.cs
+++ b/HtmlForgeX.Tests/TestDataTablesColumnBuilder.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDataTablesColumnBuilder
+{
+    [TestMethod]
+    public void ColumnBuilder_AssignsSequentialIndexes()
+    {
+        var table = new DataTablesTable();
+        table.ConfigureColumns(cols =>
+        {
+            cols.Column(c => c.Title("First").Build());
+            cols.Column(c => c.Title("Second").Build());
+            cols.Column(c => c.Title("Third").Build());
+        });
+
+        var html = table.ToString();
+
+        var first = html.IndexOf("\"targets\": 0");
+        var second = html.IndexOf("\"targets\": 1");
+        var third = html.IndexOf("\"targets\": 2");
+
+        Assert.IsTrue(first >= 0, "First column index not found");
+        Assert.IsTrue(second > first, "Second column index should follow first");
+        Assert.IsTrue(third > second, "Third column index should follow second");
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/Builders/DataTablesColumnBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Builders/DataTablesColumnBuilder.cs
@@ -6,6 +6,8 @@ namespace HtmlForgeX;
 public class DataTablesColumnBuilder
 {
     private readonly List<DataTablesColumn> _columns = new List<DataTablesColumn>();
+    // Tracks the next available column index when none is specified
+    private int _nextIndex;
 
     /// <summary>Add a column configuration</summary>
     public DataTablesColumnBuilder Column(int targetIndex, Action<DataTablesColumn> configure)
@@ -13,13 +15,14 @@ public class DataTablesColumnBuilder
         var column = new DataTablesColumn { Targets = targetIndex };
         configure(column);
         _columns.Add(column);
+        _nextIndex = Math.Max(_nextIndex, targetIndex + 1);
         return this;
     }
 
     /// <summary>Add a column configuration by name</summary>
     public DataTablesColumnBuilder Column(string name, Action<DataTablesColumn> configure)
     {
-        var column = new DataTablesColumn { Name = name };
+        var column = new DataTablesColumn { Name = name, Targets = _nextIndex++ };
         configure(column);
         _columns.Add(column);
         return this;
@@ -101,6 +104,14 @@ public class DataTablesColumnBuilder
     /// <summary>Add a column to the collection</summary>
     internal void AddColumn(DataTablesColumn column)
     {
+        if (!column.Targets.HasValue)
+        {
+            column.Targets = _nextIndex++;
+        }
+        else
+        {
+            _nextIndex = Math.Max(_nextIndex, column.Targets.Value + 1);
+        }
         _columns.Add(column);
     }
 


### PR DESCRIPTION
## Summary
- track internal column index in `DataTablesColumnBuilder`
- use tracked index when adding columns
- add test verifying sequential column order

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68789f3ce7b4832eba59e6a14f90bfe5