### PR TITLE
Fix library weight overwrite

### DIFF
--- a/HtmlForgeX.Tests/TestAddLibraryWeight.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryWeight.cs
@@ -11,4 +11,15 @@ public class TestAddLibraryWeight {
         Assert.IsTrue(doc.Configuration.Libraries.TryGetValue(Libraries.SmartWizard, out var weight));
         Assert.AreEqual((byte)10, weight);
     }
+
+    [TestMethod]
+    public void AddLibrary_OverwriteWeight_DoesNotDuplicate() {
+        using var doc = new Document();
+        doc.AddLibrary(Libraries.SmartWizard, 10);
+        doc.AddLibrary(Libraries.SmartWizard, 5);
+
+        Assert.AreEqual(1, doc.Configuration.Libraries.Count);
+        Assert.IsTrue(doc.Configuration.Libraries.TryGetValue(Libraries.SmartWizard, out var weight));
+        Assert.AreEqual((byte)5, weight);
+    }
 }

--- a/HtmlForgeX/Containers/Core/Document.Library.cs
+++ b/HtmlForgeX/Containers/Core/Document.Library.cs
@@ -21,7 +21,7 @@ public partial class Document
     /// <param name="weight">Ordering weight. Lower values load first.</param>
     public void AddLibrary(Libraries library, byte weight)
     {
-        Configuration.Libraries.TryAdd(library, weight);
+        Configuration.Libraries.AddOrUpdate(library, weight, (_, _) => weight);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- update `AddLibrary(Libraries, byte)` to overwrite the weight for an existing entry
- test weight overwrite retains single entry

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878e2a871f8832e8ec5f86a9b8d9f9e