### PR TITLE
Normalize inline code whitespace

### DIFF
--- a/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryUtf8.cs
@@ -36,4 +36,37 @@ public class TestAddLibraryUtf8 {
         StringAssert.Contains(headHtml, cssContent);
         StringAssert.Contains(headHtml, jsContent);
     }
+
+    [TestMethod]
+    public void AddLibrary_DeduplicatesWhitespaceVariants() {
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var css1 = Path.Combine(tempDir, $"dup1_{System.Guid.NewGuid():N}.css");
+        var css2 = Path.Combine(tempDir, $"dup2_{System.Guid.NewGuid():N}.css");
+        var js1 = Path.Combine(tempDir, $"dup1_{System.Guid.NewGuid():N}.js");
+        var js2 = Path.Combine(tempDir, $"dup2_{System.Guid.NewGuid():N}.js");
+
+        File.WriteAllText(css1, "body { color: red; }", Encoding.UTF8);
+        File.WriteAllText(css2, " body  {  color: red;   }\n", Encoding.UTF8);
+        File.WriteAllText(js1, "console.log('hi');", Encoding.UTF8);
+        File.WriteAllText(js2, "\nconsole.log('hi');\n", Encoding.UTF8);
+
+        var lib = new Library {
+            Header = new LibraryLinks {
+                Css = [css1, css2],
+                Js = [js1, js2]
+            }
+        };
+
+        using var doc = new Document { LibraryMode = LibraryMode.Offline };
+        var added = doc.AddLibrary(lib);
+
+        File.Delete(css1);
+        File.Delete(css2);
+        File.Delete(js1);
+        File.Delete(js2);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, doc.Head.Styles.Count);
+        Assert.AreEqual(1, doc.Head.Scripts.Count);
+    }
 }

--- a/HtmlForgeX/Containers/Core/Head.cs
+++ b/HtmlForgeX/Containers/Core/Head.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 using HtmlForgeX.Logging;
 
@@ -434,7 +435,7 @@ public class Head : Element {
     /// </summary>
     /// <param name="css">CSS rules to embed.</param>
     public void AddCssInline(string css) {
-        css = css.Trim();
+        css = Regex.Replace(css.Trim(), @"\s+", " ");
         if (_cssInlineSet.Add(css)) {
             Styles.Add($"<style>{css}</style>");
         }
@@ -445,7 +446,7 @@ public class Head : Element {
     /// </summary>
     /// <param name="js">JavaScript code to embed.</param>
     public void AddJsInline(string js) {
-        js = js.Trim();
+        js = Regex.Replace(js.Trim(), @"\s+", " ");
         if (_jsInlineSet.Add(js)) {
             Scripts.Add($"<script>{js}</script>");
         }


### PR DESCRIPTION
## Summary
- collapse whitespace in `Head.AddCssInline` and `Head.AddJsInline`
- test deduplication when library files have whitespace differences

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6878e274f2d8832e9336b2e8651ae43a