### PR TITLE
Add tests for JS directory handling

### DIFF
--- a/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
+++ b/HtmlForgeX.Tests/TestDocumentSaveErrors.cs
@@ -105,4 +105,23 @@ public class TestDocumentSaveErrors {
         stream.Dispose();
         File.Delete(path);
     }
+
+    [TestMethod]
+    public void Save_OfflineWithFiles_CreatesScriptDirectory() {
+        using var doc = new Document { LibraryMode = LibraryMode.OfflineWithFiles };
+        doc.ScriptPath = Path.Combine("assets", "scripts");
+        doc.AddLibrary(Libraries.Bootstrap);
+
+        var tempDir = TestUtilities.GetFrameworkSpecificTempPath();
+        var dir = Path.Combine(tempDir, Guid.NewGuid().ToString());
+        var filePath = Path.Combine(dir, "file.html");
+
+        doc.Save(filePath);
+
+        var scriptDir = Path.Combine(dir, "assets", "scripts");
+        Assert.IsTrue(Directory.Exists(scriptDir));
+        Assert.IsTrue(File.Exists(Path.Combine(scriptDir, "bootstrap.bundle.min.js")));
+
+        Directory.Delete(dir, true);
+    }
 }


### PR DESCRIPTION
## Summary
- verify JS directory is created when missing in OfflineWithFiles mode

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Save_OfflineWithFiles_CreatesScriptDirectory" --logger "console;verbosity=detailed"` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878e2633838832ebc62f259c2e6dd6b