### PR TITLE
Check DataTablesTable style conflicts

### DIFF
--- a/HtmlForgeX.Tests/TestDataTablesStyleWarnings.cs
+++ b/HtmlForgeX.Tests/TestDataTablesStyleWarnings.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using HtmlForgeX.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDataTablesStyleWarnings {
+    private static InternalLogger GetLogger() {
+        return Document._logger;
+    }
+
+    [TestMethod]
+    public void Style_AddingConflictingSizeStyles_LogsWarning() {
+        var logger = GetLogger();
+        string? received = null;
+        EventHandler<LogEventArgs> handler = (_, e) => received = e.FullMessage;
+        logger.OnWarningMessage += handler;
+        var table = new DataTablesTable();
+        table.Style(BootStrapTableStyle.Small);
+        table.Style(BootStrapTableStyle.Large);
+        logger.OnWarningMessage -= handler;
+        Assert.IsNotNull(received);
+        StringAssert.Contains(received!, "Small");
+        StringAssert.Contains(received!, "Large");
+        Assert.AreEqual(1, table.StyleList.Count(s => s is BootStrapTableStyle.Small or BootStrapTableStyle.Medium or BootStrapTableStyle.Large));
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
+++ b/HtmlForgeX/Containers/DataTables/DataTablesTable.cs
@@ -126,7 +126,19 @@ public class DataTablesTable : Table {
 
     /// <summary>Add a bootstrap table style.</summary>
     public DataTablesTable Style(BootStrapTableStyle style) {
-        StyleList.Add(style);
+        if (style is BootStrapTableStyle.Small or BootStrapTableStyle.Medium or BootStrapTableStyle.Large) {
+            var existingSize = StyleList.FirstOrDefault(s => s is BootStrapTableStyle.Small or BootStrapTableStyle.Medium or BootStrapTableStyle.Large);
+            if (existingSize != default && existingSize != style) {
+                Document._logger.WriteWarning(
+                    $"Table size style '{style}' is incompatible with already applied '{existingSize}'. Only one size style can be used.");
+                return this;
+            }
+        }
+
+        if (!StyleList.Contains(style)) {
+            StyleList.Add(style);
+        }
+
         return this;
     }
 


### PR DESCRIPTION
## Summary
- prevent incompatible Bootstrap size styles on DataTablesTable
- log warnings when conflicting styles are used
- test that warnings are emitted via InternalLogger

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878e2863be8832ea31acbeb3c5176c0