### PR TITLE
Add TablerCountdown builder

### DIFF
--- a/HtmlForgeX.Examples/Tabler/ExampleTablerCountdown.cs
+++ b/HtmlForgeX.Examples/Tabler/ExampleTablerCountdown.cs
@@ -1,0 +1,21 @@
+namespace HtmlForgeX.Examples.Tabler;
+
+internal static class ExampleTablerCountdown {
+    public static void Create(bool openInBrowser = false) {
+        using var document = new Document { Head = { Title = "Countdown Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Card(card => {
+                        card.Countdown(c => c
+                            .EndTime(DateTime.Now.AddMinutes(1))
+                            .Format("MM:SS")
+                            .OnComplete("console.log('Finished')"));
+                    });
+                });
+            });
+        });
+
+        document.Save("TablerCountdownDemo.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerCountdown.cs
+++ b/HtmlForgeX.Tests/TestTablerCountdown.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerCountdown {
+    [TestMethod]
+    public void Countdown_GeneratesHtml() {
+        var card = new TablerCard();
+        card.Countdown(c => c.EndTime(DateTime.UtcNow.AddHours(1)));
+        var html = card.ToString();
+        Assert.IsTrue(html.Contains("setInterval"));
+        Assert.IsTrue(html.Contains("DOMContentLoaded"));
+    }
+
+    [TestMethod]
+    public void Countdown_CompletionCallback() {
+        var card = new TablerCard();
+        card.Countdown(c => c.OnComplete("done"));
+        var html = card.ToString();
+        Assert.IsTrue(html.Contains("done()"));
+    }
+}

--- a/HtmlForgeX/Containers/Core/Element.Tabler.cs
+++ b/HtmlForgeX/Containers/Core/Element.Tabler.cs
@@ -437,4 +437,16 @@ public abstract partial class Element {
         this.Add(smartWizard);
         return smartWizard;
     }
+
+    /// <summary>
+    /// Adds and configures a countdown timer element.
+    /// </summary>
+    /// <param name="config">Optional configuration action.</param>
+    /// <returns>The created <see cref="TablerCountdown"/>.</returns>
+    public TablerCountdown Countdown(Action<TablerCountdown>? config = null) {
+        var countdown = new TablerCountdown();
+        config?.Invoke(countdown);
+        this.Add(countdown);
+        return countdown;
+    }
 }

--- a/HtmlForgeX/Containers/Tabler/TablerCountdown.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCountdown.cs
@@ -1,0 +1,72 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Renders a countdown timer that updates every second and triggers a callback when finished.
+/// </summary>
+public class TablerCountdown : Element {
+    private string Id { get; } = GlobalStorage.GenerateRandomId("countdown");
+    private DateTime End { get; set; } = DateTime.UtcNow;
+    private string FormatString { get; set; } = "HH:mm:ss";
+    private string? CompletionCallback { get; set; }
+    /// <summary>
+    /// Sets the end time for the countdown.
+    /// </summary>
+    public TablerCountdown EndTime(DateTime endTime) {
+        End = endTime;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the display format using tokens DD, HH, MM and SS.
+    /// </summary>
+    public TablerCountdown Format(string format) {
+        FormatString = format;
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies a JavaScript callback to invoke when the countdown completes.
+    /// </summary>
+    public TablerCountdown OnComplete(string callback) {
+        CompletionCallback = callback;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() {
+        var span = new HtmlTag("span").Id(Id);
+        string callback = string.IsNullOrWhiteSpace(CompletionCallback) ? string.Empty : $"{CompletionCallback}();";
+        var script = new HtmlTag("script").Value($@"
+        document.addEventListener('DOMContentLoaded', function() {{
+            var end = new Date('{End:o}');
+            var el = document.getElementById('{Id}');
+            function pad(n) {{ return n.toString().padStart(2,'0'); }}
+            function format(d,h,m,s) {{
+                return '{FormatString}'
+                    .replace('DD', pad(d))
+                    .replace('HH', pad(h))
+                    .replace('MM', pad(m))
+                    .replace('SS', pad(s));
+            }}
+            function update() {{
+                var now = new Date();
+                var diff = Math.floor((end - now) / 1000);
+                if (diff <= 0) {{
+                    el.textContent = format(0,0,0,0);
+                    clearInterval(timer);
+                    {callback}
+                    return;
+                }}
+                var d = Math.floor(diff / 86400);
+                var h = Math.floor((diff % 86400) / 3600);
+                var m = Math.floor((diff % 3600) / 60);
+                var s = diff % 60;
+                el.textContent = format(d,h,m,s);
+            }}
+            update();
+            var timer = setInterval(update, 1000);
+        }});
+        ");
+        return span + script.ToString();
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -257,15 +257,6 @@ element.ColorPicker(picker => {
 });
 ```
 
-### 16. Countdown/Timer (`TablerCountdown`)
-```csharp
-// Proposed API
-element.Countdown(countdown => {
-    countdown.EndTime(DateTime.Now.AddHours(24))
-             .Format("DD:HH:MM:SS")
-             .OnComplete("handleCountdownComplete");
-});
-```
 
 ## Phase 6: Enhancement of Existing Components
 


### PR DESCRIPTION
## Summary
- enable fluent Countdown() builder on all Tabler elements
- update countdown example to use new API
- adjust countdown tests to exercise builder

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688122f57024832e83fcc2d1b3f5319c