### PR TITLE
Add TablerModal footer builder

### DIFF
--- a/HtmlForgeX.Examples/Tabler/ExampleTablerModal.cs
+++ b/HtmlForgeX.Examples/Tabler/ExampleTablerModal.cs
@@ -1,0 +1,27 @@
+namespace HtmlForgeX.Examples.Tabler;
+
+internal static class ExampleTablerModal {
+    public static void Create(bool openInBrowser = false) {
+        using var document = new Document { Head = { Title = "Modal Demo" } };
+        document.Body.Page(page => {
+            page.Row(row => {
+                row.Column(column => {
+                    column.Modal(modal => {
+                        modal.Title("Confirm Action")
+                             .Size(TablerModalSize.Large)
+                             .Scrollable()
+                             .Content(content => {
+                                 content.Text("Are you sure?");
+                             })
+                             .Footer(footer => {
+                                 footer.Button("Cancel", TablerColor.Light).Dismiss()
+                                       .Button("Confirm", TablerColor.Primary).Submit();
+                             });
+                    });
+                });
+            });
+        });
+
+        document.Save("TablerModalDemo.html", openInBrowser);
+    }
+}

--- a/HtmlForgeX.Tests/TestTablerModal.cs
+++ b/HtmlForgeX.Tests/TestTablerModal.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HtmlForgeX.Tests;
+
+[TestClass]
+public class TestTablerModal {
+    [TestMethod]
+    public void Modal_GeneratesBasicHtml() {
+        var modal = new TablerModal()
+            .Title("Test")
+            .Content(c => c.Text("Body"))
+            .Footer(f => f.Button("Close", TablerColor.Primary).Dismiss());
+        var html = modal.ToString();
+        Assert.IsTrue(html.Contains("modal-content"));
+        Assert.IsTrue(html.Contains("modal-header"));
+        Assert.IsTrue(html.Contains("modal-body"));
+        Assert.IsTrue(html.Contains("modal-footer"));
+    }
+
+    [TestMethod]
+    public void Modal_ScrollableAddsClass() {
+        var modal = new TablerModal().Scrollable();
+        var html = modal.ToString();
+        Assert.IsTrue(html.Contains("modal-dialog-scrollable"));
+    }
+
+    [DataTestMethod]
+    [DataRow(TablerModalSize.Small, "modal-sm")]
+    [DataRow(TablerModalSize.Large, "modal-lg")]
+    [DataRow(TablerModalSize.FullWidth, "modal-full-width")]
+    [DataRow(TablerModalSize.Default, "")]
+    public void Modal_SizeAddsCorrectClass(TablerModalSize size, string expected) {
+        var modal = new TablerModal().Size(size);
+        var html = modal.ToString();
+        if (string.IsNullOrEmpty(expected)) {
+            Assert.IsFalse(html.Contains("modal-sm") || html.Contains("modal-lg") || html.Contains("modal-full-width"));
+        } else {
+            Assert.IsTrue(html.Contains(expected));
+        }
+    }
+
+    [TestMethod]
+    public void Modal_FooterButtonAddsDismissAttribute() {
+        var modal = new TablerModal()
+            .Footer(f => f.Button("Close", TablerColor.Primary).Dismiss());
+        var html = modal.ToString();
+        Assert.IsTrue(html.Contains("data-bs-dismiss=\"modal\""));
+    }
+}

--- a/HtmlForgeX/Containers/Core/Element.Tabler.cs
+++ b/HtmlForgeX/Containers/Core/Element.Tabler.cs
@@ -437,4 +437,16 @@ public abstract partial class Element {
         this.Add(smartWizard);
         return smartWizard;
     }
+
+    /// <summary>
+    /// Adds and configures a <see cref="TablerModal"/> component.
+    /// </summary>
+    /// <param name="config">Configuration action.</param>
+    /// <returns>The created modal.</returns>
+    public TablerModal Modal(Action<TablerModal> config) {
+        var modal = new TablerModal();
+        config(modal);
+        this.Add(modal);
+        return modal;
+    }
 }

