### PR TITLE
Add test timeout to CI

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -40,6 +40,7 @@ jobs:
 
             - name: Run tests
               run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              timeout-minutes: 10
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -81,6 +82,7 @@ jobs:
 
             - name: Run tests
               run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              timeout-minutes: 10
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -115,6 +117,7 @@ jobs:
 
             - name: Run tests
               run: dotnet test HtmlForgeX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              timeout-minutes: 10
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -97,6 +97,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 6.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net6.0 /noautorsp'
@@ -105,6 +106,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 7.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net7.0 /noautorsp'
@@ -113,6 +115,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 8.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net8.0 /noautorsp'

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -101,6 +101,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 6.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net6.0 /noautorsp'
@@ -109,6 +110,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 7.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net7.0 /noautorsp'
@@ -117,6 +119,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 8.0)'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: '--framework net8.0 /noautorsp'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,7 @@ steps:
   
   - task: DotNetCoreCLI@2
     displayName: 'Run Tests'
+    timeoutInMinutes: 10
     inputs:
       command: 'test'
       arguments: --configuration $(buildConfiguration) --collect "Code coverage"


### PR DESCRIPTION
## Summary
- ensure test steps abort after 10 minutes across CI pipelines

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68793126b80c832e889363de21505f94