### PR TITLE
Add SaveAsync example usage and tests

### DIFF
--- a/HtmlForgeX.Examples/Experimenting/ExampleHeadlessRendering.cs
+++ b/HtmlForgeX.Examples/Experimenting/ExampleHeadlessRendering.cs
@@ -11,7 +11,7 @@ internal class ExampleHeadlessRendering {
         doc.Head.Title = "Headless Rendering Example";
         doc.Body.Add(new HtmlTag("h1", "Hello from Headless Browser"));
         var path = Path.Combine(Path.GetTempPath(), "headless_example.html");
-        doc.Save(path, openInBrowser);
+        await doc.SaveAsync(path, openInBrowser).ConfigureAwait(false);
 
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });

--- a/HtmlForgeX.Tests/TestDocumentSave.cs
+++ b/HtmlForgeX.Tests/TestDocumentSave.cs
@@ -39,6 +39,20 @@ public class TestDocumentSave {
     }
 
     [TestMethod]
+    public async Task SaveAsync_CreatesDirectoryAndWritesUtf8() {
+        using var doc = new Document();
+        string tempDir = Path.Combine(TestUtilities.GetFrameworkSpecificTempPath(), Guid.NewGuid().ToString());
+        string dir = Path.Combine(tempDir, "subDirectory");
+        string path = Path.Combine(dir, "testSubDirectoryAsync.html");
+
+        await doc.SaveAsync(path);
+        Assert.IsTrue(Directory.Exists(dir));
+        string content = File.ReadAllText(path, Encoding.UTF8);
+        Assert.AreEqual(doc.ToString(), content);
+        Directory.Delete(tempDir, true);
+    }
+
+    [TestMethod]
     public async Task SaveAsync_InvalidPath_ThrowsArgumentException() {
         using var doc = new Document();
         await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await doc.SaveAsync("invalid\0path.html"));


### PR DESCRIPTION
## Summary
- add SaveAsync unit test verifying directory creation
- save example headless document asynchronously

## Testing
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688092356d84832eaec05d273285c053