### PR TITLE
Add TablerColor hex attribute mapping

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -38,6 +38,7 @@ internal class Program {
 
         // Tabler examples html output
         ExampleTablerTag.Create(openInBrowser);
+        ExampleTablerColorHex.Create();
         ExampleTablerAlerts.Create(openInBrowser);
 
         // Experimental examples (console output)

--- a/HtmlForgeX.Examples/Tags/ExampleTablerColorHex.cs
+++ b/HtmlForgeX.Examples/Tags/ExampleTablerColorHex.cs
@@ -1,0 +1,11 @@
+using HtmlForgeX.Examples;
+
+namespace HtmlForgeX.Examples.Tags;
+
+internal static class ExampleTablerColorHex {
+    public static void Create() {
+        HelpersSpectre.PrintTitle("TablerColor to Hex");
+        HelpersSpectre.Info($"Primary: {TablerColor.Primary.ToHex()}");
+        HelpersSpectre.Info($"Azure light: {TablerColor.AzureLight.ToHex()}");
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerColorHex.cs
+++ b/HtmlForgeX.Tests/TestTablerColorHex.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerColorHex {
+    [TestMethod]
+    public void TablerColorToHex_WorksForVariousColors() {
+        Assert.AreEqual("#066fd1", TablerColor.Blue.ToHex());
+        Assert.AreEqual("#e6f1fa", TablerColor.BlueLight.ToHex());
+        Assert.AreEqual("#374151", TablerColor.Gray700.ToHex());
+        Assert.AreEqual("#1877f2", TablerColor.Facebook.ToHex());
+        Assert.AreEqual("#d63939", TablerColor.Failed.ToHex());
+        Assert.AreEqual("#00000000", TablerColor.Transparent.ToHex());
+    }
+
+    [TestMethod]
+    public void TablerColorToHex_AllColorsHaveAttributes() {
+        foreach (var color in Enum.GetValues<TablerColor>()) {
+            var field = typeof(TablerColor).GetField(color.ToString());
+            var attr = field?.GetCustomAttribute<HexColorAttribute>();
+            Assert.IsNotNull(attr, $"Missing HexColorAttribute for {color}");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(attr!.Hex), $"Empty hex for {color}");
+        }
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerColor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using System.Reflection;
 
 namespace HtmlForgeX;
 
@@ -11,58 +12,72 @@ public enum TablerColor {
     /// <summary>
     /// Blue.
     /// </summary>
+    [HexColor("#066fd1")]
     Blue,
     /// <summary>
     /// Azure.
     /// </summary>
+    [HexColor("#4299e1")]
     Azure,
     /// <summary>
     /// Indigo.
     /// </summary>
+    [HexColor("#4263eb")]
     Indigo,
     /// <summary>
     /// Purple.
     /// </summary>
+    [HexColor("#ae3ec9")]
     Purple,
     /// <summary>
     /// Pink.
     /// </summary>
+    [HexColor("#d6336c")]
     Pink,
     /// <summary>
     /// Red.
     /// </summary>
+    [HexColor("#d63939")]
     Red,
     /// <summary>
     /// Orange.
     /// </summary>
+    [HexColor("#f76707")]
     Orange,
     /// <summary>
     /// Yellow.
     /// </summary>
+    [HexColor("#f59f00")]
     Yellow,
     /// <summary>
     /// Lime.
     /// </summary>
+    [HexColor("#74b816")]
     Lime,
     /// <summary>
     /// Green.
     /// </summary>
+    [HexColor("#2fb344")]
     Green,
     /// <summary>
     /// Teal.
     /// </summary>
+    [HexColor("#0ca678")]
     Teal,
     /// <summary>
     /// Cyan.
     /// </summary>
+    [HexColor("#17a2b8")]
     Cyan,
     /// <summary>
     /// White.
     /// </summary>
+    [HexColor("#ffffff")]
     White,
     /// <summary>
     /// Black.
     /// </summary>
+    [HexColor("#000000")]
     Black,
 
     // Light colors
@@ -70,50 +85,62 @@ public enum TablerColor {
     /// <summary>
     /// Blue light.
     /// </summary>
+    [HexColor("#e6f1fa")]
     BlueLight,
     /// <summary>
     /// Azure light.
     /// </summary>
+    [HexColor("#ecf5fc")]
     AzureLight,
     /// <summary>
     /// Indigo light.
     /// </summary>
+    [HexColor("#eceffd")]
     IndigoLight,
     /// <summary>
     /// Purple light.
     /// </summary>
+    [HexColor("#f7ecfa")]
     PurpleLight,
     /// <summary>
     /// Pink light.
     /// </summary>
+    [HexColor("#fbebf0")]
     PinkLight,
     /// <summary>
     /// Red light.
     /// </summary>
+    [HexColor("#fbebeb")]
     RedLight,
     /// <summary>
     /// Orange light.
     /// </summary>
+    [HexColor("#fef0e6")]
     OrangeLight,
     /// <summary>
     /// Yellow light.
     /// </summary>
+    [HexColor("#fef5e6")]
     YellowLight,
     /// <summary>
     /// Lime light.
     /// </summary>
+    [HexColor("#f1f8e8")]
     LimeLight,
     /// <summary>
     /// Green light.
     /// </summary>
+    [HexColor("#eaf7ec")]
     GreenLight,
     /// <summary>
     /// Teal light.
     /// </summary>
+    [HexColor("#e7f6f2")]
     TealLight,
     /// <summary>
     /// Cyan light.
     /// </summary>
+    [HexColor("#e8f6f8")]
     CyanLight,
 
     // Gray colors
@@ -121,42 +148,52 @@ public enum TablerColor {
     /// <summary>
     /// Gray 50.
     /// </summary>
+    [HexColor("#f9fafb")]
     Gray50,
     /// <summary>
     /// Gray 100.
     /// </summary>
+    [HexColor("#f3f4f6")]
     Gray100,
     /// <summary>
     /// Gray 200.
     /// </summary>
+    [HexColor("#e5e7eb")]
     Gray200,
     /// <summary>
     /// Gray 300.
     /// </summary>
+    [HexColor("#d1d5db")]
     Gray300,
     /// <summary>
     /// Gray 400.
     /// </summary>
+    [HexColor("#9ca3af")]
     Gray400,
     /// <summary>
     /// Gray 500.
     /// </summary>
+    [HexColor("#6b7280")]
     Gray500,
     /// <summary>
     /// Gray 600.
     /// </summary>
+    [HexColor("#4b5563")]
     Gray600,
     /// <summary>
     /// Gray 700.
     /// </summary>
+    [HexColor("#374151")]
     Gray700,
     /// <summary>
     /// Gray 800.
     /// </summary>
+    [HexColor("#1f2937")]
     Gray800,
     /// <summary>
     /// Gray 900.
     /// </summary>
+    [HexColor("#111827")]
     Gray900,
 
     // Social colors
@@ -164,62 +201,77 @@ public enum TablerColor {
     /// <summary>
     /// Facebook.
     /// </summary>
+    [HexColor("#1877f2")]
     Facebook,
     /// <summary>
     /// Twitter.
     /// </summary>
+    [HexColor("#1da1f2")]
     Twitter,
     /// <summary>
     /// Linkedin.
     /// </summary>
+    [HexColor("#0a66c2")]
     Linkedin,
     /// <summary>
     /// Google.
     /// </summary>
+    [HexColor("#dc4e41")]
     Google,
     /// <summary>
     /// Youtube.
     /// </summary>
+    [HexColor("#ff0000")]
     Youtube,
     /// <summary>
     /// Vimeo.
     /// </summary>
+    [HexColor("#1ab7ea")]
     Vimeo,
     /// <summary>
     /// Dribbble.
     /// </summary>
+    [HexColor("#ea4c89")]
     Dribbble,
     /// <summary>
     /// Github.
     /// </summary>
+    [HexColor("#181717")]
     Github,
     /// <summary>
     /// Instagram.
     /// </summary>
+    [HexColor("#e4405f")]
     Instagram,
     /// <summary>
     /// Pinterest.
     /// </summary>
+    [HexColor("#bd081c")]
     Pinterest,
     /// <summary>
     /// Vk.
     /// </summary>
+    [HexColor("#6383a8")]
     Vk,
     /// <summary>
     /// Rss.
     /// </summary>
+    [HexColor("#ffa500")]
     Rss,
     /// <summary>
     /// Flickr.
     /// </summary>
+    [HexColor("#0063dc")]
     Flickr,
     /// <summary>
     /// Bitbucket.
     /// </summary>
+    [HexColor("#0052cc")]
     Bitbucket,
     /// <summary>
     /// Tabler.
     /// </summary>
+    [HexColor("#066fd1")]
     Tabler,
 
     // Status colors
@@ -227,42 +279,52 @@ public enum TablerColor {
     /// <summary>
     /// Default.
     /// </summary>
+    [HexColor("#d1d5db")]
     Default,
     /// <summary>
     /// Primary.
     /// </summary>
+    [HexColor("#066fd1")]
     Primary,
     /// <summary>
     /// Success.
     /// </summary>
+    [HexColor("#2fb344")]
     Success,
     /// <summary>
     /// Failed.
     /// </summary>
+    [HexColor("#d63939")]
     Failed,
     /// <summary>
     /// Info.
     /// </summary>
+    [HexColor("#4299e1")]
     Info,
     /// <summary>
     /// Warning.
     /// </summary>
+    [HexColor("#f59f00")]
     Warning,
     /// <summary>
     /// Danger.
     /// </summary>
+    [HexColor("#d63939")]
     Danger,
     /// <summary>
     /// Light.
     /// </summary>
+    [HexColor("#f9fafb")]
     Light,
     /// <summary>
     /// Dark.
     /// </summary>
+    [HexColor("#1f2937")]
     Dark,
     /// <summary>
     /// Transparent.
     /// </summary>
+    [HexColor("#00000000")]
     Transparent
 }
 
@@ -326,4 +388,27 @@ public static class ColorExtensions {
     public static string ToTablerAlert(this TablerColor color) {
         return "alert-" + color.ToTablerString();
     }
+
+    /// <summary>
+    /// Returns the hexadecimal color code for the given <see cref="TablerColor"/>.
+    /// </summary>
+    public static string ToHex(this TablerColor color) {
+        if (HexMap.TryGetValue(color, out var hex)) {
+            return hex;
+        }
+
+        return "#000000";
+    }
+
+    private static readonly IReadOnlyDictionary<TablerColor, string> HexMap = Enum
+        .GetValues<TablerColor>()
+        .Select(value => new {
+            Value = value,
+            Hex = typeof(TablerColor)
+                .GetField(value.ToString())?
+                .GetCustomAttribute<HexColorAttribute>()?
+                .Hex
+        })
+        .Where(x => x.Hex is not null)
+        .ToDictionary(x => x.Value, x => x.Hex!);
 }

--- a/HtmlForgeX/Containers/Tabler/HexColorAttribute.cs
+++ b/HtmlForgeX/Containers/Tabler/HexColorAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace HtmlForgeX;
+
+/// <summary>
+/// Specifies the hex color code for a <see cref="TablerColor"/> value.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+public sealed class HexColorAttribute : Attribute {
+    /// <summary>
+    /// Gets the hex color code (e.g., "#ffffff").
+    /// </summary>
+    public string Hex { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HexColorAttribute"/> class.
+    /// </summary>
+    /// <param name="hex">The hex color code.</param>
+    public HexColorAttribute(string hex) {
+        Hex = hex;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `HexColorAttribute` for `TablerColor` values
- generate hex color map from attributes instead of switch
- add unit test ensuring every color has the attribute
- demonstrate hex retrieval in examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6880b3772278832e8757121777fc7761