### PR TITLE
Add toast options example and tests

### DIFF
--- a/Docs/TASK_LIST.md
+++ b/Docs/TASK_LIST.md
@@ -45,8 +45,6 @@ This task list covers the complete upgrade from Tabler 1.0.0 to 1.3.0, implement
 ### Interactive & Notification Components
 - [ ] **Implement TablerCookieBanner component** for GDPR compliance with customizable text, buttons, and positioning  
   *Reference: [cookie-banner.html](Assets/TablerDemo/cookie-banner.html)*
-- [ ] **Implement TablerToast component** for temporary notification messages with auto-dismiss, positioning, and styling options  
-  *Reference: [toasts.html](Assets/TablerDemo/toasts.html)*
 - [ ] **Implement TablerOffcanvas component** for sidebar panels that slide in from left/right/top/bottom  
   *Reference: [offcanvas.html](Assets/TablerDemo/offcanvas.html)*
 

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -55,6 +55,7 @@ internal class Program {
         // Toast examples
         ExampleTablerToast.Create(openInBrowser);
         ExampleTablerToastAdvanced.Create(openInBrowser);
+        ExampleTablerToastOptions.Create(openInBrowser);
         ExampleTablerProgressBarShowcase.Create(openInBrowser);
         ExampleTablerTimeline.Create(openInBrowser);
         ExampleTablerLogs.Create(openInBrowser);

--- a/HtmlForgeX.Examples/Tabler/ExampleTablerToastOptions.cs
+++ b/HtmlForgeX.Examples/Tabler/ExampleTablerToastOptions.cs
@@ -1,0 +1,49 @@
+namespace HtmlForgeX.Examples.Tabler;
+
+internal static class ExampleTablerToastOptions {
+    public static void Create(bool openInBrowser = false) {
+        using var document = new Document { Head = { Title = "Toast Options Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Toast(toast => {
+                            toast.Title("Information")
+                                .Message("Just letting you know")
+                                .Type(TablerToastType.Info)
+                                .Position(TablerToastPosition.TopCenter)
+                                .AutoDismiss(2000);
+                        });
+
+                        card.Toast(toast => {
+                            toast.Title("Warning")
+                                .Message("Low disk space")
+                                .Type(TablerToastType.Warning)
+                                .Position(TablerToastPosition.BottomCenter)
+                                .AutoDismiss(3000);
+                        });
+
+                        card.Toast(toast => {
+                            toast.Title("Success")
+                                .Message("Operation completed")
+                                .Type(TablerToastType.Success)
+                                .Position(TablerToastPosition.TopRight)
+                                .AutoDismiss(2500);
+                        });
+
+                        card.Toast(toast => {
+                            toast.Title("Error")
+                                .Message("Something went wrong")
+                                .Type(TablerToastType.Danger)
+                                .Position(TablerToastPosition.BottomLeft)
+                                .AutoDismiss(3500);
+                        });
+                    });
+                });
+            });
+        });
+
+        document.Save("ToastOptionsDemo.html", openInBrowser);
+    }
+}
+

--- a/HtmlForgeX.Tests/TestTablerToast.cs
+++ b/HtmlForgeX.Tests/TestTablerToast.cs
@@ -30,4 +30,33 @@ public class TestTablerToast {
         Assert.IsTrue(html.Contains("bootstrap.Toast"));
         Assert.IsTrue(html.Contains("delay: 1000"));
     }
+
+    [DataTestMethod]
+    [DataRow(TablerToastType.Success, "text-bg-success")]
+    [DataRow(TablerToastType.Warning, "text-bg-warning")]
+    [DataRow(TablerToastType.Danger, "text-bg-danger")]
+    [DataRow(TablerToastType.Info, "text-bg-info")]
+    [DataRow(TablerToastType.Default, "")]
+    public void Toast_TypeAddsCorrectClass(TablerToastType type, string expectedClass) {
+        var toast = new TablerToast("T", "M").Type(type);
+        var html = toast.ToString();
+        if (string.IsNullOrEmpty(expectedClass)) {
+            Assert.IsFalse(html.Contains("text-bg-"));
+        } else {
+            Assert.IsTrue(html.Contains(expectedClass));
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow(TablerToastPosition.TopLeft, "top-0 start-0")]
+    [DataRow(TablerToastPosition.TopCenter, "top-0 start-50 translate-middle-x")]
+    [DataRow(TablerToastPosition.TopRight, "top-0 end-0")]
+    [DataRow(TablerToastPosition.BottomLeft, "bottom-0 start-0")]
+    [DataRow(TablerToastPosition.BottomCenter, "bottom-0 start-50 translate-middle-x")]
+    [DataRow(TablerToastPosition.BottomRight, "bottom-0 end-0")]
+    public void Toast_PositionAddsCorrectClass(TablerToastPosition position, string expectedClass) {
+        var toast = new TablerToast("T", "M").Position(position);
+        var html = toast.ToString();
+        Assert.IsTrue(html.Contains(expectedClass));
+    }
 }


### PR DESCRIPTION
## Summary
- add ExampleTablerToastOptions sample with different toast configurations
- test all toast position and type options
- hook up new example in Program
- remove TablerToast TODO entry from docs

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -v n`
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6880de79ed8c832e8249e792c58baa3a