### PR TITLE
Fix warnings by documenting VisNetwork enums

### DIFF
--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkEnums.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkEnums.cs
@@ -9,21 +9,84 @@ namespace HtmlForgeX;
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkNodeShape>))]
 public enum VisNetworkNodeShape {
+    /// <summary>
+    /// Node is rendered as an ellipse.
+    /// </summary>
     Ellipse,
+
+    /// <summary>
+    /// Node is rendered as a circle.
+    /// </summary>
     Circle,
+
+    /// <summary>
+    /// Node is rendered as a database symbol.
+    /// </summary>
     Database,
+
+    /// <summary>
+    /// Node is rendered as a box.
+    /// </summary>
     Box,
+
+    /// <summary>
+    /// Node is rendered as a text label only.
+    /// </summary>
     Text,
+
+    /// <summary>
+    /// Node is rendered as an image.
+    /// </summary>
     Image,
+
+    /// <summary>
+    /// Node is rendered as a circular image.
+    /// </summary>
     CircularImage,
+
+    /// <summary>
+    /// Node is rendered as a diamond.
+    /// </summary>
     Diamond,
+
+    /// <summary>
+    /// Node is rendered as a dot.
+    /// </summary>
     Dot,
+
+    /// <summary>
+    /// Node is rendered as a square.
+    /// </summary>
     Square,
+
+    /// <summary>
+    /// Node is rendered as a triangle pointing up.
+    /// </summary>
     Triangle,
+
+    /// <summary>
+    /// Node is rendered as a triangle pointing down.
+    /// </summary>
     TriangleDown,
+
+    /// <summary>
+    /// Node is rendered as a hexagon.
+    /// </summary>
     Hexagon,
+
+    /// <summary>
+    /// Node is rendered as a star.
+    /// </summary>
     Star,
+
+    /// <summary>
+    /// Node is rendered using an icon font.
+    /// </summary>
     Icon,
+
+    /// <summary>
+    /// Node uses a custom drawing routine.
+    /// </summary>
     Custom
 }
 
@@ -32,8 +95,19 @@ public enum VisNetworkNodeShape {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkAlign>))]
 public enum VisNetworkAlign {
+    /// <summary>
+    /// Align text to the left.
+    /// </summary>
     Left,
+
+    /// <summary>
+    /// Center text.
+    /// </summary>
     Center,
+
+    /// <summary>
+    /// Align text to the right.
+    /// </summary>
     Right
 }
 
@@ -42,9 +116,24 @@ public enum VisNetworkAlign {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkMulti>))]
 public enum VisNetworkMulti {
+    /// <summary>
+    /// Multi-line text is disabled.
+    /// </summary>
     False,
+
+    /// <summary>
+    /// Multi-line text is enabled.
+    /// </summary>
     True,
+
+    /// <summary>
+    /// Interpret text as HTML markup.
+    /// </summary>
     Html,
+
+    /// <summary>
+    /// Interpret text as Markdown.
+    /// </summary>
     Markdown
 }
 
@@ -53,8 +142,19 @@ public enum VisNetworkMulti {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkBorderDashes>))]
 public enum VisNetworkBorderDashes {
+    /// <summary>
+    /// Use solid borders.
+    /// </summary>
     False,
+
+    /// <summary>
+    /// Use dashed borders.
+    /// </summary>
     True,
+
+    /// <summary>
+    /// Custom dash pattern specified by an array.
+    /// </summary>
     Array
 }
 
@@ -114,10 +214,29 @@ public enum VisNetworkForceDirection {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkArrowType>))]
 public enum VisNetworkArrowType {
+    /// <summary>
+    /// Standard arrow head.
+    /// </summary>
     Arrow,
+
+    /// <summary>
+    /// Bar at the end of the edge.
+    /// </summary>
     Bar,
+
+    /// <summary>
+    /// Circular endpoint.
+    /// </summary>
     Circle,
+
+    /// <summary>
+    /// Image used as an arrow head.
+    /// </summary>
     Image,
+
+    /// <summary>
+    /// Vee shaped arrow head.
+    /// </summary>
     Vee
 }
 
@@ -126,15 +245,54 @@ public enum VisNetworkArrowType {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkSmoothType>))]
 public enum VisNetworkSmoothType {
+    /// <summary>
+    /// Dynamically chooses the best curve type.
+    /// </summary>
     Dynamic,
+
+    /// <summary>
+    /// Uses a continuous bezier curve.
+    /// </summary>
     Continuous,
+
+    /// <summary>
+    /// Uses a discrete curve between points.
+    /// </summary>
     Discrete,
+
+    /// <summary>
+    /// Diagonal straight line between points.
+    /// </summary>
     Diagonally,
+
+    /// <summary>
+    /// Straight line crossing midpoints.
+    /// </summary>
     Straightcross,
+
+    /// <summary>
+    /// Horizontal curve.
+    /// </summary>
     Horizontal,
+
+    /// <summary>
+    /// Vertical curve.
+    /// </summary>
     Vertical,
+
+    /// <summary>
+    /// Clockwise curved line.
+    /// </summary>
     Curvedcw,
+
+    /// <summary>
+    /// Counter clockwise curved line.
+    /// </summary>
     Curvedccw,
+
+    /// <summary>
+    /// Cubic bezier curve.
+    /// </summary>
     Cubicbezier
 }
 
