### PR TITLE
Add null checks for DataTables builder delegates

### DIFF
--- a/HtmlForgeX.Tests/TestDataTablesBuilderNullChecks.cs
+++ b/HtmlForgeX.Tests/TestDataTablesBuilderNullChecks.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestDataTablesBuilderNullChecks
+{
+    [TestMethod]
+    public void ColumnBuilder_NullAction_Throws()
+    {
+        var builder = new DataTablesColumnBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.Column(0, null!));
+    }
+
+    [TestMethod]
+    public void ColumnBuilder_StringOverload_NullAction_Throws()
+    {
+        var builder = new DataTablesColumnBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.Column("name", null!));
+    }
+
+    [TestMethod]
+    public void ColumnBuilder_ConfigOverload_NullAction_Throws()
+    {
+        var builder = new DataTablesColumnBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.Column(null!));
+    }
+
+    [TestMethod]
+    public void SearchBuilder_Group_NullAction_Throws()
+    {
+        var builder = new DataTablesSearchBuilderBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.Group(null!));
+    }
+
+    [TestMethod]
+    public void ExportBuilder_Custom_NullAction_Throws()
+    {
+        var builder = new DataTablesExportBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.Custom(null!));
+    }
+
+    [TestMethod]
+    public void ExportBuilder_ConfigureAll_NullAction_Throws()
+    {
+        var builder = new DataTablesExportBuilder();
+        Assert.ThrowsException<ArgumentNullException>(() => builder.ConfigureAll(null!));
+    }
+}

--- a/HtmlForgeX/Containers/DataTables/Builders/DataTablesColumnBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Builders/DataTablesColumnBuilder.cs
@@ -12,6 +12,9 @@ public class DataTablesColumnBuilder
     /// <summary>Add a column configuration</summary>
     public DataTablesColumnBuilder Column(int targetIndex, Action<DataTablesColumn> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var column = new DataTablesColumn { Targets = targetIndex };
         configure(column);
         _columns.Add(column);
@@ -22,6 +25,9 @@ public class DataTablesColumnBuilder
     /// <summary>Add a column configuration by name</summary>
     public DataTablesColumnBuilder Column(string name, Action<DataTablesColumn> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var column = new DataTablesColumn { Name = name, Targets = _nextIndex++ };
         configure(column);
         _columns.Add(column);
@@ -31,6 +37,9 @@ public class DataTablesColumnBuilder
     /// <summary>Configure column with fluent API</summary>
     public DataTablesColumnBuilder Column(Action<DataTablesColumnConfiguration> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var config = new DataTablesColumnConfiguration(this);
         configure(config);
         return this;

--- a/HtmlForgeX/Containers/DataTables/Builders/DataTablesExportBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Builders/DataTablesExportBuilder.cs
@@ -90,6 +90,9 @@ public class DataTablesExportBuilder
     /// <summary>Add custom export button</summary>
     public DataTablesExportBuilder Custom(Action<DataTablesExport> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var export = new DataTablesExport();
         configure(export);
         _exports.Add(export);
@@ -99,6 +102,9 @@ public class DataTablesExportBuilder
     /// <summary>Configure export options for all buttons</summary>
     public DataTablesExportBuilder ConfigureAll(Action<DataTablesExportOptions> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var options = new DataTablesExportOptions();
         configure(options);
 

--- a/HtmlForgeX/Containers/DataTables/Builders/DataTablesSearchBuilderBuilder.cs
+++ b/HtmlForgeX/Containers/DataTables/Builders/DataTablesSearchBuilderBuilder.cs
@@ -83,6 +83,9 @@ public class DataTablesSearchBuilderBuilder
     /// <returns>The current builder instance.</returns>
     public DataTablesSearchBuilderBuilder Group(Action<DataTablesSearchGroupBuilder> configure)
     {
+        if (configure is null)
+            throw new ArgumentNullException(nameof(configure));
+
         var builder = new DataTablesSearchGroupBuilder();
         configure(builder);
         _groups.Add(builder.Build());


### PR DESCRIPTION
## Summary
- guard against null `Action` delegates in DataTables builders
- add tests for null delegate scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878e2d5af24832e88bd1f4148b25aaa