### PR TITLE
Remove unused global storage fields

### DIFF
--- a/HtmlForgeX.Tests/TestLibraryIntegration.cs
+++ b/HtmlForgeX.Tests/TestLibraryIntegration.cs
@@ -13,8 +13,8 @@ public class TestLibraryIntegration {
             }
         };
 
-        GlobalStorage.LibraryMode = LibraryMode.Online;
         using var doc = new Document();
+        doc.LibraryMode = LibraryMode.Online;
         var added = doc.AddLibrary(customLibrary);
         var html = doc.ToString();
 

--- a/HtmlForgeX/Containers/Tabler/TablerCardImage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardImage.cs
@@ -150,7 +150,7 @@ public class TablerCardImage : Element {
     public override string ToString() {
         // Auto-embed based on LibraryMode unless explicitly overridden
         if (!SkipEmbedding && !EmbedAsBase64 &&
-            (ForceEmbedding || GlobalStorage.LibraryMode == LibraryMode.Offline)) {
+            (ForceEmbedding || Document?.Configuration.LibraryMode == LibraryMode.Offline)) {
             EmbedSmart(ImageUrl, EmbeddingTimeout);
         }
 

--- a/HtmlForgeX/GlobalStorage.cs
+++ b/HtmlForgeX/GlobalStorage.cs
@@ -1,25 +1,9 @@
-using System.Collections.Concurrent;
-
 namespace HtmlForgeX;
 
 /// <summary>
-/// Provides application wide storage for configuration and state.
+/// Provides helpers for generating identifiers.
 /// </summary>
 internal static class GlobalStorage {
-    /// <summary>Gets or sets the current theme mode.</summary>
-    internal static ThemeMode ThemeMode { get; set; } = ThemeMode.Light;
-    /// <summary>Gets or sets the library mode.</summary>
-    internal static LibraryMode LibraryMode { get; set; } = LibraryMode.Online;
-    /// <summary>Collection of libraries used by the document.</summary>
-    internal static ConcurrentDictionary<Libraries, byte> Libraries { get; } = new();
-    /// <summary>Collection of processing errors.</summary>
-    internal static ConcurrentBag<string> Errors { get; } = new();
-    /// <summary>Output path for generated files.</summary>
-    internal static string Path { get; set; } = "";
-    /// <summary>Location for CSS resources.</summary>
-    internal static string StylePath { get; set; } = "";
-    /// <summary>Location for script resources.</summary>
-    internal static string ScriptPath { get; set; } = "";
 
     /// <summary>
     /// Generates a pseudo random identifier with a prefix.


### PR DESCRIPTION
## Summary
- drop unused config fields from `GlobalStorage`
- reference document configuration when embedding card images
- update library integration test to configure `LibraryMode` on document

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build` *(fails: GeneratedHtml_ShouldMatchBaselineScreenshot)*

------
https://chatgpt.com/codex/tasks/task_e_68809225ae44832e9d004ccf9db422c2