### PR TITLE
Add easy HtmlTag helpers

### DIFF
--- a/HtmlForgeX.Tests/TestHtmlTags.cs
+++ b/HtmlForgeX.Tests/TestHtmlTags.cs
@@ -82,4 +82,13 @@ public class TestHtmlTags {
 
     }
 
+    [TestMethod]
+    public void HtmlTagAddTextAndChild() {
+        var div = new HtmlTag("div")
+            .AddText("Hello")
+            .AddChild(new HtmlTag("span").AddText("World"));
+
+        Assert.AreEqual("<div>Hello<span>World</span></div>", div.ToString());
+    }
+
 }

--- a/HtmlForgeX/HtmlTag.cs
+++ b/HtmlForgeX/HtmlTag.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Globalization;
+
 using HtmlForgeX.Extensions;
 
 namespace HtmlForgeX;
@@ -322,6 +323,23 @@ public class HtmlTag : Element {
                 Children.Add(val);
             }
         }
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a text node to this tag.
+    /// </summary>
+    /// <param name="text">The text to add.</param>
+    /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
+    public HtmlTag AddText(string text) => Value(text);
+
+    /// <summary>
+    /// Adds the specified element as a child of this tag.
+    /// </summary>
+    /// <param name="element">Element to add.</param>
+    /// <returns>The current <see cref="HtmlTag"/> instance.</returns>
+    public HtmlTag AddChild(Element? element) {
+        Add(element);
         return this;
     }
 }


### PR DESCRIPTION
## Summary
- simplify HtmlTag building with `AddText` and `AddChild`
- test the new helpers

## Testing
- `dotnet test HtmlForgeX.sln --configuration Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6880b3808228832eb24c36881ce1542e