### PR TITLE
Remove tab characters from generated HTML

### DIFF
--- a/HtmlForgeX.Tests/Baselines/whitespace_basic.txt
+++ b/HtmlForgeX.Tests/Baselines/whitespace_basic.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 </head>
 <body data-bs-theme="light">
 <p>Hello</p>

--- a/HtmlForgeX.Tests/TestHtmlSpan.cs
+++ b/HtmlForgeX.Tests/TestHtmlSpan.cs
@@ -30,7 +30,7 @@ public class TestHtmlSpan {
             "<!DOCTYPE html>",
             "<html>",
             "<head>",
-            "\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">",
+            "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">",
             "</head>",
             "<body data-bs-theme=\"light\">",
             "<span style=\"color: #FD0E35; text-align: Center\">This is table with DataTables</span><span> continue?</span>",

--- a/HtmlForgeX/Containers/Core/Body.Core.cs
+++ b/HtmlForgeX/Containers/Core/Body.Core.cs
@@ -33,7 +33,7 @@ public partial class Body : Element {
         var bodyScripts = _document.Head.GenerateBodyScripts();
         if (!string.IsNullOrEmpty(bodyScripts.Trim())) {
             bodyBuilder.AppendLine();
-            bodyBuilder.AppendLine("\t<!-- Body Scripts -->");
+            bodyBuilder.AppendLine("<!-- Body Scripts -->");
             bodyBuilder.Append(bodyScripts.TrimEnd('\r', '\n'));
         }
 
@@ -46,7 +46,7 @@ public partial class Body : Element {
         var footerScripts = _document.Head.GenerateFooterScripts();
         if (!string.IsNullOrEmpty(footerScripts.Trim())) {
             bodyBuilder.AppendLine();
-            bodyBuilder.AppendLine("\t<!-- Footer Scripts -->");
+            bodyBuilder.AppendLine("<!-- Footer Scripts -->");
             bodyBuilder.Append(footerScripts.TrimEnd('\r', '\n'));
         }
 

--- a/HtmlForgeX/Containers/Core/EmailBody.cs
+++ b/HtmlForgeX/Containers/Core/EmailBody.cs
@@ -139,27 +139,27 @@ public class EmailBody : Element {
         var actualBackgroundColor = GetThemeBackgroundColor();
 
         body.AppendLine($"<body class=\"{CssClass}{themeClass}\" style=\"{bodyStyle}\" bgcolor=\"{actualBackgroundColor}\">");
-        body.AppendLine("\t<center>");
-        body.AppendLine($"\t\t<table class=\"main {CssClass}{themeClass}\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" role=\"presentation\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; border-collapse: collapse; width: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;\" bgcolor=\"{actualBackgroundColor}\">");
-        body.AppendLine("\t\t\t<tr>");
-        body.AppendLine("\t\t\t\t<td align=\"center\" valign=\"top\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif;\">");
+        body.AppendLine("<center>");
+        body.AppendLine($"<table class=\"main {CssClass}{themeClass}\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" role=\"presentation\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; border-collapse: collapse; width: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;\" bgcolor=\"{actualBackgroundColor}\">");
+        body.AppendLine("<tr>");
+        body.AppendLine("<td align=\"center\" valign=\"top\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif;\">");
 
         // MSO conditional comments for IE/Outlook
-        body.AppendLine("\t\t\t\t\t<!--[if (gte mso 9)|(IE)]>");
-        body.AppendLine("\t\t\t\t\t<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\">");
-        body.AppendLine("\t\t\t\t\t\t<tr>");
-        body.AppendLine($"\t\t\t\t\t\t\t<td align=\"center\" valign=\"top\" width=\"{MaxWidth}\">");
-        body.AppendLine("\t\t\t\t\t<![endif]-->");
+        body.AppendLine("<!--[if (gte mso 9)|(IE)]>");
+        body.AppendLine("<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\">");
+        body.AppendLine("<tr>");
+        body.AppendLine($"<td align=\"center\" valign=\"top\" width=\"{MaxWidth}\">");
+        body.AppendLine("<![endif]-->");
 
         // Preheader text (hidden but appears in email previews)
         if (IncludePreheader && !string.IsNullOrEmpty(PreheaderText)) {
-            body.AppendLine($"\t\t\t\t\t<span class=\"preheader\" style=\"font-size: 0; display: none; max-height: 0; mso-hide: all; line-height: 0; color: transparent; height: 0; max-width: 0; opacity: 0; overflow: hidden; visibility: hidden; width: 0; padding: 0;\">{Helpers.HtmlEncode(PreheaderText)}</span>");
+            body.AppendLine($"<span class=\"preheader\" style=\"font-size: 0; display: none; max-height: 0; mso-hide: all; line-height: 0; color: transparent; height: 0; max-width: 0; opacity: 0; overflow: hidden; visibility: hidden; width: 0; padding: 0;\">{Helpers.HtmlEncode(PreheaderText)}</span>");
         }
 
         // Main content wrapper table
-        body.AppendLine($"\t\t\t\t\t<table class=\"wrap\" cellspacing=\"0\" cellpadding=\"0\" role=\"presentation\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; border-collapse: collapse; width: 100%; max-width: {MaxWidth}px; text-align: left;\">");
-        body.AppendLine("\t\t\t\t\t\t<tr>");
-        body.AppendLine("\t\t\t\t\t\t\t<td class=\"p-sm\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; padding: 8px;\">");
+        body.AppendLine($"<table class=\"wrap\" cellspacing=\"0\" cellpadding=\"0\" role=\"presentation\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; border-collapse: collapse; width: 100%; max-width: {MaxWidth}px; text-align: left;\">");
+        body.AppendLine("<tr>");
+        body.AppendLine("<td class=\"p-sm\" style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; padding: 8px;\">");
 
         // Render child elements
         foreach (var child in Children.WhereNotNull()) {
@@ -170,21 +170,21 @@ public class EmailBody : Element {
         }
 
         // Close main content wrapper
-        body.AppendLine("\t\t\t\t\t\t\t</td>");
-        body.AppendLine("\t\t\t\t\t\t</tr>");
-        body.AppendLine("\t\t\t\t\t</table>");
+        body.AppendLine("</td>");
+        body.AppendLine("</tr>");
+        body.AppendLine("</table>");
 
         // Close MSO conditional comments
-        body.AppendLine("\t\t\t\t\t<!--[if (gte mso 9)|(IE)]>");
-        body.AppendLine("\t\t\t\t\t\t\t</td>");
-        body.AppendLine("\t\t\t\t\t\t</tr>");
-        body.AppendLine("\t\t\t\t\t</table>");
-        body.AppendLine("\t\t\t\t\t<![endif]-->");
+        body.AppendLine("<!--[if (gte mso 9)|(IE)]>");
+        body.AppendLine("</td>");
+        body.AppendLine("</tr>");
+        body.AppendLine("</table>");
+        body.AppendLine("<![endif]-->");
 
-        body.AppendLine("\t\t\t\t</td>");
-        body.AppendLine("\t\t\t</tr>");
-        body.AppendLine("\t\t</table>");
-        body.AppendLine("\t</center>");
+        body.AppendLine("</td>");
+        body.AppendLine("</tr>");
+        body.AppendLine("</table>");
+        body.AppendLine("</center>");
         body.AppendLine("</body>");
 
         return StringBuilderCache.GetStringAndRelease(body);

--- a/HtmlForgeX/Containers/Core/EmailHead.cs
+++ b/HtmlForgeX/Containers/Core/EmailHead.cs
@@ -232,92 +232,92 @@ public class EmailHead : Element {
         head.AppendLine("<head>");
 
         // Content-Type meta tag (required for emails)
-        head.AppendLine($"\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Helpers.HtmlEncode(Charset)}\" />");
+        head.AppendLine($"<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Helpers.HtmlEncode(Charset)}\" />");
 
         // Title
         if (!string.IsNullOrEmpty(Title)) {
-            head.AppendLine($"\t<title>{Title}</title>");
+            head.AppendLine($"<title>{Title}</title>");
         }
 
         // Viewport meta tag
-        head.AppendLine($"\t<meta name=\"viewport\" content=\"{Helpers.HtmlEncode(Viewport)}\" />");
+        head.AppendLine($"<meta name=\"viewport\" content=\"{Helpers.HtmlEncode(Viewport)}\" />");
 
         // Format detection meta tag
-        head.AppendLine($"\t<meta content=\"{Helpers.HtmlEncode(FormatDetection)}\" name=\"format-detection\" />");
+        head.AppendLine($"<meta content=\"{Helpers.HtmlEncode(FormatDetection)}\" name=\"format-detection\" />");
 
         // Apple message reformatting meta tag
         if (DisableAppleMessageReformatting) {
-            head.AppendLine("\t<meta name=\"x-apple-disable-message-reformatting\" />");
+            head.AppendLine("<meta name=\"x-apple-disable-message-reformatting\" />");
         }
 
         // Color scheme meta tags for dark mode support
         if (_email.Configuration.DarkModeSupport) {
-            head.AppendLine($"\t<meta name=\"color-scheme\" content=\"{Helpers.HtmlEncode(ColorScheme)}\" />");
-            head.AppendLine($"\t<meta name=\"supported-color-schemes\" content=\"{Helpers.HtmlEncode(SupportedColorSchemes)}\" />");
+            head.AppendLine($"<meta name=\"color-scheme\" content=\"{Helpers.HtmlEncode(ColorScheme)}\" />");
+            head.AppendLine($"<meta name=\"supported-color-schemes\" content=\"{Helpers.HtmlEncode(SupportedColorSchemes)}\" />");
         }
 
         // Additional meta tags
         foreach (var metaTag in MetaTags.WhereNotNull()) {
-            head.AppendLine($"\t{metaTag.ToString()}");
+            head.AppendLine($"{metaTag.ToString()}");
         }
 
         // Dark mode CSS reset
         if (_email.Configuration.DarkModeSupport) {
-            head.AppendLine("\t<style data-premailer=\"ignore\">");
-            head.AppendLine("\t\t:root {");
-            head.AppendLine($"\t\t\tcolor-scheme: {ColorScheme};");
-            head.AppendLine($"\t\t\tsupported-color-schemes: {ColorScheme};");
-            head.AppendLine("\t\t}");
+            head.AppendLine("<style data-premailer=\"ignore\">");
+            head.AppendLine(":root {");
+            head.AppendLine($"color-scheme: {ColorScheme};");
+            head.AppendLine($"supported-color-schemes: {ColorScheme};");
+            head.AppendLine("}");
             head.AppendLine();
-            head.AppendLine("\t\t@media screen and (max-width: 600px) {");
-            head.AppendLine("\t\t\tu+.body {");
-            head.AppendLine("\t\t\t\twidth: 100vw !important;");
-            head.AppendLine("\t\t\t}");
-            head.AppendLine("\t\t}");
+            head.AppendLine("@media screen and (max-width: 600px) {");
+            head.AppendLine("u+.body {");
+            head.AppendLine("width: 100vw !important;");
+            head.AppendLine("}");
+            head.AppendLine("}");
             head.AppendLine();
-            head.AppendLine("\t\ta[x-apple-data-detectors] {");
-            head.AppendLine("\t\t\tcolor: inherit !important;");
-            head.AppendLine("\t\t\ttext-decoration: none !important;");
-            head.AppendLine("\t\t\tfont-size: inherit !important;");
-            head.AppendLine("\t\t\tfont-family: inherit !important;");
-            head.AppendLine("\t\t\tfont-weight: inherit !important;");
-            head.AppendLine("\t\t\tline-height: inherit !important;");
-            head.AppendLine("\t\t}");
-            head.AppendLine("\t</style>");
+            head.AppendLine("a[x-apple-data-detectors] {");
+            head.AppendLine("color: inherit !important;");
+            head.AppendLine("text-decoration: none !important;");
+            head.AppendLine("font-size: inherit !important;");
+            head.AppendLine("font-family: inherit !important;");
+            head.AppendLine("font-weight: inherit !important;");
+            head.AppendLine("line-height: inherit !important;");
+            head.AppendLine("}");
+            head.AppendLine("</style>");
         }
 
         // MSO conditional comments for Outlook
-        head.AppendLine("\t<!--[if mso]>");
-        head.AppendLine("\t  <style type=\"text/css\">");
-        head.AppendLine("\t\tbody, table, td {");
-        head.AppendLine("\t\t\tfont-family: Arial, Helvetica, sans-serif !important;");
-        head.AppendLine("\t\t}");
+        head.AppendLine("<!--[if mso]>");
+        head.AppendLine("  <style type=\"text/css\">");
+        head.AppendLine("body, table, td {");
+        head.AppendLine("font-family: Arial, Helvetica, sans-serif !important;");
+        head.AppendLine("}");
         head.AppendLine();
-        head.AppendLine("\t\timg {");
-        head.AppendLine("\t\t\t-ms-interpolation-mode: bicubic;");
-        head.AppendLine("\t\t}");
+        head.AppendLine("img {");
+        head.AppendLine("-ms-interpolation-mode: bicubic;");
+        head.AppendLine("}");
         head.AppendLine();
-        head.AppendLine("\t\t.box {");
-        head.AppendLine("\t\t\tborder-color: #eee !important;");
-        head.AppendLine("\t\t}");
-        head.AppendLine("\t  </style>");
-        head.AppendLine("\t<![endif]-->");
+        head.AppendLine(".box {");
+        head.AppendLine("border-color: #eee !important;");
+        head.AppendLine("}");
+        head.AppendLine("  </style>");
+        head.AppendLine("<![endif]-->");
 
         // Non-MSO font imports
-        head.AppendLine("\t<!--[if !mso]><!-->");
-        head.AppendLine("\t<link href=\"https://rsms.me/inter/inter.css\" rel=\"stylesheet\" type=\"text/css\" data-premailer=\"ignore\" />");
-        head.AppendLine("\t<style type=\"text/css\" data-premailer=\"ignore\">");
-        head.AppendLine("\t\t@import url(https://rsms.me/inter/inter.css);");
-        head.AppendLine("\t</style>");
-        head.AppendLine("\t<!--<![endif]-->");
+        head.AppendLine("<!--[if !mso]><!-->");
+        head.AppendLine("<link href=\"https://rsms.me/inter/inter.css\" rel=\"stylesheet\" type=\"text/css\" data-premailer=\"ignore\" />");
+        head.AppendLine("<style type=\"text/css\" data-premailer=\"ignore\">");
+        head.AppendLine("@import url(https://rsms.me/inter/inter.css);");
+        head.AppendLine("</style>");
+        head.AppendLine("<!--<![endif]-->");
 
         // Inline styles
         if (InlineStyles.Count > 0) {
-            head.AppendLine("\t<style>");
+            head.AppendLine("<style>");
             foreach (var style in InlineStyles.WhereNotNull()) {
                 head.AppendLine(style);
             }
-            head.AppendLine("\t</style>");
+            head.AppendLine("</style>");
         }
 
         head.AppendLine("</head>");

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -267,19 +267,19 @@ public class Head : Element {
         head.AppendLine("<head>");
 
         if (!string.IsNullOrEmpty(Title)) {
-            head.AppendLine($"\t<title>{Title}</title>");
+            head.AppendLine($"<title>{Title}</title>");
         }
 
         if (!string.IsNullOrEmpty(Charset)) {
-            head.AppendLine($"\t<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Helpers.HtmlEncode(Charset)}\">");
+            head.AppendLine($"<meta http-equiv=\"Content-Type\" content=\"text/html; charset={Helpers.HtmlEncode(Charset)}\">");
         }
 
         if (!string.IsNullOrEmpty(HttpEquiv) && !string.IsNullOrEmpty(Content)) {
-            head.AppendLine($"\t<meta http-equiv=\"{Helpers.HtmlEncode(HttpEquiv)}\" content=\"{Helpers.HtmlEncode(Content)}\">");
+            head.AppendLine($"<meta http-equiv=\"{Helpers.HtmlEncode(HttpEquiv)}\" content=\"{Helpers.HtmlEncode(Content)}\">");
         }
 
         if (AutoRefresh.HasValue) {
-            head.AppendLine($"\t<meta http-equiv=\"refresh\" content=\"{AutoRefresh.Value}\">");
+            head.AppendLine($"<meta http-equiv=\"refresh\" content=\"{AutoRefresh.Value}\">");
         }
 
         head.Append(MetaTagString("viewport", Viewport));
@@ -289,19 +289,19 @@ public class Head : Element {
         head.Append(MetaTagString("revised", Revised?.ToString()));
 
         foreach (var metaTag in MetaTags) {
-            head.AppendLine($"\t{metaTag.ToString().TrimEnd('\r', '\n')}");
+            head.AppendLine($"{metaTag.ToString().TrimEnd('\r', '\n')}");
         }
 
         foreach (var link in FontLinks) {
-            head.AppendLine($"\t{link}");
+            head.AppendLine($"{link}");
         }
 
         foreach (var link in CssLinks) {
-            head.AppendLine($"\t{link}");
+            head.AppendLine($"{link}");
         }
 
         foreach (var link in JsLinks) {
-            head.AppendLine($"\t{link}");
+            head.AppendLine($"{link}");
         }
 
         if (Styles.Count > 0) {
@@ -498,7 +498,7 @@ gtag('config', '{encodedIdentifier}');
             return string.Empty;
         }
         var encoded = Helpers.HtmlEncode(content);
-        return $"\t<meta name=\"{name}\" content=\"{encoded}\">\n";
+        return $"<meta name=\"{name}\" content=\"{encoded}\">\n";
     }
 
     private void ProcessLibrary(Library library) {
@@ -590,24 +590,24 @@ gtag('config', '{encodedIdentifier}');
         if (_document.Configuration.LibraryMode == LibraryMode.Online) {
             // Process CSS links
             foreach (var link in libraryLinks.CssLink) {
-                output.AppendLine($"\t<link rel=\"stylesheet\" href=\"{link}\">");
+                output.AppendLine($"<link rel=\"stylesheet\" href=\"{link}\">");
             }
 
             // Process JS links
             foreach (var link in libraryLinks.JsLink) {
-                output.AppendLine($"\t<script src=\"{link}\"></script>");
+                output.AppendLine($"<script src=\"{link}\"></script>");
             }
         } else if (_document.Configuration.LibraryMode == LibraryMode.Offline) {
             // Process embedded CSS
             foreach (var css in libraryLinks.Css) {
                 var cssContent = ReadEmbeddedResource("HtmlForgeX.Resources.Styles." + css);
-                output.AppendLine($"\t<style>{cssContent}</style>");
+                output.AppendLine($"<style>{cssContent}</style>");
             }
 
             // Process embedded JS
             foreach (var js in libraryLinks.Js) {
                 var jsContent = ReadEmbeddedResource("HtmlForgeX.Resources.Scripts." + js);
-                output.AppendLine($"\t<script>{jsContent}</script>");
+                output.AppendLine($"<script>{jsContent}</script>");
             }
         } else if (_document.Configuration.LibraryMode == LibraryMode.OfflineWithFiles) {
             // Process CSS file links
@@ -616,7 +616,7 @@ gtag('config', '{encodedIdentifier}');
                 var linkPath = string.IsNullOrEmpty(_document.Configuration.StylePath)
                     ? fileName
                     : Path.Combine(_document.Configuration.StylePath, fileName);
-                output.AppendLine($"\t<link rel=\"stylesheet\" href=\"{linkPath.Replace('\\', '/')}\">");
+                output.AppendLine($"<link rel=\"stylesheet\" href=\"{linkPath.Replace('\\', '/')}\">");
             }
 
             // Process JS file links
@@ -625,22 +625,22 @@ gtag('config', '{encodedIdentifier}');
                 var linkPath = string.IsNullOrEmpty(_document.Configuration.ScriptPath)
                     ? fileName
                     : Path.Combine(_document.Configuration.ScriptPath, fileName);
-                output.AppendLine($"\t<script src=\"{linkPath.Replace('\\', '/')}\"></script>");
+                output.AppendLine($"<script src=\"{linkPath.Replace('\\', '/')}\"></script>");
             }
         }
 
         // Process inline CSS styles (consistent with Header processing)
         foreach (var style in libraryLinks.CssStyle) {
-            output.AppendLine($"\t<style type=\"text/css\">");
+            output.AppendLine($"<style type=\"text/css\">");
             output.AppendLine(style.ToString().TrimEnd('\r', '\n'));
-            output.AppendLine($"\t</style>");
+            output.AppendLine($"</style>");
         }
 
         // Process inline JS scripts (consistent with Header processing)
         foreach (var script in libraryLinks.JsScript) {
-            output.AppendLine($"\t<script type=\"text/javascript\">");
+            output.AppendLine($"<script type=\"text/javascript\">");
             output.AppendLine(script);
-            output.AppendLine($"\t</script>");
+            output.AppendLine($"</script>");
         }
     }
 

--- a/HtmlForgeX/Containers/Email/EmailLineBreak.cs
+++ b/HtmlForgeX/Containers/Email/EmailLineBreak.cs
@@ -39,9 +39,9 @@ public class EmailLineBreak : Element {
     public override string ToString() {
         var html = StringBuilderCache.Acquire();
 
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t<tr>");
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<td style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; height: {Height}; line-height: {Height};\"></td>");
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t</tr>");
+        html.AppendLine($"<tr>");
+        html.AppendLine($"<td style=\"font-family: Inter, -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif; height: {Height}; line-height: {Height};\"></td>");
+        html.AppendLine($"</tr>");
 
         return StringBuilderCache.GetStringAndRelease(html);
     }

--- a/HtmlForgeX/Containers/Email/EmailTextBox.cs
+++ b/HtmlForgeX/Containers/Email/EmailTextBox.cs
@@ -221,13 +221,13 @@ public class EmailTextBox : Element {
         var containerStyle = $"font-family: {FontFamily}; font-size: {FontSize}; line-height: {LineHeight}; color: {Color}; text-align: {TextAlign}; font-weight: {FontWeight}; text-decoration: {TextDecoration}; margin: {Margin}; padding: {Padding};";
 
         // Use div structure for text box content
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t<tr>");
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<td style=\"font-family: {FontFamily};\">");
+        html.AppendLine($"<tr>");
+        html.AppendLine($"<td style=\"font-family: {FontFamily};\">");
 
         if (TextAlign == "center") {
-            html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<div align=\"center\">");
+            html.AppendLine($"<div align=\"center\">");
         } else {
-            html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<div class=\"defaultText\">");
+            html.AppendLine($"<div class=\"defaultText\">");
         }
 
         // Render text content
@@ -238,14 +238,14 @@ public class EmailTextBox : Element {
 
                 if (string.IsNullOrEmpty(text)) {
                     // Empty line
-                    html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<span style=\"{containerStyle}\"></span>");
+                    html.AppendLine($"<span style=\"{containerStyle}\"></span>");
                 } else {
-                    html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<span style=\"{containerStyle}\">{encodedText}</span>");
+                    html.AppendLine($"<span style=\"{containerStyle}\">{encodedText}</span>");
                 }
 
                 // Add line break between lines (except for last line)
                 if (i < TextContent.Count - 1) {
-                    html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<br />");
+                    html.AppendLine($"<br />");
                 }
             }
         }
@@ -255,9 +255,9 @@ public class EmailTextBox : Element {
             html.AppendLine(child.ToString().TrimEnd('\r', '\n'));
         }
 
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>");
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</td>");
-        html.AppendLine($"\t\t\t\t\t\t\t\t\t\t\t\t\t\t</tr>");
+        html.AppendLine($"</div>");
+        html.AppendLine($"</td>");
+        html.AppendLine($"</tr>");
 
         return StringBuilderCache.GetStringAndRelease(html);
     }


### PR DESCRIPTION
## Summary
- strip tab characters from HTML generation
- update test expectations for HtmlSpan
- adjust whitespace baseline

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878a93a2a30832e917b2a11036b55bd