### PR TITLE
Relocate FontAwesome online example

### DIFF
--- a/HtmlForgeX.Examples/Icons/ExampleFontAwesomeOnline.cs
+++ b/HtmlForgeX.Examples/Icons/ExampleFontAwesomeOnline.cs
@@ -1,12 +1,12 @@
 using System;
-using HtmlForgeX.Examples;
 
-namespace HtmlForgeX.Examples {
-    class TestFontAwesomeOnline {
-        static void Main() {
+namespace HtmlForgeX.Examples.Icons {
+    internal class ExampleFontAwesomeOnline {
+        public static void Create(bool openInBrowser = true) {
+            HelpersSpectre.PrintTitle("FontAwesome Online Mode Test");
             using var document = new Document {
-                Head = { 
-                    Title = "FontAwesome Online Mode Test", 
+                Head = {
+                    Title = "FontAwesome Online Mode Test",
                     Author = "HtmlForgeX"
                 },
                 LibraryMode = LibraryMode.Online,
@@ -23,7 +23,7 @@ namespace HtmlForgeX.Examples {
                 page.Icon(FontAwesomeSolid.Lock).WithSize(FontAwesomeSize.X2).WithColor(RGBColor.Red);
                 page.Text(" Lock Icon").LineBreak();
                 
-                page.Icon(FontAwesomeBrands.Github).WithSize(FontAwesomeSize.X3);
+                page.Icon(FontAwesomeBrands.GitHub).WithSize(FontAwesomeSize.X3);
                 page.Text(" GitHub Brand Icon").LineBreak();
                 
                 // Test in VisNetwork
@@ -43,8 +43,8 @@ namespace HtmlForgeX.Examples {
                 });
             });
 
-            document.Save("TestFontAwesomeOnline.html");
-            HelpersSpectre.Success("Test file created: TestFontAwesomeOnline.html");
+            document.Save("TestFontAwesomeOnline.html", openInBrowser);
+            HelpersSpectre.Success("FontAwesome Online Mode Test created successfully!");
         }
     }
 }

--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -10,6 +10,7 @@ using HtmlForgeX.Examples.Support;
 using HtmlForgeX.Examples.Forms;
 using HtmlForgeX.Examples.Tabler;
 using HtmlForgeX.Examples.VisNetwork;
+using HtmlForgeX.Examples.Icons;
 
 namespace HtmlForgeX.Examples;
 
@@ -36,6 +37,7 @@ internal class Program {
         // Tabler examples (console output)
         ExampleTablerIcon.Create();
         ExampleSvgIcons.Create();
+        ExampleFontAwesomeOnline.Create(openInBrowser);
 
         // Tabler examples html output
         ExampleTablerTag.Create(openInBrowser);


### PR DESCRIPTION
## Summary
- move `TestFontAwesomeOnline.cs` into the examples project under `Icons`
- rename it to `ExampleFontAwesomeOnline.cs`
- invoke the example from `Program.cs`

## Testing
- `dotnet build HtmlForgeX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688122998104832e8370e6f1799b6005