### PR TITLE
Handle SaveAsync cancellation

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSave.cs
+++ b/HtmlForgeX.Tests/TestDocumentSave.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Text;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace HtmlForgeX.Tests;
@@ -41,6 +42,15 @@ public class TestDocumentSave {
     public async Task SaveAsync_InvalidPath_ThrowsArgumentException() {
         using var doc = new Document();
         await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await doc.SaveAsync("invalid\0path.html"));
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_CancellationRequested_ThrowsOperationCanceledException() {
+        using var doc = new Document();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var path = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), $"cancel_{Guid.NewGuid():N}.html");
+        await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () => await doc.SaveAsync(path, cancellationToken: cts.Token));
     }
 
     [TestMethod]

--- a/HtmlForgeX/Containers/Core/Document.Save.cs
+++ b/HtmlForgeX/Containers/Core/Document.Save.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace HtmlForgeX;
 
@@ -77,7 +78,12 @@ public partial class Document
     /// <param name="openInBrowser">Whether to open the file after saving.</param>
     /// <param name="scriptPath">Optional scripts path.</param>
     /// <param name="stylePath">Optional styles path.</param>
-    public async Task SaveAsync(string path, bool openInBrowser = false, string scriptPath = "", string stylePath = "")
+    public async Task SaveAsync(
+        string path,
+        bool openInBrowser = false,
+        string scriptPath = "",
+        string stylePath = "",
+        CancellationToken cancellationToken = default)
     {
         PathUtilities.Validate(path);
         path = System.IO.Path.GetFullPath(path);
@@ -113,15 +119,20 @@ public partial class Document
                 _logger.WriteError($"Failed to create directory '{directory}'. {ex.Message}");
             }
         }
-        await FileWriteLock.Semaphore.WaitAsync().ConfigureAwait(false);
+        await FileWriteLock.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
 #if NET5_0_OR_GREATER
-            await File.WriteAllTextAsync(path, ToString(), Encoding.UTF8).ConfigureAwait(false);
+            await File.WriteAllTextAsync(path, ToString(), Encoding.UTF8, cancellationToken).ConfigureAwait(false);
 #else
             using var writer = new StreamWriter(path, false, Encoding.UTF8);
+            cancellationToken.ThrowIfCancellationRequested();
             await writer.WriteAsync(ToString()).ConfigureAwait(false);
 #endif
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- add optional `CancellationToken` parameter to `Document.SaveAsync` and `Email.SaveAsync`
- rethrow `OperationCanceledException` to allow callers to handle cancellation
- test SaveAsync cancellation with a `CancellationTokenSource`

## Testing
- `dotnet test`
- `dotnet build HtmlForgeX/HtmlForgeX.csproj -f net8.0`
- ❌ `dotnet build HtmlForgeX/HtmlForgeX.csproj -f net472` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e2beaea4832eab31c03eeb75e72b