### PR TITLE
Refactor image embedding utilities

### DIFF
--- a/HtmlForgeX.Tests/TestImageEmbedding.cs
+++ b/HtmlForgeX.Tests/TestImageEmbedding.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace HtmlForgeX.Tests;
 
 [TestClass]
-public class TestImageEmbeddingHelper {
+public class TestImageEmbedding {
     private static int GetFreePort() {
         TcpListener listener = new(IPAddress.Loopback, 0);
         listener.Start();
@@ -35,7 +35,7 @@ public class TestImageEmbeddingHelper {
     public void EmbedFromUrl_InvalidUrl_ReturnsFailure() {
         string prefix = StartErrorServer();
         string url = $"{prefix}image.png";
-        var result = ImageEmbeddingHelper.EmbedFromUrl(url, 5);
+        var result = ImageEmbedding.EmbedFromUrl(url, 5);
         Assert.IsFalse(result.Success);
         Assert.AreEqual($"HTTP error while downloading {url}", result.ErrorMessage);
     }

--- a/HtmlForgeX/Containers/Tabler/TablerCardImage.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardImage.cs
@@ -100,7 +100,7 @@ public class TablerCardImage : Element {
     /// Embed image from file path
     /// </summary>
     public TablerCardImage EmbedFromFile(string filePath) {
-        var result = ImageEmbeddingHelper.EmbedFromFile(filePath, 0, true);
+        var result = ImageEmbedding.EmbedFromFile(filePath, 0, true);
         if (result.Success) {
             Base64Data = result.Base64Data;
             MimeType = result.MimeType;
@@ -122,7 +122,7 @@ public class TablerCardImage : Element {
     /// <param name="timeoutSeconds">Download timeout in seconds.</param>
     /// <returns>The <see cref="TablerCardImage"/> for chaining.</returns>
     public async Task<TablerCardImage> EmbedFromUrlAsync(string url, int timeoutSeconds = 30) {
-        var result = await ImageEmbeddingHelper.EmbedFromUrlAsync(url, timeoutSeconds, 0, true).ConfigureAwait(false);
+        var result = await ImageEmbedding.EmbedFromUrlAsync(url, timeoutSeconds, 0, true).ConfigureAwait(false);
         if (result.Success) {
             Base64Data = result.Base64Data;
             MimeType = result.MimeType;
@@ -135,7 +135,7 @@ public class TablerCardImage : Element {
     /// Smart embedding - auto-detects file vs URL
     /// </summary>
     public TablerCardImage EmbedSmart(string source, int timeoutSeconds = 30) {
-        var result = ImageEmbeddingHelper.EmbedSmart(source, timeoutSeconds, 0, true);
+        var result = ImageEmbedding.EmbedSmart(source, timeoutSeconds, 0, true);
         if (result.Success) {
             Base64Data = result.Base64Data;
             MimeType = result.MimeType;

--- a/HtmlForgeX/Containers/VisNetwork/VisNetwork.Utilities.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetwork.Utilities.cs
@@ -60,28 +60,8 @@ public partial class VisNetwork {
             return source;
         }
 
-        try {
-            byte[] bytes;
-            string mimeType;
-
-            if (Uri.TryCreate(source, UriKind.Absolute, out var uri) && 
-                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
-                var download = ImageUtilities.DownloadImage(source, timeoutSeconds);
-                if (download is null) {
-                    return source;
-                }
-                (bytes, mimeType) = download.Value;
-            } else if (File.Exists(source)) {
-                (bytes, mimeType) = ImageUtilities.LoadImageFromFile(source);
-            } else {
-                return source;
-            }
-
-            var base64 = Convert.ToBase64String(bytes);
-            return $"data:{mimeType};base64,{base64}";
-        } catch {
-            return source;
-        }
+        var result = ImageEmbedding.EmbedSmart(source, timeoutSeconds);
+        return result.Success ? $"data:{result.MimeType};base64,{result.Base64Data}" : source;
     }
 
     #region Clustering Methods

--- a/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
+++ b/HtmlForgeX/Containers/VisNetwork/VisNetworkNode.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 
 namespace HtmlForgeX;
 
@@ -281,31 +280,8 @@ public class VisNetworkNode {
     }
 
     private static string EmbedImage(string source, int timeoutSeconds) {
-        if (string.IsNullOrEmpty(source)) {
-            return source;
-        }
-
-        try {
-            byte[] bytes;
-            string mimeType;
-
-            if (Uri.TryCreate(source, UriKind.Absolute, out var uri) && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
-                var download = ImageUtilities.DownloadImage(source, timeoutSeconds);
-                if (download is null) {
-                    return source;
-                }
-                (bytes, mimeType) = download.Value;
-            } else if (File.Exists(source)) {
-                (bytes, mimeType) = ImageUtilities.LoadImageFromFile(source);
-            } else {
-                return source;
-            }
-
-            var base64 = Convert.ToBase64String(bytes);
-            return $"data:{mimeType};base64,{base64}";
-        } catch {
-            return source;
-        }
+        var result = ImageEmbedding.EmbedSmart(source, timeoutSeconds);
+        return result.Success ? $"data:{result.MimeType};base64,{result.Base64Data}" : source;
     }
 
     private static string GetMimeTypeFromExtension(string extension) =>

--- a/HtmlForgeX/Utilities/ImageEmbedding.cs
+++ b/HtmlForgeX/Utilities/ImageEmbedding.cs
@@ -9,7 +9,7 @@ namespace HtmlForgeX;
 /// Shared utility for image embedding functionality
 /// Used by both EmailImage and TablerCardImage to avoid code duplication
 /// </summary>
-public static class ImageEmbeddingHelper {
+public static class ImageEmbedding {
 
     /// <summary>
     /// Embeds an image from a file path as base64
@@ -17,8 +17,19 @@ public static class ImageEmbeddingHelper {
     /// <param name="filePath">Path to the image file</param>
     /// <param name="maxFileSize">Maximum file size allowed for embedding (0 = no limit)</param>
     /// <param name="logWarnings">Whether to log warnings to console</param>
+    /// <param name="optimize">Whether to optimize the image before encoding</param>
+    /// <param name="maxWidth">Maximum width used when optimizing</param>
+    /// <param name="maxHeight">Maximum height used when optimizing</param>
+    /// <param name="quality">JPEG quality used for optimization</param>
     /// <returns>ImageEmbeddingResult containing the embedding data or error info</returns>
-    public static ImageEmbeddingResult EmbedFromFile(string filePath, long maxFileSize = 0, bool logWarnings = false) {
+    public static ImageEmbeddingResult EmbedFromFile(
+        string filePath,
+        long maxFileSize = 0,
+        bool logWarnings = false,
+        bool optimize = false,
+        int maxWidth = 0,
+        int maxHeight = 0,
+        int quality = 85) {
         try {
             if (!File.Exists(filePath)) {
                 return ImageEmbeddingResult.CreateFailure("File not found: " + filePath);
@@ -35,7 +46,7 @@ public static class ImageEmbeddingHelper {
                 return ImageEmbeddingResult.CreateFailure(message);
             }
 
-            var (bytes, mimeType) = ImageUtilities.LoadImageFromFile(filePath);
+            var (bytes, mimeType) = ImageUtilities.LoadImageFromFile(filePath, optimize, maxWidth, maxHeight, quality);
             var base64Data = Convert.ToBase64String(bytes);
 
             return ImageEmbeddingResult.CreateSuccess(base64Data, mimeType);
@@ -55,9 +66,21 @@ public static class ImageEmbeddingHelper {
     /// <param name="timeoutSeconds">Timeout for the download</param>
     /// <param name="maxFileSize">Maximum file size allowed for embedding (0 = no limit)</param>
     /// <param name="logWarnings">Whether to log warnings to console</param>
+    /// <param name="optimize">Whether to optimize the image before encoding</param>
+    /// <param name="maxWidth">Maximum width used when optimizing</param>
+    /// <param name="maxHeight">Maximum height used when optimizing</param>
+    /// <param name="quality">JPEG quality used for optimization</param>
     /// <returns>ImageEmbeddingResult containing the embedding data or error info</returns>
-    public static ImageEmbeddingResult EmbedFromUrl(string url, int timeoutSeconds = 30, long maxFileSize = 0, bool logWarnings = false) =>
-        EmbedFromUrlAsync(url, timeoutSeconds, maxFileSize, logWarnings).GetAwaiter().GetResult();
+    public static ImageEmbeddingResult EmbedFromUrl(
+        string url,
+        int timeoutSeconds = 30,
+        long maxFileSize = 0,
+        bool logWarnings = false,
+        bool optimize = false,
+        int maxWidth = 0,
+        int maxHeight = 0,
+        int quality = 85) =>
+        EmbedFromUrlAsync(url, timeoutSeconds, maxFileSize, logWarnings, optimize, maxWidth, maxHeight, quality).GetAwaiter().GetResult();
 
     /// <summary>
     /// Asynchronously embeds an image from a URL as base64
@@ -66,8 +89,20 @@ public static class ImageEmbeddingHelper {
     /// <param name="timeoutSeconds">Timeout for the download</param>
     /// <param name="maxFileSize">Maximum file size allowed for embedding (0 = no limit)</param>
     /// <param name="logWarnings">Whether to log warnings to console</param>
+    /// <param name="optimize">Whether to optimize the image before encoding</param>
+    /// <param name="maxWidth">Maximum width used when optimizing</param>
+    /// <param name="maxHeight">Maximum height used when optimizing</param>
+    /// <param name="quality">JPEG quality used for optimization</param>
     /// <returns>ImageEmbeddingResult containing the embedding data or error info</returns>
-    public static async Task<ImageEmbeddingResult> EmbedFromUrlAsync(string url, int timeoutSeconds = 30, long maxFileSize = 0, bool logWarnings = false) {
+    public static async Task<ImageEmbeddingResult> EmbedFromUrlAsync(
+        string url,
+        int timeoutSeconds = 30,
+        long maxFileSize = 0,
+        bool logWarnings = false,
+        bool optimize = false,
+        int maxWidth = 0,
+        int maxHeight = 0,
+        int quality = 85) {
         try {
             var download = await ImageUtilities.DownloadImageAsync(url, timeoutSeconds).ConfigureAwait(false);
             if (download is null) {
@@ -82,6 +117,11 @@ public static class ImageEmbeddingHelper {
                     Console.WriteLine("Warning: " + message + ". Using direct URL.");
                 }
                 return ImageEmbeddingResult.CreateFailure(message);
+            }
+
+            if (optimize) {
+                var extension = ImageUtilities.GetExtensionFromMimeType(mimeType);
+                bytes = ImageUtilities.OptimizeImageBytes(bytes, extension, maxWidth, maxHeight, quality);
             }
 
             // 'mimeType' already determined by DownloadImage
@@ -104,8 +144,20 @@ public static class ImageEmbeddingHelper {
     /// <param name="timeoutSeconds">Timeout for URL downloads</param>
     /// <param name="maxFileSize">Maximum file size allowed for embedding (0 = no limit)</param>
     /// <param name="logWarnings">Whether to log warnings to console</param>
+    /// <param name="optimize">Whether to optimize the image before encoding</param>
+    /// <param name="maxWidth">Maximum width used when optimizing</param>
+    /// <param name="maxHeight">Maximum height used when optimizing</param>
+    /// <param name="quality">JPEG quality used for optimization</param>
     /// <returns>ImageEmbeddingResult containing the embedding data or error info</returns>
-    public static ImageEmbeddingResult EmbedSmart(string source, int timeoutSeconds = 30, long maxFileSize = 0, bool logWarnings = false) {
+    public static ImageEmbeddingResult EmbedSmart(
+        string source,
+        int timeoutSeconds = 30,
+        long maxFileSize = 0,
+        bool logWarnings = false,
+        bool optimize = false,
+        int maxWidth = 0,
+        int maxHeight = 0,
+        int quality = 85) {
         if (string.IsNullOrEmpty(source)) {
             return ImageEmbeddingResult.CreateFailure("Source is null or empty");
         }
@@ -113,12 +165,12 @@ public static class ImageEmbeddingHelper {
         // Check if it's a URL
         if (Uri.TryCreate(source, UriKind.Absolute, out Uri? uri) &&
            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
-            return EmbedFromUrl(source, timeoutSeconds, maxFileSize, logWarnings);
+            return EmbedFromUrl(source, timeoutSeconds, maxFileSize, logWarnings, optimize, maxWidth, maxHeight, quality);
         }
 
         // Check if it's a file path
         if (File.Exists(source)) {
-            return EmbedFromFile(source, maxFileSize, logWarnings);
+            return EmbedFromFile(source, maxFileSize, logWarnings, optimize, maxWidth, maxHeight, quality);
         }
 
         return ImageEmbeddingResult.CreateFailure("Source is neither a valid URL nor an existing file: " + source);


### PR DESCRIPTION
## Summary
- centralize base64 image embedding logic in `ImageEmbedding` utility
- use the new helper from `VisNetwork`, `EmailImage`, and `TablerCardImage`
- update unit tests for the renamed helper

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6880b3c3b684832eb76aca6915de71f3