### PR TITLE
Fix XML documentation warnings

### DIFF
--- a/HtmlForgeX/Containers/Core/Document.Save.cs
+++ b/HtmlForgeX/Containers/Core/Document.Save.cs
@@ -78,6 +78,7 @@ public partial class Document
     /// <param name="openInBrowser">Whether to open the file after saving.</param>
     /// <param name="scriptPath">Optional scripts path.</param>
     /// <param name="stylePath">Optional styles path.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task SaveAsync(
         string path,
         bool openInBrowser = false,

--- a/HtmlForgeX/Containers/Core/Element.Email.cs
+++ b/HtmlForgeX/Containers/Core/Element.Email.cs
@@ -3,7 +3,7 @@ namespace HtmlForgeX;
 public abstract partial class Element {
     // Email Extension Methods for Natural Builder Pattern
     /// <summary>
-    /// Adds an <see cref="EmailText"/> element with optional content.
+    /// Adds an <see cref="T:HtmlForgeX.EmailText"/> element with optional content.
     /// </summary>
     /// <param name="content">Initial text content.</param>
     /// <returns>The created element.</returns>
@@ -14,7 +14,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailText"/> element using the provided action.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailText"/> element using the provided action.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -26,7 +26,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailTable"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailTable"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -38,7 +38,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds an <see cref="EmailTable"/> populated from a collection.
+    /// Adds an <see cref="T:HtmlForgeX.EmailTable"/> populated from a collection.
     /// </summary>
     /// <typeparam name="T">Type of items in the collection.</typeparam>
     /// <param name="data">Data used to populate the table.</param>
@@ -51,7 +51,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailList"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailList"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -63,7 +63,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailRow"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailRow"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -76,7 +76,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailColumn"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailColumn"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -89,7 +89,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailBox"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailBox"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -102,7 +102,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailBox"/> element using a fluent builder.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailBox"/> element using a fluent builder.
     /// </summary>
     /// <param name="config">Builder configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -116,7 +116,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailTextBox"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailTextBox"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -128,7 +128,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailImage"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailImage"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>
@@ -140,7 +140,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds an <see cref="EmailImage"/> element with the specified source.
+    /// Adds an <see cref="T:HtmlForgeX.EmailImage"/> element with the specified source.
     /// </summary>
     /// <param name="source">Image source path or URL.</param>
     /// <returns>The created image element.</returns>
@@ -151,7 +151,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds an <see cref="EmailImage"/> element with specified source and width.
+    /// Adds an <see cref="T:HtmlForgeX.EmailImage"/> element with specified source and width.
     /// </summary>
     /// <param name="source">Image source path or URL.</param>
     /// <param name="width">Width value.</param>
@@ -209,7 +209,7 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds and configures an <see cref="EmailLink"/> element.
+    /// Adds and configures an <see cref="T:HtmlForgeX.EmailLink"/> element.
     /// </summary>
     /// <param name="config">Configuration action.</param>
     /// <returns>The current element for chaining.</returns>

--- a/HtmlForgeX/Containers/Core/Element.cs
+++ b/HtmlForgeX/Containers/Core/Element.cs
@@ -148,12 +148,6 @@ public abstract partial class Element {
     }
 
     /// <summary>
-    /// Adds the table.
-    /// </summary>
-    /// <param name="objects">The objects.</param>
-    /// <param name="tableType">Type of the table.</param>
-    /// <returns></returns>
-    /// <summary>
     /// Creates a table from a collection of objects.
     /// </summary>
     /// <param name="objects">Data source.</param>

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -313,6 +313,7 @@ public class Email : Element {
     /// </summary>
     /// <param name="path">File path.</param>
     /// <param name="openInBrowser">Whether to open the file after saving.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     public async Task SaveAsync(string path, bool openInBrowser = false, CancellationToken cancellationToken = default) {
         PathUtilities.Validate(path);
         Configuration.Email.DefaultPadding = path; // Store path in configuration

--- a/HtmlForgeX/Containers/Email/EmailColumn.cs
+++ b/HtmlForgeX/Containers/Email/EmailColumn.cs
@@ -98,11 +98,6 @@ public class EmailColumn : Element {
     /// <summary>
     /// Sets the text alignment of the column content.
     /// </summary>
-    /// <param name="alignment">The text alignment (left, center, right).</param>
-    /// <returns>The EmailColumn object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the text alignment of the column content.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailColumn"/> instance.</returns>
     public EmailColumn SetAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Email/EmailContent.cs
+++ b/HtmlForgeX/Containers/Email/EmailContent.cs
@@ -26,11 +26,6 @@ public class EmailContent : Element {
     /// <summary>
     /// Sets the text alignment for the content.
     /// </summary>
-    /// <param name="alignment">The alignment value ("left", "center", "right")</param>
-    /// <returns>The EmailContent object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the text alignment for the content.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailContent"/> instance.</returns>
     public EmailContent WithAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Email/EmailImage.cs
+++ b/HtmlForgeX/Containers/Email/EmailImage.cs
@@ -313,11 +313,6 @@ public class EmailImage : Element {
     /// <summary>
     /// Sets the image alignment.
     /// </summary>
-    /// <param name="alignment">The image alignment.</param>
-    /// <returns>The EmailImage object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the image alignment.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailImage"/> instance.</returns>
     public EmailImage WithAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Email/EmailLink.cs
+++ b/HtmlForgeX/Containers/Email/EmailLink.cs
@@ -251,11 +251,6 @@ public class EmailLink : Element {
     /// <summary>
     /// Sets the text alignment.
     /// </summary>
-    /// <param name="alignment">The text alignment.</param>
-    /// <returns>The EmailLink object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the text alignment.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailLink"/> instance.</returns>
     public EmailLink WithAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Email/EmailText.cs
+++ b/HtmlForgeX/Containers/Email/EmailText.cs
@@ -179,11 +179,6 @@ public class EmailText : Element {
     /// <summary>
     /// Sets the text alignment.
     /// </summary>
-    /// <param name="alignment">The text alignment.</param>
-    /// <returns>The EmailText object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the text alignment.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailText"/> instance.</returns>
     public EmailText WithAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Email/EmailTextBox.cs
+++ b/HtmlForgeX/Containers/Email/EmailTextBox.cs
@@ -136,11 +136,6 @@ public class EmailTextBox : Element {
     /// <summary>
     /// Sets the text alignment.
     /// </summary>
-    /// <param name="alignment">The text alignment.</param>
-    /// <returns>The EmailTextBox object, allowing for method chaining.</returns>
-    /// <summary>
-    /// Sets the text alignment.
-    /// </summary>
     /// <param name="alignment">The alignment option.</param>
     /// <returns>The <see cref="EmailTextBox"/> instance.</returns>
     public EmailTextBox WithAlignment(Alignment alignment) {

--- a/HtmlForgeX/Containers/Tabler/TablerCard.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCard.cs
@@ -108,7 +108,7 @@ public class TablerCard : Element {
     public RGBColor? CustomBackgroundColor { get; set; }
 
     /// <summary>
-    /// Gets or sets a custom text color used when <see cref="TextColor"/> is <c>null</c>.
+    /// Gets or sets a custom text color used when <see cref="M:HtmlForgeX.TablerCardMini.TextColor(HtmlForgeX.TablerColor)"/> is <c>null</c>.
     /// </summary>
     public RGBColor? CustomTextColor { get; set; }
 


### PR DESCRIPTION
## Summary
- disambiguate cref references in email extension docs
- remove duplicate XML comments that caused CS1571
- add missing `cancellationToken` documentation for async save methods
- clarify TablerCard custom text color docs

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68790b436ae4832e8fa34dc486677cf1