### PR TITLE
Fix AddLibrary duplicates with weights

### DIFF
--- a/HtmlForgeX.Tests/TestAddLibraryWeight.cs
+++ b/HtmlForgeX.Tests/TestAddLibraryWeight.cs
@@ -13,13 +13,24 @@ public class TestAddLibraryWeight {
     }
 
     [TestMethod]
-    public void AddLibrary_OverwriteWeight_DoesNotDuplicate() {
+    public void AddLibrary_DuplicateWeight_Ignored() {
         using var doc = new Document();
         doc.AddLibrary(Libraries.SmartWizard, 10);
         doc.AddLibrary(Libraries.SmartWizard, 5);
 
         Assert.AreEqual(1, doc.Configuration.Libraries.Count);
         Assert.IsTrue(doc.Configuration.Libraries.TryGetValue(Libraries.SmartWizard, out var weight));
-        Assert.AreEqual((byte)5, weight);
+        Assert.AreEqual((byte)10, weight);
+    }
+
+    [TestMethod]
+    public void AddLibrary_SecondDifferentWeight_Ignored() {
+        using var doc = new Document();
+        doc.AddLibrary(Libraries.SmartWizard, 0);
+        doc.AddLibrary(Libraries.SmartWizard, 10);
+
+        Assert.AreEqual(1, doc.Configuration.Libraries.Count);
+        Assert.IsTrue(doc.Configuration.Libraries.TryGetValue(Libraries.SmartWizard, out var weight));
+        Assert.AreEqual((byte)0, weight);
     }
 }

--- a/HtmlForgeX/Containers/Core/Document.Library.cs
+++ b/HtmlForgeX/Containers/Core/Document.Library.cs
@@ -18,7 +18,7 @@ public partial class Document
     /// <param name="weight">Ordering weight. Lower values load first.</param>
     public void AddLibrary(Libraries library, byte weight)
     {
-        Configuration.Libraries.AddOrUpdate(library, weight, (_, _) => weight);
+        Configuration.Libraries.TryAdd(library, weight);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ignore duplicate library registrations with weight
- add an extra test to verify that re-registering with a different weight keeps the original weight

## Testing
- `dotnet test --no-build` *(fails: Host system is missing dependencies to run browsers)*
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6880911cbe58832ebf476ea24be528a9