### PR TITLE
Fix DataTables scrolling reset

### DIFF
--- a/HtmlForgeX.Tests/TestDataTablesScrolling.cs
+++ b/HtmlForgeX.Tests/TestDataTablesScrolling.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDataTablesScrolling {
+    [TestMethod]
+    public void Scrolling_ShouldResetScrollY_WhenNull() {
+        var table = new DataTablesTable();
+        table.Scrolling("200px");
+        table.Scrolling(null);
+
+        var html = table.ToString();
+
+        Assert.IsNull(table.Options.ScrollY, "ScrollY should be reset to null");
+        StringAssert.Contains(html, "\"scrollY\": false");
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -112,10 +112,15 @@ public class DataTablesTable : Table {
         if (!string.IsNullOrEmpty(scrollY)) {
             Options.ScrollY = scrollY;
             _features["scrollY"] = true;
+        } else {
+            Options.ScrollY = null;
+            _features["scrollY"] = false;
         }
+
         if (scrollX) {
             _features["scrollX"] = true;
         }
+
         Options.ScrollCollapse = scrollCollapse;
         return this;
     }


### PR DESCRIPTION
## Summary
- reset `Options.ScrollY` when Scrolling() parameter is null
- add regression test for resetting scroll

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6878e2903a20832ea22dd3b8ad4cdc5c