### PR TITLE
Fix warnings for ChartJsConverters

### DIFF
--- a/HtmlForgeX/Containers/ChartJs/ChartJsConverters.cs
+++ b/HtmlForgeX/Containers/ChartJs/ChartJsConverters.cs
@@ -8,6 +8,13 @@ namespace HtmlForgeX;
 /// Converts ChartJsPosition enum to lowercase string.
 /// </summary>
 public class ChartJsPositionConverter : JsonConverter<ChartJsPosition> {
+    /// <summary>
+    /// Reads a <see cref="ChartJsPosition"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsPosition"/>.</returns>
     public override ChartJsPosition Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value?.ToLowerInvariant() switch {
@@ -20,6 +27,12 @@ public class ChartJsPositionConverter : JsonConverter<ChartJsPosition> {
         };
     }
 
+    /// <summary>
+    /// Writes a <see cref="ChartJsPosition"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsPosition value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString().ToLowerInvariant());
     }
@@ -29,6 +42,13 @@ public class ChartJsPositionConverter : JsonConverter<ChartJsPosition> {
 /// Converts ChartJsAlign enum to lowercase string.
 /// </summary>
 public class ChartJsAlignConverter : JsonConverter<ChartJsAlign> {
+    /// <summary>
+    /// Reads a <see cref="ChartJsAlign"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsAlign"/>.</returns>
     public override ChartJsAlign Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value?.ToLowerInvariant() switch {
@@ -39,6 +59,12 @@ public class ChartJsAlignConverter : JsonConverter<ChartJsAlign> {
         };
     }
 
+    /// <summary>
+    /// Writes a <see cref="ChartJsAlign"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsAlign value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString().ToLowerInvariant());
     }
@@ -48,6 +74,13 @@ public class ChartJsAlignConverter : JsonConverter<ChartJsAlign> {
 /// Converts ChartJsInteractionMode enum to lowercase string.
 /// </summary>
 public class ChartJsInteractionModeConverter : JsonConverter<ChartJsInteractionMode> {
+    /// <summary>
+    /// Reads a <see cref="ChartJsInteractionMode"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsInteractionMode"/>.</returns>
     public override ChartJsInteractionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value?.ToLowerInvariant() switch {
@@ -61,6 +94,12 @@ public class ChartJsInteractionModeConverter : JsonConverter<ChartJsInteractionM
         };
     }
 
+    /// <summary>
+    /// Writes a <see cref="ChartJsInteractionMode"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsInteractionMode value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString().ToLowerInvariant());
     }
@@ -70,6 +109,13 @@ public class ChartJsInteractionModeConverter : JsonConverter<ChartJsInteractionM
 /// Converts ChartJsFontStyle enum to lowercase string.
 /// </summary>
 public class ChartJsFontStyleConverter : JsonConverter<ChartJsFontStyle> {
+    /// <summary>
+    /// Reads a <see cref="ChartJsFontStyle"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsFontStyle"/>.</returns>
     public override ChartJsFontStyle Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         var value = reader.GetString();
         return value?.ToLowerInvariant() switch {
@@ -80,6 +126,12 @@ public class ChartJsFontStyleConverter : JsonConverter<ChartJsFontStyle> {
         };
     }
 
+    /// <summary>
+    /// Writes a <see cref="ChartJsFontStyle"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsFontStyle value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString().ToLowerInvariant());
     }
@@ -89,6 +141,13 @@ public class ChartJsFontStyleConverter : JsonConverter<ChartJsFontStyle> {
 /// Converts ChartJsFontWeight enum to lowercase string or numeric value.
 /// </summary>
 public class ChartJsFontWeightConverter : JsonConverter<ChartJsFontWeight> {
+    /// <summary>
+    /// Reads a <see cref="ChartJsFontWeight"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsFontWeight"/>.</returns>
     public override ChartJsFontWeight Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         if (reader.TokenType == JsonTokenType.String) {
             var value = reader.GetString();
@@ -103,6 +162,12 @@ public class ChartJsFontWeightConverter : JsonConverter<ChartJsFontWeight> {
         return ChartJsFontWeight.Normal;
     }
 
+    /// <summary>
+    /// Writes a <see cref="ChartJsFontWeight"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsFontWeight value, JsonSerializerOptions options) {
         writer.WriteStringValue(value.ToString().ToLowerInvariant());
     }
@@ -112,6 +177,13 @@ public class ChartJsFontWeightConverter : JsonConverter<ChartJsFontWeight> {
 /// Converts nullable ChartJsPosition enum.
 /// </summary>
 public class ChartJsPositionNullableConverter : JsonConverter<ChartJsPosition?> {
+    /// <summary>
+    /// Reads a nullable <see cref="ChartJsPosition"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsPosition"/> value or <c>null</c>.</returns>
     public override ChartJsPosition? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         if (reader.TokenType == JsonTokenType.Null) {
             return null;
@@ -127,6 +199,12 @@ public class ChartJsPositionNullableConverter : JsonConverter<ChartJsPosition?> 
         };
     }
 
+    /// <summary>
+    /// Writes a nullable <see cref="ChartJsPosition"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsPosition? value, JsonSerializerOptions options) {
         if (value.HasValue) {
             writer.WriteStringValue(value.Value.ToString().ToLowerInvariant());
@@ -140,6 +218,13 @@ public class ChartJsPositionNullableConverter : JsonConverter<ChartJsPosition?> 
 /// Converts nullable ChartJsAlign enum.
 /// </summary>
 public class ChartJsAlignNullableConverter : JsonConverter<ChartJsAlign?> {
+    /// <summary>
+    /// Reads a nullable <see cref="ChartJsAlign"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsAlign"/> value or <c>null</c>.</returns>
     public override ChartJsAlign? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         if (reader.TokenType == JsonTokenType.Null) {
             return null;
@@ -153,6 +238,12 @@ public class ChartJsAlignNullableConverter : JsonConverter<ChartJsAlign?> {
         };
     }
 
+    /// <summary>
+    /// Writes a nullable <see cref="ChartJsAlign"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsAlign? value, JsonSerializerOptions options) {
         if (value.HasValue) {
             writer.WriteStringValue(value.Value.ToString().ToLowerInvariant());
@@ -166,6 +257,13 @@ public class ChartJsAlignNullableConverter : JsonConverter<ChartJsAlign?> {
 /// Converts nullable ChartJsInteractionMode enum.
 /// </summary>
 public class ChartJsInteractionModeNullableConverter : JsonConverter<ChartJsInteractionMode?> {
+    /// <summary>
+    /// Reads a nullable <see cref="ChartJsInteractionMode"/> value from JSON.
+    /// </summary>
+    /// <param name="reader">The JSON reader.</param>
+    /// <param name="typeToConvert">The target type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The parsed <see cref="ChartJsInteractionMode"/> value or <c>null</c>.</returns>
     public override ChartJsInteractionMode? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         if (reader.TokenType == JsonTokenType.Null) {
             return null;
@@ -182,6 +280,12 @@ public class ChartJsInteractionModeNullableConverter : JsonConverter<ChartJsInte
         };
     }
 
+    /// <summary>
+    /// Writes a nullable <see cref="ChartJsInteractionMode"/> value as JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, ChartJsInteractionMode? value, JsonSerializerOptions options) {
         if (value.HasValue) {
             writer.WriteStringValue(value.Value.ToString().ToLowerInvariant());


### PR DESCRIPTION
## Summary
- document ChartJsConverters methods with XML comments to resolve CS1591 warnings

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build` *(fails: VisNetwork_GradientWithComplexEdgeOptions, VisNetwork_EdgeColorOptions_StringOverloads, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a967cba18832e8c0df39d1601043d