### PR TITLE
Implement Email library registration

### DIFF
--- a/HtmlForgeX.Tests/TestEmailAddLibrary.cs
+++ b/HtmlForgeX.Tests/TestEmailAddLibrary.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestEmailAddLibrary
+{
+    [TestMethod]
+    public void AddLibrary_RegistersLibrary()
+    {
+        var email = new Email();
+        email.AddLibrary(EmailLibraries.EmailCore);
+
+        Assert.IsTrue(email.Configuration.Email.Libraries.ContainsKey(EmailLibraries.EmailCore));
+    }
+}

--- a/HtmlForgeX/Containers/Core/Email.cs
+++ b/HtmlForgeX/Containers/Core/Email.cs
@@ -433,6 +433,6 @@ public class Email : Element {
     /// </summary>
     /// <param name="library">Library identifier.</param>
     public void AddLibrary(EmailLibraries library) {
-        // TODO: Implement email library management
+        Configuration.Email.Libraries.TryAdd(library, 0);
     }
 }


### PR DESCRIPTION
## Summary
- implement the `AddLibrary` method for email
- add a new MSTest covering library registration for `Email`

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -f net8.0 --no-build --filter TestEmailAddLibrary`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -f net8.0` *(fails: Playwright browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68808943857c832e997ec50df6e48f9d