### PR TITLE
Fix duplicate CardMini avatars

### DIFF
--- a/HtmlForgeX/Containers/Tabler/TablerCardMini.cs
+++ b/HtmlForgeX/Containers/Tabler/TablerCardMini.cs
@@ -88,7 +88,7 @@ public class TablerCardMini : TablerCard {
         cardBodyDiv.Class("card-body").Value(CardContent);
         cardBodyDiv.Attributes["style"] = CardInnerStyle!;
 
-        var cardInside = cardBodyDiv.Row(cardRow => {
+        cardBodyDiv.Row(cardRow => {
             cardRow.Column(TablerColumnNumber.Auto, avatarColumn => {
                 var avatar = avatarColumn.Avatar().Icon(AvatarIcon);
 
@@ -104,8 +104,6 @@ public class TablerCardMini : TablerCard {
                 textColumn.Text(SubtitleText).Style(TablerTextStyle.Muted);
             });
         });
-
-        cardBodyDiv.Value(cardInside);
 
         // Add the card body to the card
         cardDiv.Value(cardBodyDiv);


### PR DESCRIPTION
## Summary
- avoid adding the same row twice when rendering `TablerCardMini`

## Testing
- `dotnet build HtmlForgeX.sln -c Release`
- `dotnet test HtmlForgeX.Tests/HtmlForgeX.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688212ca4e10832e967404eb104012cb