--- a/HtmlForgeX/Containers/Tabler/Enums/TablerModalSize.cs
+++ b/HtmlForgeX/Containers/Tabler/Enums/TablerModalSize.cs
@@ -1,0 +1,34 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Defines available Tabler modal sizes.
+/// </summary>
+public enum TablerModalSize {
+    /// <summary>Default size.</summary>
+    Default,
+    /// <summary>Small modal.</summary>
+    Small,
+    /// <summary>Large modal.</summary>
+    Large,
+    /// <summary>Full width modal.</summary>
+    FullWidth
+}
+
+/// <summary>
+/// Extension helpers for <see cref="TablerModalSize"/> values.
+/// </summary>
+public static class TablerModalSizeExtensions {
+    /// <summary>
+    /// Converts modal size to the corresponding CSS class.
+    /// </summary>
+    /// <param name="size">Modal size.</param>
+    /// <returns>CSS class name or empty string.</returns>
+    public static string EnumToString(this TablerModalSize size) {
+        return size switch {
+            TablerModalSize.Small => "modal-sm",
+            TablerModalSize.Large => "modal-lg",
+            TablerModalSize.FullWidth => "modal-full-width",
+            _ => string.Empty
+        };
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/Modal/TablerModal.cs
+++ b/HtmlForgeX/Containers/Tabler/Modal/TablerModal.cs
@@ -1,0 +1,133 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Represents a Tabler modal dialog component.
+/// </summary>
+public class TablerModal : Element {
+    private string Id { get; } = GlobalStorage.GenerateRandomId("modal");
+    private string? PrivateTitle { get; set; }
+    private ElementContainer? PrivateContent { get; set; }
+    private ElementContainer? PrivateFooter { get; set; }
+    private bool PrivateScrollable { get; set; }
+    private TablerModalSize PrivateSize { get; set; } = TablerModalSize.Default;
+
+    /// <summary>
+    /// Sets modal title.
+    /// </summary>
+    public TablerModal Title(string title) {
+        PrivateTitle = title;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets modal size.
+    /// </summary>
+    public TablerModal Size(TablerModalSize size) {
+        PrivateSize = size;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables scrollable dialog.
+    /// </summary>
+    public TablerModal Scrollable(bool scrollable = true) {
+        PrivateScrollable = scrollable;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures modal body content.
+    /// </summary>
+    public TablerModal Content(Action<ElementContainer> content) {
+        var container = new ElementContainer();
+        content(container);
+        PrivateContent = container;
+        return this;
+    }
+
+    /// <summary>
+    /// Returns container for modal body content.
+    /// </summary>
+    public ElementContainer Content() {
+        PrivateContent = new ElementContainer();
+        return PrivateContent;
+    }
+
+    /// <summary>
+    /// Configures modal footer content with raw <see cref="ElementContainer"/>.
+    /// </summary>
+    public TablerModal Footer(Action<ElementContainer> footer) {
+        var container = new ElementContainer();
+        footer(container);
+        PrivateFooter = container;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures modal footer using a fluent builder.
+    /// </summary>
+    /// <param name="footer">Configuration action.</param>
+    /// <returns>The current modal.</returns>
+    public TablerModal Footer(Action<TablerModalFooterBuilder> footer) {
+        var container = new ElementContainer();
+        var builder = new TablerModalFooterBuilder(container, Document);
+        footer(builder);
+        PrivateFooter = container;
+        return this;
+    }
+
+    /// <summary>
+    /// Returns container for modal footer content.
+    /// </summary>
+    public ElementContainer Footer() {
+        PrivateFooter = new ElementContainer();
+        return PrivateFooter;
+    }
+
+    /// <inheritdoc />
+    protected internal override void RegisterLibraries() {
+        Document?.AddLibrary(Libraries.Bootstrap);
+        Document?.AddLibrary(Libraries.Tabler);
+        base.RegisterLibraries();
+    }
+
+    /// <inheritdoc />
+    public override string ToString() {
+        var modal = new HtmlTag("div")
+            .Class("modal modal-blur fade position-relative rounded d-block show bg-surface-backdrop py-6 w-auto h-auto")
+            .Id(Id)
+            .Attribute("tabindex", "-1")
+            .Attribute("role", "dialog")
+            .Attribute("aria-hidden", "true");
+
+        var dialog = new HtmlTag("div")
+            .Class("modal-dialog")
+            .Class(PrivateSize.EnumToString())
+            .Class("modal-dialog-centered");
+        if (PrivateScrollable) {
+            dialog.Class("modal-dialog-scrollable");
+        }
+
+        var content = new HtmlTag("div").Class("modal-content");
+
+        var header = new HtmlTag("div").Class("modal-header");
+        if (!string.IsNullOrEmpty(PrivateTitle)) {
+            header.Value(new HtmlTag("h5").Class("modal-title").Value(PrivateTitle));
+        }
+        header.Value(new HtmlTag("button").Class("btn-close").Attribute("data-bs-dismiss", "modal").Attribute("aria-label", "Close"));
+        content.Value(header);
+
+        if (PrivateContent != null) {
+            content.Value(new HtmlTag("div").Class("modal-body").Value(PrivateContent));
+        }
+
+        if (PrivateFooter != null) {
+            content.Value(new HtmlTag("div").Class("modal-footer").Value(PrivateFooter));
+        }
+
+        dialog.Value(content);
+        modal.Value(dialog);
+
+        return modal.ToString();
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/Modal/TablerModalButton.cs
+++ b/HtmlForgeX/Containers/Tabler/Modal/TablerModalButton.cs
@@ -1,0 +1,65 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Represents a button within a <see cref="TablerModal"/> footer.
+/// </summary>
+public class TablerModalButton : Element {
+    private bool dismiss;
+    private bool submit;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerModalButton"/> class.
+    /// </summary>
+    /// <param name="text">Button text.</param>
+    /// <param name="color">Button color.</param>
+    public TablerModalButton(string text, TablerColor color) {
+        Text = text;
+        Color = color;
+    }
+
+    /// <summary>Button label text.</summary>
+    public new string Text { get; set; }
+
+    /// <summary>Visual color of the button.</summary>
+    public TablerColor Color { get; set; }
+
+    /// <summary>
+    /// Marks this button as dismissing the modal.
+    /// </summary>
+    public TablerModalButton Dismiss() {
+        dismiss = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Marks this button as submitting the modal form.
+    /// </summary>
+    public TablerModalButton Submit() {
+        submit = true;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() {
+        var btn = new HtmlTag("a")
+            .Class("btn")
+            .Class($"btn-{Color.ToTablerString()}")
+            .Attribute("href", "#");
+
+        if (dismiss) {
+            btn.Attribute("data-bs-dismiss", "modal");
+        }
+
+        if (submit) {
+            btn.Attribute("type", "submit");
+            // Typically submit buttons also dismiss the modal
+            if (!dismiss) {
+                btn.Attribute("data-bs-dismiss", "modal");
+            }
+            btn.Class("ms-auto");
+        }
+
+        btn.Value(Text);
+        return btn.ToString();
+    }
+}

--- a/HtmlForgeX/Containers/Tabler/Modal/TablerModalFooterBuilder.cs
+++ b/HtmlForgeX/Containers/Tabler/Modal/TablerModalFooterBuilder.cs
@@ -1,0 +1,69 @@
+namespace HtmlForgeX;
+
+/// <summary>
+/// Builder for configuring modal footer content without exposing raw HTML.
+/// </summary>
+public class TablerModalFooterBuilder {
+    private readonly ElementContainer container;
+    private readonly Document? document;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TablerModalFooterBuilder"/> class.
+    /// </summary>
+    /// <param name="container">Container that will hold footer elements.</param>
+    /// <param name="document">Optional document reference used when adding elements.</param>
+    public TablerModalFooterBuilder(ElementContainer container, Document? document) {
+        this.container = container;
+        this.document = document;
+    }
+
+    /// <summary>
+    /// Adds a button to the footer.
+    /// </summary>
+    /// <param name="text">Button text.</param>
+    /// <param name="color">Button color.</param>
+    /// <param name="config">Optional additional configuration.</param>
+    /// <returns>A chain object for further configuration.</returns>
+    public TablerModalFooterButtonChain Button(string text, TablerColor color, Action<TablerModalButton>? config = null) {
+        var button = new TablerModalButton(text, color);
+        config?.Invoke(button);
+        if (document != null) {
+            button.Document = document;
+            button.OnAddedToDocument();
+        }
+        container.Add(button);
+        return new TablerModalFooterButtonChain(this, button);
+    }
+}
+
+/// <summary>
+/// Chain object returned after adding a button to the footer.
+/// Allows calling methods like <c>Dismiss</c> or <c>Submit</c> fluently.
+/// </summary>
+public class TablerModalFooterButtonChain {
+    private readonly TablerModalFooterBuilder parent;
+    private readonly TablerModalButton button;
+
+    internal TablerModalFooterButtonChain(TablerModalFooterBuilder parent, TablerModalButton button) {
+        this.parent = parent;
+        this.button = button;
+    }
+
+    /// <summary>
+    /// Marks the previously added button as a dismiss button.
+    /// </summary>
+    /// <returns>The parent builder.</returns>
+    public TablerModalFooterBuilder Dismiss() {
+        button.Dismiss();
+        return parent;
+    }
+
+    /// <summary>
+    /// Marks the previously added button as a submit button.
+    /// </summary>
+    /// <returns>The parent builder.</returns>
+    public TablerModalFooterBuilder Submit() {
+        button.Submit();
+        return parent;
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ This document outlines the implementation plan for Tabler features missing in Ht
 - **Tags**: `TablerTag`
 - **Timeline**: `TablerTimeline`
 - **Toasts**: `TablerToast`
+- **Modals**: `TablerModal`
 
 ### 🔄 Partially Implemented (Need Enhancement)
 - **Cards**: Missing ribbon, stamps, hover effects
@@ -38,7 +39,7 @@ This document outlines the implementation plan for Tabler features missing in Ht
 
 ## Phase 1: Core Interactive Components (High Priority)
 
-### 1. Modals (`TablerModal`)
+### ✅ Modals (`TablerModal`)
 **Source Reference**: `/preview/pages/modals.html`
 ```csharp
 // Proposed API


### PR DESCRIPTION
## Summary
- implement TablerModalFooterBuilder and TablerModalButton for fluent footer configuration
- add fluent Footer overload to TablerModal
- update example to showcase builder usage
- extend unit tests for new API

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68812349048c832eb79b0daebcab8beb