### PR TITLE
Add Tabler form examples and tests

### DIFF
--- a/HtmlForgeX.Examples/Program.cs
+++ b/HtmlForgeX.Examples/Program.cs
@@ -62,6 +62,7 @@ internal class Program {
 
         // Forms examples
         ExampleTablerForm.Create(openInBrowser);
+        ExampleTablerFormInputs.Create(openInBrowser);
         ExampleComprehensiveForm.Create(openInBrowser);
 
         // Quill editor example

--- a/HtmlForgeX.Examples/Tabler/ExampleTablerFormInputs.cs
+++ b/HtmlForgeX.Examples/Tabler/ExampleTablerFormInputs.cs
@@ -1,0 +1,36 @@
+namespace HtmlForgeX.Examples.Tabler;
+
+internal static class ExampleTablerFormInputs {
+    public static void Create(bool openInBrowser = false) {
+        using var document = new Document { Head = { Title = "Form Inputs Demo" } };
+        document.Body.Page(page => {
+            page.Card(card => {
+                card.Header(header => header.Title("Form Inputs"));
+                card.Form(form => {
+                    form.Input("email", input => {
+                        input.Type(InputType.Email)
+                             .Label("Email")
+                             .Placeholder("name@example.com")
+                             .Required();
+                    });
+                    form.Input("password", input => {
+                        input.Type(InputType.Password)
+                             .Label("Password")
+                             .Placeholder("********")
+                             .Required();
+                    });
+                    form.Select("country", select => {
+                        select.Label("Country")
+                              .Options(new[] { "USA", "Canada", "UK" })
+                              .Searchable();
+                    });
+                    form.InputMask("phone", mask => {
+                        mask.Label("Phone")
+                            .Pattern("+1 (999) 999-9999");
+                    });
+                });
+            });
+        });
+        document.Save("FormInputsDemo.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerFormControls.cs
+++ b/HtmlForgeX.Tests/TestTablerFormControls.cs
@@ -1,0 +1,57 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerFormControls {
+    [TestMethod]
+    public void TablerInput_EmailAttributes() {
+        var input = new TablerInput("email")
+            .Type(InputType.Email)
+            .Placeholder("user@example.com")
+            .Required();
+        var html = input.ToString();
+        StringAssert.Contains(html, "type=\"email\"");
+        StringAssert.Contains(html, "id=\"email\"");
+        StringAssert.Contains(html, "name=\"email\"");
+        StringAssert.Contains(html, "placeholder=\"user@example.com\"");
+        StringAssert.Contains(html, "required");
+    }
+
+    [TestMethod]
+    public void TablerInput_PasswordAttributes() {
+        var input = new TablerInput("password")
+            .Type(InputType.Password)
+            .Required();
+        var html = input.ToString();
+        StringAssert.Contains(html, "type=\"password\"");
+        StringAssert.Contains(html, "id=\"password\"");
+        StringAssert.Contains(html, "name=\"password\"");
+        StringAssert.Contains(html, "required");
+    }
+
+    [TestMethod]
+    public void TablerSelect_GeneratesOptions() {
+        var select = new TablerSelect("country")
+            .Option("United States", "US")
+            .Option("Canada", "CA")
+            .Multiple()
+            .Required();
+        var html = select.ToString();
+        StringAssert.Contains(html, "id=\"country\"");
+        StringAssert.Contains(html, "name=\"country\"");
+        StringAssert.Contains(html, "multiple");
+        StringAssert.Contains(html, "required");
+        StringAssert.Contains(html, "<option value=\"US\">United States</option>");
+        StringAssert.Contains(html, "<option value=\"CA\">Canada</option>");
+    }
+
+    [TestMethod]
+    public void TablerInputMask_PatternAttributes() {
+        var mask = new TablerInputMask("phone")
+            .Pattern("+1 (999) 999-9999");
+        var html = mask.ToString();
+        StringAssert.Contains(html, "data-mask=\"+1 (999) 999-9999\"");
+        StringAssert.Contains(html, "data-mask-visible=\"true\"");
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ This document outlines the implementation plan for Tabler features missing in Ht
 - **Tags**: `TablerTag`
 - **Timeline**: `TablerTimeline`
 - **Toasts**: `TablerToast`
+- **Forms**: `TablerForm`, `TablerInput`, `TablerSelect`, `TablerInputMask`
 
 ### 🔄 Partially Implemented (Need Enhancement)
 - **Cards**: Missing ribbon, stamps, hover effects


### PR DESCRIPTION
## Summary
- showcase Tabler form inputs via new `ExampleTablerFormInputs` demo
- call the new example from the example runner
- mark forms as implemented in TODO
- test HTML output of Tabler form controls

## Testing
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_6881232d0660832e8a8d07198cfab098