@@ -143,8 +301,19 @@ public enum VisNetworkSmoothType {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkEdgeType>))]
 public enum VisNetworkEdgeType {
+    /// <summary>
+    /// Standard arrow between nodes.
+    /// </summary>
     Arrow,
+
+    /// <summary>
+    /// Bar shaped connection.
+    /// </summary>
     Bar,
+
+    /// <summary>
+    /// Circular connection point.
+    /// </summary>
     Circle
 }
 
@@ -157,9 +326,24 @@ public enum VisNetworkEdgeType {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkPhysicsSolver>))]
 public enum VisNetworkPhysicsSolver {
+    /// <summary>
+    /// Uses the Barnes-Hut algorithm.
+    /// </summary>
     BarnesHut,
+
+    /// <summary>
+    /// Uses the ForceAtlas2 based algorithm.
+    /// </summary>
     ForceAtlas2based,
+
+    /// <summary>
+    /// Uses a repulsion algorithm.
+    /// </summary>
     Repulsion,
+
+    /// <summary>
+    /// Uses hierarchical repulsion.
+    /// </summary>
     HierarchicalRepulsion
 }
 
@@ -188,9 +372,24 @@ public enum VisNetworkShakeTowards {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkLayoutDirection>))]
 public enum VisNetworkLayoutDirection {
+    /// <summary>
+    /// Top to bottom layout.
+    /// </summary>
     Ud,  // up-down
+
+    /// <summary>
+    /// Bottom to top layout.
+    /// </summary>
     Du,  // down-up
+
+    /// <summary>
+    /// Left to right layout.
+    /// </summary>
     Lr,  // left-right
+
+    /// <summary>
+    /// Right to left layout.
+    /// </summary>
     Rl   // right-left
 }
 
@@ -199,7 +398,14 @@ public enum VisNetworkLayoutDirection {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkLayoutSort>))]
 public enum VisNetworkLayoutSort {
+    /// <summary>
+    /// Sort by hub size.
+    /// </summary>
     Hubsize,
+
+    /// <summary>
+    /// Sort in directed order.
+    /// </summary>
     Directed
 }
 
@@ -208,7 +414,14 @@ public enum VisNetworkLayoutSort {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkTreeSpacing>))]
 public enum VisNetworkTreeSpacing {
+    /// <summary>
+    /// Minimize edge crossings.
+    /// </summary>
     EdgeMinimization,
+
+    /// <summary>
+    /// Keep distance between nodes consistent.
+    /// </summary>
     NodeDistance
 }
 
@@ -221,8 +434,19 @@ public enum VisNetworkTreeSpacing {
 /// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkKeyboardSpeed>))]
 public enum VisNetworkKeyboardSpeed {
+    /// <summary>
+    /// Horizontal movement speed.
+    /// </summary>
     X,
+
+    /// <summary>
+    /// Vertical movement speed.
+    /// </summary>
     Y,
+
+    /// <summary>
+    /// Zoom speed.
+    /// </summary>
     Zoom
 }
 
@@ -230,18 +454,64 @@ public enum VisNetworkKeyboardSpeed {
 
 #region Manipulation Enums
 
+/// <summary>
+/// Supported locales for VisNetwork interface texts.
+/// </summary>
 [JsonConverter(typeof(VisNetworkEnumConverter<VisNetworkLocale>))]
 public enum VisNetworkLocale {
+    /// <summary>
+    /// English locale.
+    /// </summary>
     En,
+
+    /// <summary>
+    /// Spanish locale.
+    /// </summary>
     Es,
+
+    /// <summary>
+    /// German locale.
+    /// </summary>
     De,
+
+    /// <summary>
+    /// French locale.
+    /// </summary>
     Fr,
+
+    /// <summary>
+    /// Italian locale.
+    /// </summary>
     It,
+
+    /// <summary>
+    /// Dutch locale.
+    /// </summary>
     Nl,
+
+    /// <summary>
+    /// Portuguese locale.
+    /// </summary>
     Pt,
+
+    /// <summary>
+    /// Russian locale.
+    /// </summary>
     Ru,
+
+    /// <summary>
+    /// Ukrainian locale.
+    /// </summary>
     Uk,
+
+    /// <summary>
+    /// Chinese locale.
+    /// </summary>
     Zh,
+
+    /// <summary>
+    /// Japanese locale.
+    /// </summary>
     Ja
 }
 
@@ -308,7 +578,17 @@ public static class VisNetworkArrowExtensions {
 
 #region Base Converter
 
+/// <summary>
+/// Custom JSON converter handling serialization of VisNetwork enums.
+/// </summary>
 public class VisNetworkEnumConverter<T> : JsonConverter<T> where T : struct, Enum {
+    /// <summary>
+    /// Reads a VisNetwork enum value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The enum type being converted.</param>
+    /// <param name="options">Serializer options.</param>
+    /// <returns>The parsed enum value or default.</returns>
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         if (value == null) {
@@ -336,6 +616,12 @@ public class VisNetworkEnumConverter<T> : JsonConverter<T> where T : struct, Enu
         return default;
     }
 
+    /// <summary>
+    /// Writes a VisNetwork enum value to JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">Value to serialize.</param>
+    /// <param name="options">Serializer options.</param>
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) {
         var stringValue = value.ToString();
         


### PR DESCRIPTION
## Summary
- document every value of `VisNetworkEnums` to silence CS1591 warnings
- add docs for `VisNetworkEnumConverter` and its methods

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687a96cc7e4c832e8e5bf03bb90647a6